### PR TITLE
fix: never auto-decide user interaction tools

### DIFF
--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -54,16 +54,17 @@ func NewPermissionResponse(d PermissionDecision) PermissionResponse {
 // Returns (decision, true, nil) for allow/deny, (zero, false, nil) for fallthrough,
 // and (zero, false, error) on failure.
 func DecidePermission(ctx context.Context, cfg config.Config, input hookctx.HookInput) (PermissionDecision, bool, error) {
+	// Tools that require user interaction must never be auto-decided.
+	switch input.ToolName {
+	case "ExitPlanMode", "AskUserQuestion", "EnterPlanMode":
+		slog.Info("user interaction tool: falling through", "tool", input.ToolName)
+		return PermissionDecision{}, false, nil
+	}
+
 	// Some permission modes should not be overridden by the hook.
-	// - plan: user must approve all actions explicitly
-	// - bypassPermissions: user opted out of permission checks
-	// - dontAsk: only pre-approved tools run, deny the rest
 	switch input.PermissionMode {
 	case "plan":
-		if input.ToolName == "ExitPlanMode" {
-			slog.Info("plan mode: ExitPlanMode falling through to user")
-			return PermissionDecision{}, false, nil
-		}
+		// In plan mode, let the LLM decide for non-interaction tools.
 	case "bypassPermissions":
 		slog.Info("bypass mode: falling through", "tool", input.ToolName)
 		return PermissionDecision{}, false, nil

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -56,7 +56,7 @@ func NewPermissionResponse(d PermissionDecision) PermissionResponse {
 func DecidePermission(ctx context.Context, cfg config.Config, input hookctx.HookInput) (PermissionDecision, bool, error) {
 	// Tools that require user interaction must never be auto-decided.
 	switch input.ToolName {
-	case "ExitPlanMode", "AskUserQuestion", "EnterPlanMode":
+	case "ExitPlanMode", "AskUserQuestion":
 		slog.Info("user interaction tool: falling through", "tool", input.ToolName)
 		return PermissionDecision{}, false, nil
 	}


### PR DESCRIPTION
## Why

`AskUserQuestion` が ccgate に auto-allow されると、Claude がユーザーの回答を待たずに勝手に進んでしまう。
`ExitPlanMode` も同様に、plan モードの承認がユーザーの意思なく通ってしまう。

## What

- `AskUserQuestion`, `ExitPlanMode` を LLM 判定対象から除外し、常に fallthrough
- これらのツールはユーザーとの対話が必須なため、ccgate が介入すべきでない

(by Claude Code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/ccgate/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
