### PR TITLE
feat!: rename API key env var from CC_AUTOMODE to CCGATE

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The `$schema` field points to the hosted JSON Schema for editor autocompletion.
 
 ### 3. API key
 
-Set the `CC_AUTOMODE_ANTHROPIC_API_KEY` or `ANTHROPIC_API_KEY` environment variable.
+Set the `CCGATE_ANTHROPIC_API_KEY` or `ANTHROPIC_API_KEY` environment variable.
 
 ## Configuration
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -78,7 +78,7 @@ ccgate init > ~/.claude/ccgate.jsonnet
 
 ### 3. API キー
 
-環境変数 `CC_AUTOMODE_ANTHROPIC_API_KEY` または `ANTHROPIC_API_KEY` を設定してください。
+環境変数 `CCGATE_ANTHROPIC_API_KEY` または `ANTHROPIC_API_KEY` を設定してください。
 
 ## 設定
 

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -91,7 +91,7 @@ func DecidePermission(ctx context.Context, cfg config.Config, input hookctx.Hook
 
 	apiKey, ok := resolveAPIKey()
 	if !ok {
-		slog.Warn("no API key found (CC_AUTOMODE_ANTHROPIC_API_KEY / ANTHROPIC_API_KEY)")
+		slog.Warn("no API key found (CCGATE_ANTHROPIC_API_KEY / ANTHROPIC_API_KEY)")
 		return DecisionResult{FallthroughKind: "no_apikey"}, nil
 	}
 
@@ -143,7 +143,7 @@ func DecidePermission(ctx context.Context, cfg config.Config, input hookctx.Hook
 }
 
 func resolveAPIKey() (string, bool) {
-	if key := strings.TrimSpace(os.Getenv("CC_AUTOMODE_ANTHROPIC_API_KEY")); key != "" {
+	if key := strings.TrimSpace(os.Getenv("CCGATE_ANTHROPIC_API_KEY")); key != "" {
 		return key, true
 	}
 	if key := strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY")); key != "" {


### PR DESCRIPTION
## Why

The environment variable `CC_AUTOMODE_ANTHROPIC_API_KEY` was inherited from the original dotfiles implementation. Now that ccgate is a standalone project, it should use its own namespace.

## What

- Rename `CC_AUTOMODE_ANTHROPIC_API_KEY` to `CCGATE_ANTHROPIC_API_KEY`
- `ANTHROPIC_API_KEY` continues to work as fallback
- Update README and Japanese docs

## Breaking Changes

- Users must rename their environment variable from `CC_AUTOMODE_ANTHROPIC_API_KEY` to `CCGATE_ANTHROPIC_API_KEY`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/ccgate/pull/32" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
