### PR TITLE
feat: embed default safety rules and add init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,31 +45,18 @@ Download a binary from [Releases](https://github.com/tak848/ccgate/releases) and
 
 ## Setup
 
-### 1. Create a config file
+### 1. Create a config file (optional)
 
-Write your rules in `~/.claude/ccgate.jsonnet`.
-See [example/ccgate.jsonnet](example/ccgate.jsonnet) for reference.
+ccgate ships with sensible default safety rules. Without any config file, it works out of the box.
 
-```jsonnet
-{
-  provider: {
-    name: 'anthropic',
-    model: 'claude-haiku-4-5',
-    timeout_ms: 40000,
-  },
-  allow: [
-    'Read-Only Operations: ...',
-  ],
-  deny: [
-    'Git Destructive: force push, deleting remote branches, ...',
-  ],
-  environment: [
-    '**Trusted repo**: The git repository the session started in.',
-  ],
-}
+To customize, output the defaults and edit:
+
+```bash
+ccgate init > ~/.claude/ccgate.jsonnet
 ```
 
-The `$schema` field points to the hosted JSON Schema for editor autocompletion — no local file needed.
+See [example/ccgate.jsonnet](example/ccgate.jsonnet) for reference.
+The `$schema` field points to the hosted JSON Schema for editor autocompletion.
 
 ### 2. Register as a Claude Code hook
 
@@ -101,11 +88,13 @@ Set the `CC_AUTOMODE_ANTHROPIC_API_KEY` or `ANTHROPIC_API_KEY` environment varia
 
 ### Config file loading order
 
-1. `~/.claude/ccgate.jsonnet` — Base config
-2. `{repo_root}/ccgate.local.jsonnet` — Project-local (untracked files only)
-3. `{repo_root}/.claude/ccgate.local.jsonnet` — Project-local (untracked files only)
+1. **Embedded defaults** — Built-in safety rules (fallback when no global config exists)
+2. `~/.claude/ccgate.jsonnet` — Global config (**replaces** embedded defaults entirely)
+3. `{repo_root}/ccgate.local.jsonnet` — Project-local (untracked files only, **appended**)
+4. `{repo_root}/.claude/ccgate.local.jsonnet` — Project-local (untracked files only, **appended**)
 
-Later files merge into earlier ones (allow/deny/environment are appended, provider fields are overwritten).
+If a global config file exists, embedded defaults are not used. The global config is the complete base.
+Project-local configs always append to the base (allow/deny/environment are appended, provider fields are overwritten).
 Project-local configs are only loaded if **not tracked by Git**.
 
 ### Config fields
@@ -118,9 +107,24 @@ Project-local configs are only loaded if **not tracked by Git**.
 | `log_path` | string | `"~/.claude/logs/ccgate.log"` | Log file path. Supports `~` for home directory. |
 | `log_disabled` | bool | `false` | Disable logging entirely |
 | `log_max_size` | int | `5242880` | Max log file size in bytes before rotation (default 5MB) |
-| `allow` | string[] | `[]` | Allow rules |
-| `deny` | string[] | `[]` | Deny rules (mandatory) |
-| `environment` | string[] | `[]` | Environment context |
+| `allow` | string[] | `[]` | Allow guidance rules (natural language, interpreted by the LLM) |
+| `deny` | string[] | `[]` | Deny guidance rules (mandatory). Supports inline `deny_message:` hints |
+| `environment` | string[] | `[]` | Context strings passed to the LLM (trust level, policies, etc.) |
+
+## Default Rules
+
+When no global config file exists, ccgate uses built-in default rules:
+
+**Allow:** Read-only operations, local development commands, git feature branch operations, package manager installs.
+
+**Deny:** Download-and-execute (curl|bash), direct tool invocation (npx, pnpx, etc.), git destructive operations, out-of-repo deletion, sibling checkout / worktree confusion.
+
+Run `ccgate init` to see the full default configuration. To customize, redirect to a file and edit:
+
+```bash
+ccgate init > ~/.claude/ccgate.jsonnet    # Global config (replaces defaults)
+ccgate init -p > ccgate.local.jsonnet     # Project-local template (appended)
+```
 
 ## Logging
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -41,31 +41,18 @@ go install github.com/tak848/ccgate@latest
 
 ## セットアップ
 
-### 1. 設定ファイルを配置
+### 1. 設定ファイルを配置 (オプション)
 
-`~/.claude/ccgate.jsonnet` にルールを記述します。
-[example/ccgate.jsonnet](../example/ccgate.jsonnet) を参考にしてください。
+ccgate はデフォルトの安全ルールを内蔵しているため、設定ファイルなしでも動作します。
 
-```jsonnet
-{
-  provider: {
-    name: 'anthropic',
-    model: 'claude-haiku-4-5',
-    timeout_ms: 40000,
-  },
-  allow: [
-    'Read-Only Operations: ...',
-  ],
-  deny: [
-    'Git Destructive: force push, deleting remote branches, ...',
-  ],
-  environment: [
-    '**Trusted repo**: The git repository the session started in.',
-  ],
-}
+カスタマイズする場合はデフォルトを出力して編集:
+
+```bash
+ccgate init > ~/.claude/ccgate.jsonnet
 ```
 
-`$schema` フィールドでホストされた JSON Schema を参照しているため、ローカルにファイルを配置せずにエディタ補完が効きます。
+[example/ccgate.jsonnet](../example/ccgate.jsonnet) も参考にしてください。
+`$schema` フィールドでホストされた JSON Schema を参照しているため、エディタ補完が効きます。
 
 ### 2. Claude Code の hooks に登録
 
@@ -97,11 +84,13 @@ go install github.com/tak848/ccgate@latest
 
 ### 設定ファイルの読み込み順序
 
-1. `~/.claude/ccgate.jsonnet` — ベース設定
-2. `{repo_root}/ccgate.local.jsonnet` — プロジェクトローカル (Git 未追跡のみ)
-3. `{repo_root}/.claude/ccgate.local.jsonnet` — プロジェクトローカル (Git 未追跡のみ)
+1. **組み込みデフォルト** — 内蔵の安全ルール (グローバル設定がない場合のフォールバック)
+2. `~/.claude/ccgate.jsonnet` — グローバル設定 (組み込みデフォルトを**完全に置換**)
+3. `{repo_root}/ccgate.local.jsonnet` — プロジェクトローカル (Git 未追跡のみ、**追加**)
+4. `{repo_root}/.claude/ccgate.local.jsonnet` — プロジェクトローカル (Git 未追跡のみ、**追加**)
 
-後のファイルが前のファイルの設定をマージ (allow/deny/environment は追加、provider は上書き) します。
+グローバル設定が存在する場合、組み込みデフォルトは使用されません。
+プロジェクトローカル設定は常にベースに追加されます (allow/deny/environment は追加、provider は上書き)。
 プロジェクトローカル設定は **Git に追跡されていないファイルのみ** 読み込まれます。
 
 ### 設定項目
@@ -114,9 +103,24 @@ go install github.com/tak848/ccgate@latest
 | `log_path` | string | `"~/.claude/logs/ccgate.log"` | ログファイルパス。`~` でホームディレクトリ展開 |
 | `log_disabled` | bool | `false` | ログ出力を完全に無効化 |
 | `log_max_size` | int | `5242880` | ローテーション閾値 (bytes, デフォルト 5MB) |
-| `allow` | string[] | `[]` | 許可ルール |
-| `deny` | string[] | `[]` | 拒否ルール (mandatory) |
-| `environment` | string[] | `[]` | 環境コンテキスト |
+| `allow` | string[] | `[]` | 許可ルール (自然言語、LLM が解釈) |
+| `deny` | string[] | `[]` | 拒否ルール (mandatory)。`deny_message:` ヒント対応 |
+| `environment` | string[] | `[]` | LLM に渡すコンテキスト (信頼レベル、ポリシー等) |
+
+## デフォルトルール
+
+グローバル設定がない場合、ccgate は組み込みのデフォルトルールを使用します:
+
+**許可:** 読み取り専用操作、ローカル開発コマンド、git フィーチャーブランチ操作、パッケージマネージャーのインストール。
+
+**拒否:** リモートコードのダウンロード実行 (curl|bash)、直接ツール実行 (npx, pnpx 等)、git 破壊的操作、リポジトリ外の削除、ワークツリー混同。
+
+`ccgate init` でデフォルト設定の全容を確認できます。カスタマイズする場合:
+
+```bash
+ccgate init > ~/.claude/ccgate.jsonnet    # グローバル設定 (デフォルトを置換)
+ccgate init -p > ccgate.local.jsonnet     # プロジェクトローカルテンプレート (追加)
+```
 
 ## ログ
 

--- a/example/ccgate.jsonnet
+++ b/example/ccgate.jsonnet
@@ -1,22 +1,38 @@
 {
   ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/ccgate.schema.json',
+
+  // This file replaces embedded defaults entirely.
+  // Start from: ccgate init > ~/.claude/ccgate.jsonnet
+
   provider: {
     name: 'anthropic',
     model: 'claude-haiku-4-5',
     timeout_ms: 40000,
   },
-  // log_path: '~/.claude/logs/ccgate.log',
+
+  // Full allow rules (replaces defaults, not appended)
   allow: [
-    'Read-Only Operations: GET requests, read-only API calls, or queries that do not modify state.',
-    'Local Operations: Read-only work inside the current repository or current worktree.',
-    'Draft PR Creation: If the operation creates a pull request AND draft is true in tool_input_raw, allow immediately. If draft is false or absent, fallthrough.',
+    'Read-Only Operations: Read, Glob, Grep, and other read-only tools.',
+    'Local Development: Build, test, lint, format commands in the current repository.',
+    'Git Feature Branch: Git operations on non-protected branches.',
+    'Package Manager Install: npm install, go mod tidy, pip install, etc.',
+    'Draft PR Creation: If the operation creates a pull request AND draft is true in tool_input_raw, allow immediately.',
   ],
+
+  // Full deny rules (replaces defaults, not appended)
+  // deny_message is an optional hint -- the LLM adapts it to the specific situation.
   deny: [
-    'Git Destructive: force push (--force), deleting remote branches (push --delete), or rewriting published history. Check recent_transcript and tool_input.description — if the user explicitly requested the operation, fallthrough instead of deny. deny_message: git の破壊的操作です。ユーザーの明示的な指示を確認してください。',
-    'Sibling Checkout / Worktree Confusion: When is_worktree is true, any access to paths under primary_checkout_root or other sibling checkouts MUST be denied. No exceptions. Do not deliberate. deny_message: 現在のワークツリー外のチェックアウトにアクセスしようとしています。ワークツリー内のパスを使用してください。',
+    'Download and Execute: Piping downloaded content to a shell (curl|bash, wget|sh, etc.).',
+    'Direct Tool Invocation: npx, pnpx, pnpm exec, bunx, etc.',
+    'Git Destructive: force push, deleting remote branches, rewriting history.',
+    'Out-of-Repo Deletion: rm -rf targeting paths outside the current repository.',
+    'Sibling Checkout / Worktree Confusion: When is_worktree is true, deny access to primary_checkout_root.',
+    // Optional: add deny_message for custom user-facing messages
+    // 'Custom Rule: ... deny_message: Custom explanation shown to Claude when denied.',
   ],
+
   environment: [
     '**Trusted repo**: The git repository the session started in.',
-    '**Current worktree context**: Prefer the current worktree and its own files over sibling checkouts unless the user clearly asks otherwise.',
+    '**Current worktree context**: Prefer the current worktree over sibling checkouts.',
   ],
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,6 +15,12 @@ import (
 
 	"github.com/tak848/ccgate/internal/gitutil"
 )
+
+//go:embed defaults.jsonnet
+var DefaultsJsonnet string
+
+//go:embed defaults_project.jsonnet
+var DefaultsProjectJsonnet string
 
 const (
 	DefaultTimeoutMS      = 20_000
@@ -142,31 +149,56 @@ func (c Config) ResolveMetricsPath() string {
 	return resolvePath(c.MetricsPath)
 }
 
+// ConfigSource indicates where the base configuration came from.
+type ConfigSource string
+
+const (
+	SourceEmbeddedDefaults ConfigSource = "embedded_defaults"
+	SourceGlobalConfig     ConfigSource = "global_config"
+)
+
+// LoadResult holds the loaded config and metadata about the loading process.
+type LoadResult struct {
+	Config Config
+	Source ConfigSource
+}
+
 // Load reads the base config from ~/.claude/ and merges project-local overrides.
-func Load(cwd string) (Config, error) {
+// If no global config exists, embedded defaults are used as fallback.
+func Load(cwd string) (LoadResult, error) {
 	cfg := Default()
 
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return cfg, fmt.Errorf("user home dir: %w", err)
+		return LoadResult{Config: cfg}, fmt.Errorf("user home dir: %w", err)
 	}
 
+	source := SourceEmbeddedDefaults
 	basePath := filepath.Join(home, ".claude", BaseConfigName)
-	if err := mergeConfigFile(basePath, &cfg); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return cfg, fmt.Errorf("base config %s: %w", basePath, err)
+	if err := mergeConfigFile(basePath, &cfg); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// No global config: use embedded defaults as fallback.
+			if err := mergeConfigString(DefaultsJsonnet, &cfg); err != nil {
+				return LoadResult{Config: cfg}, fmt.Errorf("embedded defaults: %w", err)
+			}
+		} else {
+			return LoadResult{Config: cfg}, fmt.Errorf("base config %s: %w", basePath, err)
+		}
+	} else {
+		source = SourceGlobalConfig
 	}
 
 	for _, path := range safeProjectLocalConfigPaths(cwd) {
 		if err := mergeConfigFile(path, &cfg); err != nil && !errors.Is(err, os.ErrNotExist) {
-			return cfg, fmt.Errorf("local config %s: %w", path, err)
+			return LoadResult{Config: cfg}, fmt.Errorf("local config %s: %w", path, err)
 		}
 	}
 
 	if err := cfg.Validate(); err != nil {
-		return cfg, fmt.Errorf("config validation: %w", err)
+		return LoadResult{Config: cfg}, fmt.Errorf("config validation: %w", err)
 	}
 
-	return cfg, nil
+	return LoadResult{Config: cfg, Source: source}, nil
 }
 
 func projectLocalConfigPaths(cwd string) []string {
@@ -222,7 +254,19 @@ func mergeConfigFile(path string, cfg *Config) error {
 		}
 		return fmt.Errorf("evaluate jsonnet: %w", err)
 	}
+	return mergeConfigJSON(data, cfg)
+}
 
+func mergeConfigString(snippet string, cfg *Config) error {
+	vm := jsonnet.MakeVM()
+	data, err := vm.EvaluateAnonymousSnippet("defaults.jsonnet", snippet)
+	if err != nil {
+		return fmt.Errorf("evaluate jsonnet snippet: %w", err)
+	}
+	return mergeConfigJSON(data, cfg)
+}
+
+func mergeConfigJSON(data string, cfg *Config) error {
 	var override Config
 	if err := json.Unmarshal([]byte(data), &override); err != nil {
 		return fmt.Errorf("unmarshal config: %w", err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -163,6 +163,93 @@ func TestSafeProjectLocalConfigPathsSkipsTrackedFile(t *testing.T) {
 	}
 }
 
+func TestMergeConfigStringAppliesDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg := Default()
+	if err := mergeConfigString(DefaultsJsonnet, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Allow) == 0 {
+		t.Fatal("expected allow rules from embedded defaults")
+	}
+	if len(cfg.Deny) == 0 {
+		t.Fatal("expected deny rules from embedded defaults")
+	}
+	if len(cfg.Environment) == 0 {
+		t.Fatal("expected environment from embedded defaults")
+	}
+}
+
+func TestEmbeddedDefaultsValidJsonnet(t *testing.T) {
+	t.Parallel()
+
+	snippets := map[string]string{
+		"defaults":         DefaultsJsonnet,
+		"defaults_project": DefaultsProjectJsonnet,
+	}
+	for name, snippet := range snippets {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			cfg := Default()
+			if err := mergeConfigString(snippet, &cfg); err != nil {
+				t.Fatalf("embedded %s is invalid jsonnet: %v", name, err)
+			}
+			if err := cfg.Validate(); err != nil {
+				t.Fatalf("config from embedded %s should be valid: %v", name, err)
+			}
+		})
+	}
+}
+
+func TestLoadFallsBackToDefaultsWhenNoGlobalConfig(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel.
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, ".claude"), 0o755)
+	t.Setenv("HOME", dir)
+
+	lr, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lr.Source != SourceEmbeddedDefaults {
+		t.Fatalf("source = %q, want %q", lr.Source, SourceEmbeddedDefaults)
+	}
+	if len(lr.Config.Allow) == 0 {
+		t.Fatal("expected allow rules from embedded defaults")
+	}
+	if len(lr.Config.Deny) == 0 {
+		t.Fatal("expected deny rules from embedded defaults")
+	}
+}
+
+func TestLoadUsesGlobalConfigWhenPresent(t *testing.T) {
+	// t.Setenv is incompatible with t.Parallel.
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	os.MkdirAll(claudeDir, 0o755)
+	content := `{ provider: { name: 'anthropic', model: 'claude-haiku-4-5' }, allow: ['Custom allow'] }`
+	if err := os.WriteFile(filepath.Join(claudeDir, BaseConfigName), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", dir)
+
+	lr, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lr.Source != SourceGlobalConfig {
+		t.Fatalf("source = %q, want %q", lr.Source, SourceGlobalConfig)
+	}
+	if len(lr.Config.Allow) != 1 || lr.Config.Allow[0] != "Custom allow" {
+		t.Fatalf("unexpected allow: %v", lr.Config.Allow)
+	}
+	// Deny should be empty (defaults not applied).
+	if len(lr.Config.Deny) != 0 {
+		t.Fatalf("expected no deny rules (defaults not applied), got %v", lr.Config.Deny)
+	}
+}
+
 func gitRun(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -205,7 +205,9 @@ func TestEmbeddedDefaultsValidJsonnet(t *testing.T) {
 func TestLoadFallsBackToDefaultsWhenNoGlobalConfig(t *testing.T) {
 	// t.Setenv is incompatible with t.Parallel.
 	dir := t.TempDir()
-	os.MkdirAll(filepath.Join(dir, ".claude"), 0o755)
+	if err := os.MkdirAll(filepath.Join(dir, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	t.Setenv("HOME", dir)
 
 	lr, err := Load("")
@@ -227,7 +229,9 @@ func TestLoadUsesGlobalConfigWhenPresent(t *testing.T) {
 	// t.Setenv is incompatible with t.Parallel.
 	dir := t.TempDir()
 	claudeDir := filepath.Join(dir, ".claude")
-	os.MkdirAll(claudeDir, 0o755)
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	content := `{ provider: { name: 'anthropic', model: 'claude-haiku-4-5' }, allow: ['Custom allow'] }`
 	if err := os.WriteFile(filepath.Join(claudeDir, BaseConfigName), []byte(content), 0o644); err != nil {
 		t.Fatal(err)

--- a/internal/config/defaults.jsonnet
+++ b/internal/config/defaults.jsonnet
@@ -1,0 +1,33 @@
+{
+  // Default safety rules for ccgate.
+  // Inspired by Claude Code Auto Mode defaults.
+  // Customize: ccgate init > ~/.claude/ccgate.jsonnet
+
+  provider: {
+    name: 'anthropic',
+    model: 'claude-haiku-4-5',
+    // timeout_ms defaults to 20000 (from Go constant DefaultTimeoutMS).
+    // Uncomment to override: timeout_ms: 40000,
+  },
+
+  allow: [
+    'Read-Only Operations: Read, Glob, Grep, and other read-only tools that do not modify state.',
+    'Local Development: Build, test, lint, format commands in the current repository.',
+    'Git Feature Branch: Git operations on non-protected branches (not main, master, release/*, prod).',
+    'Package Manager Install: Package manager commands (npm install, go mod tidy, pip install, etc.) in the current repository.',
+  ],
+
+  // deny_message is an example hint -- the LLM should adapt it to the specific situation.
+  // It helps the LLM understand WHY the rule exists and what kind of feedback to give.
+  deny: [
+    'Download and Execute: Piping downloaded content to a shell (curl|bash, wget|sh, etc.), or executing remote scripts without review. deny_message: Downloading and executing remote code is not allowed.',
+    'Direct Tool Invocation: Running tools directly via npx, pnpx, pnpm exec, bunx, etc. instead of using project-defined scripts. deny_message: Use project-defined scripts instead.',
+    'Git Destructive: force push (--force, --force-with-lease), deleting remote branches (push --delete), or rewriting published history. Check recent_transcript -- if the user explicitly requested the operation, fallthrough instead of deny. deny_message: Destructive git operation detected. Confirm with user.',
+    'Out-of-Repo Deletion: rm -rf or destructive file operations targeting paths outside the current repository (check referenced_paths against repo_root). Deletion within the repository (node_modules, dist, build artifacts) is fine. deny_message: Deletion outside the repository is not allowed.',
+    'Sibling Checkout / Worktree Confusion: When is_worktree is true, any access to paths under primary_checkout_root or other sibling checkouts MUST be denied. deny_message: Accessing paths outside the current worktree is not allowed.',
+  ],
+
+  environment: [
+    '**Trusted repo**: The git repository the session started in.',
+  ],
+}

--- a/internal/config/defaults.jsonnet
+++ b/internal/config/defaults.jsonnet
@@ -1,4 +1,6 @@
 {
+  ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/ccgate.schema.json',
+
   // Default safety rules for ccgate.
   // Inspired by Claude Code Auto Mode defaults.
   // Customize: ccgate init > ~/.claude/ccgate.jsonnet

--- a/internal/config/defaults_project.jsonnet
+++ b/internal/config/defaults_project.jsonnet
@@ -1,4 +1,6 @@
 {
+  ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/ccgate.schema.json',
+
   // Project-local ccgate configuration.
   // This file adds restrictions on top of the global config.
   // Place as: {repo_root}/ccgate.local.jsonnet or {repo_root}/.claude/ccgate.local.jsonnet

--- a/internal/config/defaults_project.jsonnet
+++ b/internal/config/defaults_project.jsonnet
@@ -1,0 +1,20 @@
+{
+  // Project-local ccgate configuration.
+  // This file adds restrictions on top of the global config.
+  // Place as: {repo_root}/ccgate.local.jsonnet or {repo_root}/.claude/ccgate.local.jsonnet
+  // IMPORTANT: Must NOT be tracked by git (add to .gitignore).
+
+  deny: [
+    // Add project-specific deny rules here.
+    // Examples:
+    // 'Network Access: Deny curl, wget, or HTTP requests to external services. deny_message: Network access is restricted in this project.',
+    // 'Script Execution: Deny running shell scripts (.sh, .bash) from this repository. deny_message: Script execution is restricted in this project.',
+  ],
+
+  environment: [
+    // Describe the project context for the LLM.
+    // Examples:
+    // '**Untrusted repository**: Apply strict security policies.',
+    // '**Production repository**: Deny any operations that could affect production.',
+  ],
+}

--- a/internal/gate/anthropic.go
+++ b/internal/gate/anthropic.go
@@ -153,9 +153,10 @@ func buildSystemPrompt(cfg config.Config) string {
 	b.WriteString("- fallthrough: When uncertain whether an action is planning or implementation.\n\n")
 
 	b.WriteString("Normal decision rules:\n")
-	b.WriteString("- deny: When a deny guidance rule matches. EXCEPT: if recent_transcript shows the user explicitly requested the operation, use fallthrough instead of deny to let the user confirm.\n")
-	b.WriteString("- allow: When the operation matches allow guidance. Also, if the most recent user message directly and specifically describes the exact command/tool/path being executed, allow it unless it matches a deny rule targeting dangerous patterns (download-and-execute, force push, etc.). If the user message is ambiguous (e.g. \"yes, go ahead\" without specifying the action), do NOT treat it as explicit permission.\n")
-	b.WriteString("- fallthrough: When genuinely uncertain, OR when a deny rule matches but the user explicitly requested the operation.\n\n")
+	b.WriteString("- deny: When a deny guidance rule matches. EXCEPT: if recent_transcript shows the user explicitly requested the exact operation, use fallthrough instead of deny to let the user confirm.\n")
+	b.WriteString("- allow: When the operation matches allow guidance and no deny rule matches.\n")
+	b.WriteString("- fallthrough: When genuinely uncertain, OR when a deny rule matches but the user explicitly requested the operation.\n")
+	b.WriteString("Deny rules always take priority over allow rules. Explicit user requests can only escalate deny to fallthrough, never to allow.\n\n")
 
 	b.WriteString("Always provide a brief reason for your decision.\n")
 	b.WriteString("When deny, provide a concise deny_message. If the deny rule includes a deny_message hint, adapt it to the specific situation.\n")

--- a/internal/gate/anthropic.go
+++ b/internal/gate/anthropic.go
@@ -25,7 +25,7 @@ const (
 type PermissionLLMOutput struct {
 	Behavior    string `json:"behavior" jsonschema_description:"One of allow, deny, fallthrough."`
 	Reason      string `json:"reason" jsonschema_description:"Brief reason for the decision. Always provide this regardless of behavior."`
-	DenyMessage string `json:"deny_message" jsonschema_description:"When behavior is deny, a concise Japanese explanation of why. Must not be empty when denying."`
+	DenyMessage string `json:"deny_message" jsonschema_description:"When behavior is deny, a concise explanation of why. Must not be empty when denying."`
 }
 
 // PermissionPromptInput is the user message sent to the LLM.
@@ -142,17 +142,23 @@ func callAnthropic(parent context.Context, cfg config.Config, input hookctx.Hook
 
 func buildSystemPrompt(cfg config.Config) string {
 	var b strings.Builder
-	b.WriteString("You are a PermissionRequest hook classifier for Claude Code.\n")
+	b.WriteString("You are ccgate, a PermissionRequest hook classifier for Claude Code.\n")
 	b.WriteString("Return one of: allow, deny, fallthrough.\n")
 	b.WriteString("Decide quickly. Do not deliberate or reconsider.\n\n")
-	b.WriteString("Decision rules:\n")
-	b.WriteString("- deny: When a deny guidance rule matches, OR a built-in rule matches. EXCEPT: if recent_transcript shows the user explicitly requested the operation, use fallthrough instead of deny to let the user confirm.\n")
-	b.WriteString("- allow: When the operation matches allow guidance, OR is a routine development operation (build, test, lint, git, file read/write) in the current repository.\n")
+
+	b.WriteString("Plan mode override (when permission_mode is \"plan\"):\n")
+	b.WriteString("Evaluate BEFORE normal rules. Plan mode restricts actions to planning only.\n")
+	b.WriteString("- allow: Read operations and write operations related to planning (file reads, searches, plan file edits).\n")
+	b.WriteString("- deny: Implementation actions (git commit, build, deploy, package install).\n")
+	b.WriteString("- fallthrough: When uncertain whether an action is planning or implementation.\n\n")
+
+	b.WriteString("Normal decision rules:\n")
+	b.WriteString("- deny: When a deny guidance rule matches. EXCEPT: if recent_transcript shows the user explicitly requested the operation, use fallthrough instead of deny to let the user confirm.\n")
+	b.WriteString("- allow: When the operation matches allow guidance. Also, if the most recent user message directly and specifically describes the exact command/tool/path being executed, allow it unless it matches a deny rule targeting dangerous patterns (download-and-execute, force push, etc.). If the user message is ambiguous (e.g. \"yes, go ahead\" without specifying the action), do NOT treat it as explicit permission.\n")
 	b.WriteString("- fallthrough: When genuinely uncertain, OR when a deny rule matches but the user explicitly requested the operation.\n\n")
-	b.WriteString("Built-in deny rules:\n")
-	b.WriteString("- Direct tool invocation (npx, pnpm exec, etc.): Deny when a command bypasses project scripts by invoking tools directly. Prefer project-defined scripts (e.g. pnpm format over pnpm exec prettier). deny_message: プロジェクトのスクリプトを使用してください。\n\n")
+
 	b.WriteString("Always provide a brief reason for your decision.\n")
-	b.WriteString("When deny, provide a concise Japanese deny_message.\n")
+	b.WriteString("When deny, provide a concise deny_message. If the deny rule includes a deny_message hint, adapt it to the specific situation.\n")
 	b.WriteString("The user message includes settings_permissions and recent_transcript as background context.\n")
 	b.WriteString("settings_permissions shows static rules. An operation NOT being there is NOT a reason to deny or fallthrough.\n")
 	b.WriteString("recent_transcript shows recent user messages and tool calls. Use it to understand what the user asked for. If the user explicitly requested the operation, prefer allow or fallthrough over deny.\n\n")

--- a/internal/gate/anthropic_test.go
+++ b/internal/gate/anthropic_test.go
@@ -1,0 +1,67 @@
+package gate
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/tak848/ccgate/internal/config"
+)
+
+func TestBuildSystemPromptRemovedHardcodedContent(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Default()
+	cfg.Allow = []string{"Test allow"}
+	cfg.Deny = []string{"Test deny"}
+	prompt := buildSystemPrompt(cfg)
+
+	for _, banned := range []string{
+		"Japanese",
+		"Built-in deny rules",
+		"routine development operation",
+	} {
+		if strings.Contains(prompt, banned) {
+			t.Errorf("system prompt should not contain %q", banned)
+		}
+	}
+}
+
+func TestBuildSystemPromptInjectsConfigRules(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Default()
+	cfg.Allow = []string{"Custom allow rule"}
+	cfg.Deny = []string{"Custom deny rule"}
+	cfg.Environment = []string{"Custom env"}
+	prompt := buildSystemPrompt(cfg)
+
+	for _, expected := range []string{
+		"Custom allow rule",
+		"Custom deny rule",
+		"Custom env",
+		"Plan mode override",
+	} {
+		if !strings.Contains(prompt, expected) {
+			t.Errorf("system prompt should contain %q", expected)
+		}
+	}
+}
+
+func TestPermissionOutputSchemaNoJapanese(t *testing.T) {
+	t.Parallel()
+
+	schema, err := permissionOutputSchema()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(string(data), "Japanese") {
+		t.Fatal("output schema should not reference 'Japanese'")
+	}
+}

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -14,7 +14,7 @@ const (
 	BehaviorAllow       = "allow"
 	BehaviorDeny        = "deny"
 	BehaviorFallthrough = "fallthrough"
-	DefaultDenyMessage  = "危険な可能性が高いため、自動許可しません。"
+	DefaultDenyMessage  = "Automatically denied as potentially dangerous."
 )
 
 type PermissionDecision struct {

--- a/main.go
+++ b/main.go
@@ -64,8 +64,7 @@ func _main() int {
 		switch kctx.Command() {
 		case "init":
 			return runInit(cli.Init)
-		}
-		if kctx.Command() == "metrics" {
+		case "metrics":
 			cwd, err := os.Getwd()
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "warning: failed to get working directory: %v\n", err)

--- a/main.go
+++ b/main.go
@@ -35,7 +35,14 @@ func init() {
 
 type CLI struct {
 	Version kong.VersionFlag `help:"Print version and exit."`
+	Init    InitCmd          `cmd:"" help:"Output default configuration."`
 	Metrics MetricsCmd       `cmd:"" help:"Show usage metrics summary."`
+}
+
+type InitCmd struct {
+	Project bool   `help:"Output project-local configuration template." short:"p"`
+	Output  string `help:"Write to file instead of stdout." short:"o" type:"path"`
+	Force   bool   `help:"Overwrite existing file." short:"f"`
 }
 
 type MetricsCmd struct {
@@ -54,17 +61,21 @@ func _main() int {
 			kong.Description("Claude Code PermissionRequest hook.\nReads HookInput JSON from stdin, returns allow/deny/fallthrough to stdout."),
 			kong.Vars{"version": version},
 		)
+		switch kctx.Command() {
+		case "init":
+			return runInit(cli.Init)
+		}
 		if kctx.Command() == "metrics" {
 			cwd, err := os.Getwd()
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "warning: failed to get working directory: %v\n", err)
 			}
-			cfg, err := config.Load(cwd)
+			lr, err := config.Load(cwd)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "failed to load config: %v\n", err)
 				return 1
 			}
-			if err := metrics.PrintReport(os.Stdout, cfg.ResolveMetricsPath(), metrics.ReportOptions{
+			if err := metrics.PrintReport(os.Stdout, lr.Config.ResolveMetricsPath(), metrics.ReportOptions{
 				Days:   cli.Metrics.Days,
 				AsJSON: cli.Metrics.JSON,
 			}); err != nil {
@@ -77,11 +88,44 @@ func _main() int {
 
 	// No args: if tty, show usage; if pipe, run hook.
 	if term.IsTerminal(int(os.Stdin.Fd())) {
-		fmt.Fprintf(os.Stderr, "ccgate %s\n\nClaude Code PermissionRequest hook.\nReads HookInput JSON from stdin, returns allow/deny/fallthrough to stdout.\n\nCommands:\n  ccgate metrics [--days N] [--json]\n\nFlags:\n  --version    Print version and exit\n  --help       Show help\n", version)
+		fmt.Fprintf(os.Stderr, "ccgate %s\n\nClaude Code PermissionRequest hook.\nReads HookInput JSON from stdin, returns allow/deny/fallthrough to stdout.\n\nCommands:\n  ccgate init [-p] [-o FILE] [-f]   Output default configuration\n  ccgate metrics [--days N] [--json] Show usage metrics summary\n\nFlags:\n  --version    Print version and exit\n  --help       Show help\n", version)
 		return 0
 	}
 
 	return runHook()
+}
+
+func runInit(cmd InitCmd) int {
+	content := config.DefaultsJsonnet
+	if cmd.Project {
+		content = config.DefaultsProjectJsonnet
+	}
+
+	if cmd.Output == "" {
+		fmt.Print(content)
+		return 0
+	}
+
+	if !cmd.Force {
+		if _, err := os.Stat(cmd.Output); err == nil {
+			fmt.Fprintf(os.Stderr, "error: file already exists: %s (use -f to overwrite)\n", cmd.Output)
+			return 1
+		}
+	}
+
+	dir := filepath.Dir(cmd.Output)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "error: failed to create directory %s: %v\n", dir, err)
+		return 1
+	}
+
+	if err := os.WriteFile(cmd.Output, []byte(content), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "error: failed to write file %s: %v\n", cmd.Output, err)
+		return 1
+	}
+
+	fmt.Fprintf(os.Stderr, "wrote %s\n", cmd.Output)
+	return 0
 }
 
 func runHook() int {
@@ -94,19 +138,25 @@ func runHook() int {
 		return 1
 	}
 
-	cfg, err := config.Load(input.Cwd)
+	lr, err := config.Load(input.Cwd)
 	if err != nil {
 		slog.Error("failed to load config", "error", err)
 		return 1
 	}
+	cfg := lr.Config
 
 	logger, cleanup := initLogger(cfg.ResolveLogPath(), cfg.IsLogDisabled(), cfg.GetLogMaxSize())
 	defer cleanup()
 	slog.SetDefault(logger)
 
+	if lr.Source == config.SourceGlobalConfig && len(cfg.Allow) == 0 && len(cfg.Deny) == 0 {
+		slog.Warn("allow and deny rules are both empty; embedded defaults were not applied because a global config exists")
+	}
+
 	slog.Info("hook invoked",
 		"tool", input.ToolName,
 		"permission_mode", input.PermissionMode,
+		"config_source", string(lr.Source),
 	)
 
 	start := time.Now()


### PR DESCRIPTION
## Why

ccgate required a config file to function meaningfully — without one, allow/deny rules were empty and the LLM had no guidance. The system prompt also contained hardcoded personal preferences (Japanese deny_message, npx/pnpm built-in deny rule) that made it unsuitable for external users.

## What

- Embed default safety rules (allow/deny/environment) as a Go-embedded jsonnet file, used as fallback when no global config exists
- Add `ccgate init` subcommand to output default config (`-p` for project template, `-o` for file output, `-f` to force overwrite)
- Remove hardcoded built-in deny/allow rules and Japanese language constraint from system prompt
- Add plan mode override and explicit user permission logic to decision rules
- Change DefaultDenyMessage to English
- Update README and Japanese docs for new config loading behavior (embedded defaults as fallback, global config replaces defaults, project-local appends)

## Breaking Changes

- **Built-in deny rules removed from system prompt**: The previously hardcoded npx/pnpm deny rule and "routine development operation" allow are now in `defaults.jsonnet`. Existing users with a global config (`~/.claude/ccgate.jsonnet`) need to add these rules to their config, as embedded defaults are not applied when a global config exists.
- **Japanese deny_message no longer enforced**: The system prompt no longer forces Japanese deny messages. Deny message language depends on deny rule hints.
- **DefaultDenyMessage changed to English**: The fallback deny message is now English.

Migration guide: `z/202604080827-v0.4.0-dotfiles-migration.md`

Related issues: #26, #27, #28, #29, #30