### PR TITLE
feat: configurable log_path and log_disabled in jsonnet

### DIFF
--- a/example/permission-gate.jsonnet
+++ b/example/permission-gate.jsonnet
@@ -5,6 +5,7 @@
     model: 'claude-haiku-4-5',
     timeout_ms: 40000,
   },
+  // log_path: '~/.claude/logs/ccgate.log',
   allow: [
     'Read-Only Operations: GET requests, read-only API calls, or queries that do not modify state.',
     'Local Operations: Read-only work inside the current repository or current worktree.',

--- a/example/permission-gate.schema.json
+++ b/example/permission-gate.schema.json
@@ -34,6 +34,14 @@
         "type": "string"
       }
     },
+    "log_path": {
+      "type": "string",
+      "description": "Log file path. Supports ~ for home directory. Default: ~/.claude/logs/ccgate.log"
+    },
+    "log_disabled": {
+      "type": "boolean",
+      "description": "Disable logging entirely. Default: false"
+    },
     "environment": {
       "type": "array",
       "items": {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	anthropic "github.com/anthropics/anthropic-sdk-go"
 	jsonnet "github.com/google/go-jsonnet"
@@ -18,12 +19,15 @@ const (
 	DefaultTimeoutMS = 20_000
 	DefaultModel     = string(anthropic.ModelClaudeHaiku4_5)
 	DefaultProvider  = "anthropic"
+	DefaultLogPath   = "~/.claude/logs/ccgate.log"
 	BaseConfigName   = "permission-gate.jsonnet"
 	LocalConfigName  = "permission-gate.local.jsonnet"
 )
 
 type Config struct {
 	Provider    ProviderConfig `json:"provider"`
+	LogPath     string         `json:"log_path"`
+	LogDisabled bool           `json:"log_disabled"`
 	Allow       []string       `json:"allow"`
 	Deny        []string       `json:"deny"`
 	Environment []string       `json:"environment"`
@@ -42,7 +46,22 @@ func Default() Config {
 			Model:     DefaultModel,
 			TimeoutMS: DefaultTimeoutMS,
 		},
+		LogPath: DefaultLogPath,
 	}
+}
+
+// ResolveLogPath expands ~ in LogPath and returns the absolute path.
+func (c Config) ResolveLogPath() string {
+	p := c.LogPath
+	if p == "" {
+		p = DefaultLogPath
+	}
+	if after, ok := strings.CutPrefix(p, "~/"); ok {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, after)
+		}
+	}
+	return p
 }
 
 // Load reads the base config from ~/.claude/ and merges project-local overrides.
@@ -139,6 +158,12 @@ func mergeConfigFile(path string, cfg *Config) error {
 	}
 	if override.Provider.TimeoutMS > 0 {
 		cfg.Provider.TimeoutMS = override.Provider.TimeoutMS
+	}
+	if override.LogPath != "" {
+		cfg.LogPath = override.LogPath
+	}
+	if override.LogDisabled {
+		cfg.LogDisabled = true
 	}
 
 	cfg.Allow = append(cfg.Allow, override.Allow...)

--- a/main.go
+++ b/main.go
@@ -34,10 +34,6 @@ func _main() int {
 		kong.Vars{"version": version},
 	)
 
-	logger, cleanup := initLogger()
-	defer cleanup()
-	slog.SetDefault(logger)
-
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -47,16 +43,20 @@ func _main() int {
 		return 1
 	}
 
-	slog.Info("hook invoked",
-		"tool", input.ToolName,
-		"permission_mode", input.PermissionMode,
-	)
-
 	cfg, err := config.Load(input.Cwd)
 	if err != nil {
 		slog.Error("failed to load config", "error", err)
 		return 1
 	}
+
+	logger, cleanup := initLogger(cfg.ResolveLogPath(), cfg.LogDisabled)
+	defer cleanup()
+	slog.SetDefault(logger)
+
+	slog.Info("hook invoked",
+		"tool", input.ToolName,
+		"permission_mode", input.PermissionMode,
+	)
 
 	start := time.Now()
 	decision, ok, err := gate.DecidePermission(ctx, cfg, input)
@@ -95,19 +95,17 @@ func _main() int {
 
 const maxLogSize = 5 * 1024 * 1024 // 5 MB
 
-func initLogger() (*slog.Logger, func()) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return slog.New(slog.NewTextHandler(os.Stderr, nil)), func() {}
+func initLogger(logPath string, disabled bool) (*slog.Logger, func()) {
+	if disabled {
+		return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError + 1})), func() {}
 	}
 
-	logDir := filepath.Join(home, ".claude", "logs")
+	logDir := filepath.Dir(logPath)
 	if err := os.MkdirAll(logDir, 0o755); err != nil {
 		slog.Warn("failed to create log directory", "error", err)
 		return slog.New(slog.NewTextHandler(os.Stderr, nil)), func() {}
 	}
 
-	logPath := filepath.Join(logDir, "ccgate.log")
 	rotateLog(logPath)
 
 	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)


### PR DESCRIPTION
## Summary

- `log_path` フィールド追加: ログファイルの出力先を jsonnet で指定可能に (デフォルト: `~/.claude/logs/ccgate.log`)
- `log_disabled` フィールド追加: `true` でログ出力を完全に無効化
- config 読み込み後にロガーを初期化する順序に変更
- JSON Schema に新フィールドを追加

### 使い方

```jsonnet
{
  // ログ出力先を変更
  log_path: '~/my-logs/ccgate.log',

  // ログを無効化
  // log_disabled: true,
}
```

(by Claude Code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/ccgate/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
