### PR TITLE
fix: skip LLM decision for plan/bypassPermissions/dontAsk modes

### DIFF
--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -54,6 +54,22 @@ func NewPermissionResponse(d PermissionDecision) PermissionResponse {
 // Returns (decision, true, nil) for allow/deny, (zero, false, nil) for fallthrough,
 // and (zero, false, error) on failure.
 func DecidePermission(ctx context.Context, cfg config.Config, input hookctx.HookInput) (PermissionDecision, bool, error) {
+	// Some permission modes should not be overridden by the hook.
+	// - plan: user must approve all actions explicitly
+	// - bypassPermissions: user opted out of permission checks
+	// - dontAsk: only pre-approved tools run, deny the rest
+	switch input.PermissionMode {
+	case "plan":
+		slog.Info("plan mode: falling through to user", "tool", input.ToolName)
+		return PermissionDecision{}, false, nil
+	case "bypassPermissions":
+		slog.Info("bypass mode: falling through", "tool", input.ToolName)
+		return PermissionDecision{}, false, nil
+	case "dontAsk":
+		slog.Info("dontAsk mode: falling through", "tool", input.ToolName)
+		return PermissionDecision{}, false, nil
+	}
+
 	if strings.ToLower(cfg.Provider.Name) != "anthropic" {
 		slog.Info("provider not anthropic, skipping", "provider", cfg.Provider.Name)
 		return PermissionDecision{}, false, nil


### PR DESCRIPTION
## Summary

- `permission_mode` に応じて LLM 呼び出しをスキップし fallthrough するように修正
  - `plan`: ユーザーが全アクションを明示的に承認すべき。ExitPlanMode が勝手に allow されていた問題を修正
  - `bypassPermissions`: ユーザーがチェックを無効にしている
  - `dontAsk`: 事前承認済みツールのみ実行、それ以外は deny
- LLM 判定は `default`, `acceptEdits`, `auto` モードでのみ実行

(by Claude Code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/ccgate/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
