### PR TITLE
chore: pin go version to current minor in renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,4 +16,12 @@
   gitIgnoredAuthors: [
     "github-actions[bot]@users.noreply.github.com",
   ],
+  packageRules: [
+    {
+      description: "Go: keep at current minor (N-1 policy)",
+      matchDepNames: ["go"],
+      matchManagers: ["gomod", "mise"],
+      allowedVersions: "<{{major}}.{{add minor 1}}",
+    },
+  ],
 }


### PR DESCRIPTION
## Summary

- renovate の packageRules に Go バージョン制限を追加
- `allowedVersions: "<{{major}}.{{add minor 1}}"` で現在の minor に固定
- 例: go 1.25 → `<1.26` に展開され、1.26 への更新を抑止
- 将来 go.mod を 1.26 に上げれば自動で `<1.27` になる

(by Claude Code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/ccgate/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
