### PR TITLE
chore: pin go 1.25.0 + toolchain go1.25.8, renovate follows patches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,4 +16,26 @@
   gitIgnoredAuthors: [
     "github-actions[bot]@users.noreply.github.com",
   ],
+  packageRules: [
+    {
+      description: "go directive: keep pinned at 1.25.0",
+      matchDepNames: ["go"],
+      matchManagers: ["gomod"],
+      matchDepTypes: ["golang"],
+      enabled: false,
+    },
+    {
+      description: "go toolchain: follow 1.25.x patches only",
+      matchDepNames: ["go"],
+      matchManagers: ["gomod"],
+      matchDepTypes: ["toolchain"],
+      allowedVersions: "<{{major}}.{{add minor 1}}",
+    },
+    {
+      description: "mise go: follow 1.25.x patches only",
+      matchDepNames: ["go"],
+      matchManagers: ["mise"],
+      allowedVersions: "<{{major}}.{{add minor 1}}",
+    },
+  ],
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/tak848/ccgate
 
 go 1.25.0
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	github.com/alecthomas/kong v1.14.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/tak848/ccgate
 
-go 1.25
+go 1.25.0
+
+toolchain go1.25.7
 
 require (
 	github.com/alecthomas/kong v1.14.0

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.25"
+go = "1.25.8"
 
 [tasks.build]
 description = "Build the binary (dev use)"


### PR DESCRIPTION
## Summary

- `go 1.25` → `go 1.25.0` に変更（最小バージョンを明示的に固定）
- `toolchain go1.25.8` を追加（最新 1.25.x パッチに固定）
- `mise.toml` の go を `1.25.8` に固定
- renovate packageRules 追加:
  - go directive: 更新無効（1.25.0 に固定）
  - toolchain: 1.25.x パッチのみ追従
  - mise go: 1.25.x パッチのみ追従

Supersedes #10

(by Claude Code)