### PR TITLE
chore: group changelog by conventional commit type

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,7 +43,7 @@ changelog:
       order: 999
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
-      - '^ci:'
-      - '^chore:'
+      - '^docs'
+      - '^test'
+      - '^ci'
+      - '^chore'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,8 +25,25 @@ checksum:
   name_template: checksums.txt
 changelog:
   sort: asc
+  use: github
+  groups:
+    - title: Breaking Changes
+      regexp: '^.*!:'
+      order: 0
+    - title: Features
+      regexp: '^feat'
+      order: 1
+    - title: Bug Fixes
+      regexp: '^fix'
+      order: 2
+    - title: Refactoring
+      regexp: '^refactor'
+      order: 3
+    - title: Others
+      order: 999
   filters:
     exclude:
       - '^docs:'
       - '^test:'
       - '^ci:'
+      - '^chore:'


### PR DESCRIPTION
## Why

Release notes were a flat list of commit messages. Grouping by type makes it easier to scan what changed.

## What

- Group changelog by Conventional Commits: Breaking Changes, Features, Bug Fixes, Refactoring
- Use `github` changelog source (PR titles instead of raw commits)
- Exclude docs/test/ci/chore commits from release notes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/ccgate/pull/33" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
