### PR TITLE
feat: configurable log settings and provider/model docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Project-local configs are only loaded if **not tracked by Git**.
 | `provider.timeout_ms` | int | `20000` | API timeout (ms) |
 | `log_path` | string | `"~/.claude/logs/ccgate.log"` | Log file path. Supports `~` for home directory. |
 | `log_disabled` | bool | `false` | Disable logging entirely |
+| `log_max_size` | int | `5242880` | Max log file size in bytes before rotation (default 5MB) |
 | `allow` | string[] | `[]` | Allow rules |
 | `deny` | string[] | `[]` | Deny rules (mandatory) |
 | `environment` | string[] | `[]` | Environment context |

--- a/README.md
+++ b/README.md
@@ -112,16 +112,27 @@ Project-local configs are only loaded if **not tracked by Git**.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `provider.name` | string | `"anthropic"` | Provider name |
-| `provider.model` | string | `"claude-haiku-4-5"` | Model name |
+| `provider.name` | string | `"anthropic"` | Provider name. Only `"anthropic"` is supported. |
+| `provider.model` | string | `"claude-haiku-4-5"` | Model name (e.g. `claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-6`) |
 | `provider.timeout_ms` | int | `20000` | API timeout (ms) |
+| `log_path` | string | `"~/.claude/logs/ccgate.log"` | Log file path. Supports `~` for home directory. |
+| `log_disabled` | bool | `false` | Disable logging entirely |
 | `allow` | string[] | `[]` | Allow rules |
 | `deny` | string[] | `[]` | Deny rules (mandatory) |
 | `environment` | string[] | `[]` | Environment context |
 
 ## Logging
 
-Logs are written to `~/.claude/logs/ccgate.log` with 5 MB rotation (`.log.1`).
+Logs are written to `~/.claude/logs/ccgate.log` by default with 5 MB rotation (`.log.1`).
+
+To change the log path or disable logging:
+
+```jsonnet
+{
+  log_path: '~/my-logs/ccgate.log',
+  // log_disabled: true,
+}
+```
 
 ## Development
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -108,16 +108,27 @@ JSON Schema (`permission-gate.schema.json`) を同じディレクトリに配置
 
 | フィールド | 型 | デフォルト | 説明 |
 |-----------|------|-----------|------|
-| `provider.name` | string | `"anthropic"` | プロバイダー名 |
-| `provider.model` | string | `"claude-haiku-4-5"` | モデル名 |
+| `provider.name` | string | `"anthropic"` | プロバイダー名。`"anthropic"` のみ対応 |
+| `provider.model` | string | `"claude-haiku-4-5"` | モデル名 (例: `claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-6`) |
 | `provider.timeout_ms` | int | `20000` | API タイムアウト (ms) |
+| `log_path` | string | `"~/.claude/logs/ccgate.log"` | ログファイルパス。`~` でホームディレクトリ展開 |
+| `log_disabled` | bool | `false` | ログ出力を完全に無効化 |
 | `allow` | string[] | `[]` | 許可ルール |
 | `deny` | string[] | `[]` | 拒否ルール (mandatory) |
 | `environment` | string[] | `[]` | 環境コンテキスト |
 
 ## ログ
 
-`~/.claude/logs/ccgate.log` に出力されます。5MB でローテーション (`.log.1`)。
+デフォルトでは `~/.claude/logs/ccgate.log` に出力されます。5MB でローテーション (`.log.1`)。
+
+ログパスの変更・無効化:
+
+```jsonnet
+{
+  log_path: '~/my-logs/ccgate.log',
+  // log_disabled: true,
+}
+```
 
 ## 開発
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -113,6 +113,7 @@ JSON Schema (`permission-gate.schema.json`) を同じディレクトリに配置
 | `provider.timeout_ms` | int | `20000` | API タイムアウト (ms) |
 | `log_path` | string | `"~/.claude/logs/ccgate.log"` | ログファイルパス。`~` でホームディレクトリ展開 |
 | `log_disabled` | bool | `false` | ログ出力を完全に無効化 |
+| `log_max_size` | int | `5242880` | ローテーション閾値 (bytes, デフォルト 5MB) |
 | `allow` | string[] | `[]` | 許可ルール |
 | `deny` | string[] | `[]` | 拒否ルール (mandatory) |
 | `environment` | string[] | `[]` | 環境コンテキスト |

--- a/example/permission-gate.schema.json
+++ b/example/permission-gate.schema.json
@@ -42,6 +42,11 @@
       "type": "boolean",
       "description": "Disable logging entirely. Default: false"
     },
+    "log_max_size": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Max log file size in bytes before rotation. Default: 5242880 (5MB)"
+    },
     "environment": {
       "type": "array",
       "items": {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,18 +16,20 @@ import (
 )
 
 const (
-	DefaultTimeoutMS = 20_000
-	DefaultModel     = string(anthropic.ModelClaudeHaiku4_5)
-	DefaultProvider  = "anthropic"
-	DefaultLogPath   = "~/.claude/logs/ccgate.log"
-	BaseConfigName   = "permission-gate.jsonnet"
-	LocalConfigName  = "permission-gate.local.jsonnet"
+	DefaultTimeoutMS  = 20_000
+	DefaultModel      = string(anthropic.ModelClaudeHaiku4_5)
+	DefaultProvider   = "anthropic"
+	DefaultLogPath    = "~/.claude/logs/ccgate.log"
+	DefaultLogMaxSize = 5 * 1024 * 1024 // 5MB
+	BaseConfigName    = "permission-gate.jsonnet"
+	LocalConfigName   = "permission-gate.local.jsonnet"
 )
 
 type Config struct {
 	Provider    ProviderConfig `json:"provider"`
 	LogPath     string         `json:"log_path"`
 	LogDisabled bool           `json:"log_disabled"`
+	LogMaxSize  int64          `json:"log_max_size"`
 	Allow       []string       `json:"allow"`
 	Deny        []string       `json:"deny"`
 	Environment []string       `json:"environment"`
@@ -46,7 +48,8 @@ func Default() Config {
 			Model:     DefaultModel,
 			TimeoutMS: DefaultTimeoutMS,
 		},
-		LogPath: DefaultLogPath,
+		LogPath:    DefaultLogPath,
+		LogMaxSize: DefaultLogMaxSize,
 	}
 }
 
@@ -164,6 +167,9 @@ func mergeConfigFile(path string, cfg *Config) error {
 	}
 	if override.LogDisabled {
 		cfg.LogDisabled = true
+	}
+	if override.LogMaxSize > 0 {
+		cfg.LogMaxSize = override.LogMaxSize
 	}
 
 	cfg.Allow = append(cfg.Allow, override.Allow...)

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func _main() int {
 		return 1
 	}
 
-	logger, cleanup := initLogger(cfg.ResolveLogPath(), cfg.LogDisabled)
+	logger, cleanup := initLogger(cfg.ResolveLogPath(), cfg.LogDisabled, cfg.LogMaxSize)
 	defer cleanup()
 	slog.SetDefault(logger)
 
@@ -93,9 +93,7 @@ func _main() int {
 	return 0
 }
 
-const maxLogSize = 5 * 1024 * 1024 // 5 MB
-
-func initLogger(logPath string, disabled bool) (*slog.Logger, func()) {
+func initLogger(logPath string, disabled bool, maxLogSize int64) (*slog.Logger, func()) {
 	if disabled {
 		return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError + 1})), func() {}
 	}
@@ -106,7 +104,7 @@ func initLogger(logPath string, disabled bool) (*slog.Logger, func()) {
 		return slog.New(slog.NewTextHandler(os.Stderr, nil)), func() {}
 	}
 
-	rotateLog(logPath)
+	rotateLog(logPath, maxLogSize)
 
 	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
@@ -128,9 +126,9 @@ func (w *atomicWriter) Write(p []byte) (int, error) {
 	return w.f.Write(p)
 }
 
-func rotateLog(path string) {
+func rotateLog(path string, maxSize int64) {
 	info, err := os.Stat(path)
-	if err != nil || info.Size() < maxLogSize {
+	if err != nil || info.Size() < maxSize {
 		return
 	}
 	prev := path + ".1"


### PR DESCRIPTION
## Summary

- provider.name が anthropic のみ対応の旨を明記
- provider.model の例に claude-haiku-4-5 / claude-sonnet-4-6 / claude-opus-4-6 を記載
- `log_path`, `log_disabled`, `log_max_size` フィールドをドキュメントに追加
- `log_max_size`: ローテーション閾値を bytes で指定可能 (デフォルト 5MB)
  - jsonnet で `10 * 1024 * 1024` のように書ける
- 英語 README / 日本語ドキュメント / JSON Schema 全て更新

(by Claude Code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/ccgate/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
