### PR TITLE
feat(metrics): record tool_input + automation rate + thousands separators

### DIFF
--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -17,6 +17,18 @@ const (
 	DefaultDenyMessage  = "Automatically denied as potentially dangerous."
 )
 
+// FallthroughKind* values are stored verbatim in metrics entries.
+// Only FallthroughKindLLM is promotable via permission rules — the other
+// kinds indicate runtime-mode or configuration conditions.
+const (
+	FallthroughKindUserInteraction = "user_interaction"
+	FallthroughKindBypass          = "bypass"
+	FallthroughKindDontAsk         = "dontask"
+	FallthroughKindNonAnthropic    = "non_anthropic"
+	FallthroughKindNoAPIKey        = "no_apikey"
+	FallthroughKindLLM             = "llm"
+)
+
 type PermissionDecision struct {
 	Behavior string `json:"behavior"`
 	Message  string `json:"message,omitempty"`
@@ -69,7 +81,7 @@ func DecidePermission(ctx context.Context, cfg config.Config, input hookctx.Hook
 	switch input.ToolName {
 	case "ExitPlanMode", "AskUserQuestion":
 		slog.Info("user interaction tool: falling through", "tool", input.ToolName)
-		return DecisionResult{FallthroughKind: "user_interaction"}, nil
+		return DecisionResult{FallthroughKind: FallthroughKindUserInteraction}, nil
 	}
 
 	// Some permission modes should not be overridden by the hook.
@@ -78,21 +90,21 @@ func DecidePermission(ctx context.Context, cfg config.Config, input hookctx.Hook
 		// In plan mode, let the LLM decide for non-interaction tools.
 	case "bypassPermissions":
 		slog.Info("bypass mode: falling through", "tool", input.ToolName)
-		return DecisionResult{FallthroughKind: "bypass"}, nil
+		return DecisionResult{FallthroughKind: FallthroughKindBypass}, nil
 	case "dontAsk":
 		slog.Info("dontAsk mode: falling through", "tool", input.ToolName)
-		return DecisionResult{FallthroughKind: "dontask"}, nil
+		return DecisionResult{FallthroughKind: FallthroughKindDontAsk}, nil
 	}
 
 	if strings.ToLower(cfg.Provider.Name) != "anthropic" {
 		slog.Info("provider not anthropic, skipping", "provider", cfg.Provider.Name)
-		return DecisionResult{FallthroughKind: "non_anthropic"}, nil
+		return DecisionResult{FallthroughKind: FallthroughKindNonAnthropic}, nil
 	}
 
 	apiKey, ok := resolveAPIKey()
 	if !ok {
 		slog.Warn("no API key found (CCGATE_ANTHROPIC_API_KEY / ANTHROPIC_API_KEY)")
-		return DecisionResult{FallthroughKind: "no_apikey"}, nil
+		return DecisionResult{FallthroughKind: FallthroughKindNoAPIKey}, nil
 	}
 
 	slog.Info("calling anthropic",
@@ -133,11 +145,11 @@ func DecidePermission(ctx context.Context, cfg config.Config, input hookctx.Hook
 		base.HasDecision = true
 		return base, nil
 	case BehaviorFallthrough, "":
-		base.FallthroughKind = "llm"
+		base.FallthroughKind = FallthroughKindLLM
 		return base, nil
 	default:
 		slog.Warn("unexpected LLM behavior", "behavior", output.Behavior)
-		base.FallthroughKind = "llm"
+		base.FallthroughKind = FallthroughKindLLM
 		return base, nil
 	}
 }

--- a/internal/hookctx/input.go
+++ b/internal/hookctx/input.go
@@ -53,8 +53,9 @@ func (h *HookInput) UnmarshalJSON(data []byte) error {
 }
 
 // MetricsFields returns the subset of tool_input recorded in metrics.
-// Only command/file_path/path/pattern are exposed; content/content_updates
-// and the raw JSON are intentionally omitted.
+// Only command/file_path/path/pattern are exposed; description,
+// content, content_updates and the raw JSON are intentionally omitted
+// to keep metrics compact and avoid leaking descriptive or file-body text.
 func (h HookInput) MetricsFields() (command, filePath, path, pattern string) {
 	return h.ToolInput.Command, h.ToolInput.FilePath, h.ToolInput.Path, h.ToolInput.Pattern
 }

--- a/internal/hookctx/input.go
+++ b/internal/hookctx/input.go
@@ -52,6 +52,13 @@ func (h *HookInput) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MetricsFields returns the subset of tool_input recorded in metrics.
+// Only command/file_path/path/pattern are exposed; content/content_updates
+// and the raw JSON are intentionally omitted.
+func (h HookInput) MetricsFields() (command, filePath, path, pattern string) {
+	return h.ToolInput.Command, h.ToolInput.FilePath, h.ToolInput.Path, h.ToolInput.Pattern
+}
+
 // ToolInputText returns a textual representation of the tool input for path extraction.
 func (h HookInput) ToolInputText() string {
 	var parts []string

--- a/internal/hookctx/input_test.go
+++ b/internal/hookctx/input_test.go
@@ -5,38 +5,31 @@ import "testing"
 func TestMetricsFields(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name                             string
+	tests := map[string]struct {
 		input                            HookToolInput
 		wantCmd, wantFP, wantPath, wantP string
 	}{
-		{
-			name:  "all empty",
+		"all empty": {
 			input: HookToolInput{},
 		},
-		{
-			name:    "bash command",
+		"bash command": {
 			input:   HookToolInput{Command: "gh pr list"},
 			wantCmd: "gh pr list",
 		},
-		{
-			name:   "write file_path",
+		"write file_path": {
 			input:  HookToolInput{FilePath: "/tmp/foo.ts"},
 			wantFP: "/tmp/foo.ts",
 		},
-		{
-			name:     "grep pattern and path",
+		"grep pattern and path": {
 			input:    HookToolInput{Path: "internal/", Pattern: "TODO"},
 			wantPath: "internal/",
 			wantP:    "TODO",
 		},
-		{
-			name:     "glob path only",
+		"glob path only": {
 			input:    HookToolInput{Path: "**/*.go"},
 			wantPath: "**/*.go",
 		},
-		{
-			name: "content and content_updates are ignored",
+		"content and content_updates are ignored": {
 			input: HookToolInput{
 				Command: "echo hi",
 				Content: "secret contents that should not leak",
@@ -46,8 +39,7 @@ func TestMetricsFields(t *testing.T) {
 			},
 			wantCmd: "echo hi",
 		},
-		{
-			name: "all fields populated returns all four verbatim",
+		"all fields populated returns all four verbatim": {
 			input: HookToolInput{
 				Command:  "c",
 				FilePath: "fp",
@@ -61,8 +53,8 @@ func TestMetricsFields(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			h := HookInput{ToolInput: tc.input}
 			cmd, fp, path, pat := h.MetricsFields()

--- a/internal/hookctx/input_test.go
+++ b/internal/hookctx/input_test.go
@@ -1,0 +1,75 @@
+package hookctx
+
+import "testing"
+
+func TestMetricsFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                             string
+		input                            HookToolInput
+		wantCmd, wantFP, wantPath, wantP string
+	}{
+		{
+			name:  "all empty",
+			input: HookToolInput{},
+		},
+		{
+			name:    "bash command",
+			input:   HookToolInput{Command: "gh pr list"},
+			wantCmd: "gh pr list",
+		},
+		{
+			name:   "write file_path",
+			input:  HookToolInput{FilePath: "/tmp/foo.ts"},
+			wantFP: "/tmp/foo.ts",
+		},
+		{
+			name:     "grep pattern and path",
+			input:    HookToolInput{Path: "internal/", Pattern: "TODO"},
+			wantPath: "internal/",
+			wantP:    "TODO",
+		},
+		{
+			name:     "glob path only",
+			input:    HookToolInput{Path: "**/*.go"},
+			wantPath: "**/*.go",
+		},
+		{
+			name: "content and content_updates are ignored",
+			input: HookToolInput{
+				Command: "echo hi",
+				Content: "secret contents that should not leak",
+				ContentUpdates: []HookContentUpdate{
+					{OldString: "a", NewString: "b"},
+				},
+			},
+			wantCmd: "echo hi",
+		},
+		{
+			name: "all fields populated returns all four verbatim",
+			input: HookToolInput{
+				Command:  "c",
+				FilePath: "fp",
+				Path:     "p",
+				Pattern:  "pat",
+			},
+			wantCmd:  "c",
+			wantFP:   "fp",
+			wantPath: "p",
+			wantP:    "pat",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h := HookInput{ToolInput: tc.input}
+			cmd, fp, path, pat := h.MetricsFields()
+			if cmd != tc.wantCmd || fp != tc.wantFP || path != tc.wantPath || pat != tc.wantP {
+				t.Errorf("MetricsFields() = (%q, %q, %q, %q), want (%q, %q, %q, %q)",
+					cmd, fp, path, pat, tc.wantCmd, tc.wantFP, tc.wantPath, tc.wantP)
+			}
+		})
+	}
+}

--- a/internal/metrics/entry.go
+++ b/internal/metrics/entry.go
@@ -2,19 +2,30 @@ package metrics
 
 import "time"
 
+// ToolInputFields is the structured subset of HookToolInput recorded in metrics.
+// Only command/file_path/path/pattern are captured; content/content_updates are
+// intentionally omitted to keep JSONL compact and avoid storing file contents.
+type ToolInputFields struct {
+	Command  string `json:"command,omitempty"`
+	FilePath string `json:"file_path,omitempty"`
+	Path     string `json:"path,omitempty"`
+	Pattern  string `json:"pattern,omitempty"`
+}
+
 // Entry represents a single ccgate invocation for metrics.
 type Entry struct {
-	Timestamp       time.Time `json:"ts"`
-	SessionID       string    `json:"sid,omitempty"`
-	ToolName        string    `json:"tool"`
-	PermissionMode  string    `json:"perm_mode"`
-	Decision        string    `json:"decision"`
-	FallthroughKind string    `json:"ft_kind,omitempty"`
-	Reason          string    `json:"reason,omitempty"`
-	DenyMessage     string    `json:"deny_msg,omitempty"`
-	Model           string    `json:"model,omitempty"`
-	InputTokens     int64     `json:"in_tok,omitempty"`
-	OutputTokens    int64     `json:"out_tok,omitempty"`
-	ElapsedMS       int64     `json:"elapsed_ms"`
-	Error           string    `json:"error,omitempty"`
+	Timestamp       time.Time       `json:"ts"`
+	SessionID       string          `json:"sid,omitempty"`
+	ToolName        string          `json:"tool"`
+	PermissionMode  string          `json:"perm_mode"`
+	Decision        string          `json:"decision"`
+	FallthroughKind string          `json:"ft_kind,omitempty"`
+	Reason          string          `json:"reason,omitempty"`
+	DenyMessage     string          `json:"deny_msg,omitempty"`
+	Model           string          `json:"model,omitempty"`
+	InputTokens     int64           `json:"in_tok,omitempty"`
+	OutputTokens    int64           `json:"out_tok,omitempty"`
+	ElapsedMS       int64           `json:"elapsed_ms"`
+	Error           string          `json:"error,omitempty"`
+	ToolInput       ToolInputFields `json:"tool_input,omitzero"`
 }

--- a/internal/metrics/report.go
+++ b/internal/metrics/report.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -16,13 +17,36 @@ import (
 // DefaultReportDays is the default number of days for metrics reports.
 const DefaultReportDays = 7
 
+// defaultDetailsTop is the default number of rows shown in the
+// "Top fallthrough/deny commands" sections.
+const defaultDetailsTop = 10
+
+// maxDisplayToolInput caps the rune length of tool_input displayed in
+// the TTY details sections. Aggregation keys use the full raw value;
+// this limit only affects what is printed.
+const maxDisplayToolInput = 200
+
+// noInputPlaceholder is the TTY-only sentinel rendered for entries whose
+// ToolInput is entirely empty. JSON output keeps the empty object instead.
+const noInputPlaceholder = "(no input)"
+
+// llmFallthroughKind is the FallthroughKind value that represents
+// "the LLM decided not to decide". Only fallthroughs of this kind are
+// promotable via permission rule additions, so the "Top fallthrough
+// commands" section filters on it.
+const llmFallthroughKind = "llm"
+
 // ReportOptions controls how the report is generated.
 type ReportOptions struct {
-	Days   int
-	AsJSON bool
+	Days       int
+	AsJSON     bool
+	DetailsTop int
 }
 
 // DailySummary aggregates metrics for a single calendar day.
+//
+// AutomationRate is (Allow+Deny)/Total. Total counts every entry on the
+// day including errors, so error bursts drag the rate down rather than up.
 type DailySummary struct {
 	Date              string  `json:"date"`
 	Total             int     `json:"total"`
@@ -30,6 +54,7 @@ type DailySummary struct {
 	Deny              int     `json:"deny"`
 	Fallthrough       int     `json:"fallthrough"`
 	Errors            int     `json:"errors"`
+	AutomationRate    float64 `json:"automation_rate"`
 	AvgElapsedMS      float64 `json:"avg_elapsed_ms"`
 	TotalInputTokens  int64   `json:"total_input_tokens"`
 	TotalOutputTokens int64   `json:"total_output_tokens"`
@@ -44,12 +69,29 @@ type ToolSummary struct {
 	Fallthrough int    `json:"fallthrough"`
 }
 
+// ToolInputSummary aggregates entries sharing the same tool name and
+// structured tool_input. Used for "Top fallthrough commands" / "Top deny
+// commands" sections. ToolInput is emitted verbatim (no omitempty) so
+// consumers can distinguish "all fields empty" from "a literal (no input)".
+type ToolInputSummary struct {
+	ToolName  string          `json:"tool"`
+	ToolInput ToolInputFields `json:"tool_input"`
+	Count     int             `json:"count"`
+}
+
 // FullReport is the complete metrics report.
+//
+// AutomationRate is computed across all entries in the range.
+// FallthroughTop is restricted to entries whose FallthroughKind is "llm"
+// because only those are promotable by adding permission rules.
 type FullReport struct {
-	Period    string         `json:"period"`
-	DataRange string         `json:"data_range,omitempty"`
-	Daily     []DailySummary `json:"daily"`
-	Tools     []ToolSummary  `json:"tools"`
+	Period         string             `json:"period"`
+	DataRange      string             `json:"data_range,omitempty"`
+	AutomationRate float64            `json:"automation_rate"`
+	Daily          []DailySummary     `json:"daily"`
+	Tools          []ToolSummary      `json:"tools"`
+	FallthroughTop []ToolInputSummary `json:"fallthrough_top"`
+	DenyTop        []ToolInputSummary `json:"deny_top"`
 }
 
 // PrintReport reads the metrics file and prints a report to w.
@@ -73,6 +115,11 @@ func buildReport(path string, opts ReportOptions) (FullReport, time.Time, error)
 	if opts.Days <= 0 {
 		opts.Days = DefaultReportDays
 	}
+	// Normalize DetailsTop: negative falls back to default, zero/positive kept as-is.
+	detailsTop := opts.DetailsTop
+	if detailsTop < 0 {
+		detailsTop = defaultDetailsTop
+	}
 
 	// Use local timezone for day boundaries (cutoff and daily grouping).
 	now := time.Now()
@@ -83,7 +130,7 @@ func buildReport(path string, opts ReportOptions) (FullReport, time.Time, error)
 		return FullReport{}, cutoff, err
 	}
 
-	return aggregate(entries, opts.Days, cutoff), cutoff, nil
+	return aggregate(entries, opts.Days, detailsTop), cutoff, nil
 }
 
 func readEntries(path string, cutoff time.Time) ([]Entry, error) {
@@ -134,12 +181,20 @@ func readEntriesFromFile(path string, cutoff time.Time) ([]Entry, error) {
 	return entries, nil
 }
 
-func aggregate(entries []Entry, days int, cutoff time.Time) FullReport {
+type aggKey struct {
+	Tool  string
+	Input ToolInputFields
+}
+
+func aggregate(entries []Entry, days int, detailsTop int) FullReport {
 	dailyMap := make(map[string]*DailySummary)
 	toolMap := make(map[string]*ToolSummary)
+	fallthroughMap := make(map[aggKey]*ToolInputSummary)
+	denyMap := make(map[aggKey]*ToolInputSummary)
 
 	var minTS, maxTS time.Time
 	loc := time.Now().Location()
+	var totalAll, totalAllowDeny int
 	for _, e := range entries {
 		if minTS.IsZero() || e.Timestamp.Before(minTS) {
 			minTS = e.Timestamp
@@ -155,6 +210,7 @@ func aggregate(entries []Entry, days int, cutoff time.Time) FullReport {
 			dailyMap[dateKey] = ds
 		}
 		ds.Total++
+		totalAll++
 		ds.TotalInputTokens += e.InputTokens
 		ds.TotalOutputTokens += e.OutputTokens
 		ds.AvgElapsedMS += float64(e.ElapsedMS)
@@ -162,8 +218,10 @@ func aggregate(entries []Entry, days int, cutoff time.Time) FullReport {
 		switch e.Decision {
 		case "allow":
 			ds.Allow++
+			totalAllowDeny++
 		case "deny":
 			ds.Deny++
+			totalAllowDeny++
 		case "fallthrough":
 			ds.Fallthrough++
 		}
@@ -185,12 +243,22 @@ func aggregate(entries []Entry, days int, cutoff time.Time) FullReport {
 		case "fallthrough":
 			ts.Fallthrough++
 		}
+
+		// Top fallthrough commands: only the LLM-driven ones, since those
+		// are the fallthroughs that a new permission rule could eliminate.
+		if e.Decision == "fallthrough" && e.FallthroughKind == llmFallthroughKind {
+			bumpToolInputSummary(fallthroughMap, e)
+		}
+		if e.Decision == "deny" {
+			bumpToolInputSummary(denyMap, e)
+		}
 	}
 
 	daily := make([]DailySummary, 0, len(dailyMap))
 	for _, ds := range dailyMap {
 		if ds.Total > 0 {
 			ds.AvgElapsedMS = ds.AvgElapsedMS / float64(ds.Total)
+			ds.AutomationRate = float64(ds.Allow+ds.Deny) / float64(ds.Total)
 		}
 		daily = append(daily, *ds)
 	}
@@ -203,8 +271,19 @@ func aggregate(entries []Entry, days int, cutoff time.Time) FullReport {
 		tools = append(tools, *ts)
 	}
 	sort.Slice(tools, func(i, j int) bool {
-		return tools[i].Total > tools[j].Total
+		if tools[i].Total != tools[j].Total {
+			return tools[i].Total > tools[j].Total
+		}
+		return tools[i].ToolName < tools[j].ToolName
 	})
+
+	fallthroughTop := rankToolInputSummaries(fallthroughMap, detailsTop)
+	denyTop := rankToolInputSummaries(denyMap, detailsTop)
+
+	var overallRate float64
+	if totalAll > 0 {
+		overallRate = float64(totalAllowDeny) / float64(totalAll)
+	}
 
 	var dataRange string
 	if !minTS.IsZero() && !maxTS.IsZero() {
@@ -214,11 +293,154 @@ func aggregate(entries []Entry, days int, cutoff time.Time) FullReport {
 	}
 
 	return FullReport{
-		Period:    fmt.Sprintf("last %d days", days),
-		DataRange: dataRange,
-		Daily:     daily,
-		Tools:     tools,
+		Period:         fmt.Sprintf("last %d days", days),
+		DataRange:      dataRange,
+		AutomationRate: overallRate,
+		Daily:          daily,
+		Tools:          tools,
+		FallthroughTop: fallthroughTop,
+		DenyTop:        denyTop,
 	}
+}
+
+func bumpToolInputSummary(m map[aggKey]*ToolInputSummary, e Entry) {
+	k := aggKey{Tool: e.ToolName, Input: e.ToolInput}
+	s, ok := m[k]
+	if !ok {
+		s = &ToolInputSummary{ToolName: e.ToolName, ToolInput: e.ToolInput}
+		m[k] = s
+	}
+	s.Count++
+}
+
+// rankToolInputSummaries sorts with a deterministic tie-breaker so the
+// output is stable across runs and CI, independent of map iteration order.
+func rankToolInputSummaries(m map[aggKey]*ToolInputSummary, top int) []ToolInputSummary {
+	if top <= 0 {
+		return []ToolInputSummary{}
+	}
+	out := make([]ToolInputSummary, 0, len(m))
+	for _, s := range m {
+		out = append(out, *s)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Count != out[j].Count {
+			return out[i].Count > out[j].Count
+		}
+		if out[i].ToolName != out[j].ToolName {
+			return out[i].ToolName < out[j].ToolName
+		}
+		if out[i].ToolInput.Command != out[j].ToolInput.Command {
+			return out[i].ToolInput.Command < out[j].ToolInput.Command
+		}
+		if out[i].ToolInput.FilePath != out[j].ToolInput.FilePath {
+			return out[i].ToolInput.FilePath < out[j].ToolInput.FilePath
+		}
+		if out[i].ToolInput.Path != out[j].ToolInput.Path {
+			return out[i].ToolInput.Path < out[j].ToolInput.Path
+		}
+		return out[i].ToolInput.Pattern < out[j].ToolInput.Pattern
+	})
+	if len(out) > top {
+		out = out[:top]
+	}
+	return out
+}
+
+// humanInt formats an integer with thousands separators.
+// Works correctly for math.MinInt64 by operating on the string representation
+// rather than negating the numeric value.
+func humanInt(n int64) string {
+	s := strconv.FormatInt(n, 10)
+	negative := strings.HasPrefix(s, "-")
+	if negative {
+		s = s[1:]
+	}
+	if len(s) <= 3 {
+		if negative {
+			return "-" + s
+		}
+		return s
+	}
+	// Insert commas from the right in groups of 3.
+	var b strings.Builder
+	firstGroup := len(s) % 3
+	if firstGroup == 0 {
+		firstGroup = 3
+	}
+	b.WriteString(s[:firstGroup])
+	for i := firstGroup; i < len(s); i += 3 {
+		b.WriteByte(',')
+		b.WriteString(s[i : i+3])
+	}
+	if negative {
+		return "-" + b.String()
+	}
+	return b.String()
+}
+
+// formatToolInputLine renders a ToolInputFields value as a single line of
+// text for the details section. It is display-only: it collapses newlines
+// and tabs to spaces so the table never breaks a row, and never mutates
+// the stored value (which stays verbatim for JSON output).
+func formatToolInputLine(tif ToolInputFields) string {
+	var s string
+	switch {
+	case tif.Command != "":
+		s = tif.Command
+	case tif.FilePath != "":
+		s = tif.FilePath
+	case tif.Path != "" && tif.Pattern != "":
+		s = tif.Pattern + " @ " + tif.Path
+	case tif.Path != "":
+		s = tif.Path
+	case tif.Pattern != "":
+		s = tif.Pattern
+	default:
+		return noInputPlaceholder
+	}
+	// Collapse line-breaking whitespace for table rendering only.
+	s = strings.NewReplacer("\n", " ", "\r", " ", "\t", " ").Replace(s)
+	return truncateRunes(s, maxDisplayToolInput)
+}
+
+// columnWidths tracks the formatted (humanInt) width of each numeric column
+// so the table can be aligned without any column running over its header.
+type columnWidths struct {
+	date, total, allow, deny, fall, err, avg, inTok, outTok int
+}
+
+func computeColumnWidths(daily []DailySummary) columnWidths {
+	cw := columnWidths{
+		date:   len("Date"),
+		total:  len("Total"),
+		allow:  len("Allow"),
+		deny:   len("Deny"),
+		fall:   len("Fall"),
+		err:    len("Err"),
+		avg:    len("Avg(ms)"),
+		inTok:  len("Tokens(in"),
+		outTok: len("out)"),
+	}
+	for _, ds := range daily {
+		cw.date = maxInt(cw.date, len(ds.Date))
+		cw.total = maxInt(cw.total, len(humanInt(int64(ds.Total))))
+		cw.allow = maxInt(cw.allow, len(humanInt(int64(ds.Allow))))
+		cw.deny = maxInt(cw.deny, len(humanInt(int64(ds.Deny))))
+		cw.fall = maxInt(cw.fall, len(humanInt(int64(ds.Fallthrough))))
+		cw.err = maxInt(cw.err, len(humanInt(int64(ds.Errors))))
+		cw.avg = maxInt(cw.avg, len(humanInt(int64(ds.AvgElapsedMS))))
+		cw.inTok = maxInt(cw.inTok, len(humanInt(ds.TotalInputTokens)))
+		cw.outTok = maxInt(cw.outTok, len(humanInt(ds.TotalOutputTokens)))
+	}
+	return cw
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 func printTable(w io.Writer, report FullReport, cutoff time.Time) {
@@ -243,20 +465,66 @@ func printTable(w io.Writer, report FullReport, cutoff time.Time) {
 		}
 	}
 
-	fmt.Fprintf(w, "%-12s %6s %6s %6s %6s %5s %9s %16s\n",
-		"Date", "Total", "Allow", "Deny", "Fall", "Err", "Avg(ms)", "Tokens(in/out)")
+	cw := computeColumnWidths(report.Daily)
+
+	const autoColWidth = 6 // e.g. " 88.4%"
+	fmt.Fprintf(w, "%-*s %*s %*s %*s %*s %*s %*s %*s %*s / %*s\n",
+		cw.date, "Date",
+		cw.total, "Total",
+		cw.allow, "Allow",
+		cw.deny, "Deny",
+		cw.fall, "Fall",
+		cw.err, "Err",
+		autoColWidth, "Auto%",
+		cw.avg, "Avg(ms)",
+		cw.inTok, "Tokens(in",
+		cw.outTok, "out)")
 	for _, ds := range report.Daily {
-		fmt.Fprintf(w, "%-12s %6d %6d %6d %6d %5d %9.0f %7d / %-7d\n",
-			ds.Date, ds.Total, ds.Allow, ds.Deny, ds.Fallthrough, ds.Errors,
-			ds.AvgElapsedMS, ds.TotalInputTokens, ds.TotalOutputTokens)
+		fmt.Fprintf(w, "%-*s %*s %*s %*s %*s %*s %*s %*s %*s / %*s\n",
+			cw.date, ds.Date,
+			cw.total, humanInt(int64(ds.Total)),
+			cw.allow, humanInt(int64(ds.Allow)),
+			cw.deny, humanInt(int64(ds.Deny)),
+			cw.fall, humanInt(int64(ds.Fallthrough)),
+			cw.err, humanInt(int64(ds.Errors)),
+			autoColWidth, fmt.Sprintf("%.1f%%", ds.AutomationRate*100),
+			cw.avg, humanInt(int64(ds.AvgElapsedMS)),
+			cw.inTok, humanInt(ds.TotalInputTokens),
+			cw.outTok, humanInt(ds.TotalOutputTokens))
 	}
+
+	fmt.Fprintf(w, "\nAutomation rate: %.1f%% ((allow+deny) / total)\n", report.AutomationRate*100)
 
 	if len(report.Tools) > 0 {
 		fmt.Fprintln(w)
 		var parts []string
 		for _, ts := range report.Tools {
-			parts = append(parts, fmt.Sprintf("%s:%d", ts.ToolName, ts.Total))
+			parts = append(parts, fmt.Sprintf("%s:%s", ts.ToolName, humanInt(int64(ts.Total))))
 		}
 		fmt.Fprintf(w, "Top tools: %s\n", strings.Join(parts, " "))
+	}
+
+	printTopSection(w, "Top fallthrough commands", report.FallthroughTop)
+	printTopSection(w, "Top deny commands", report.DenyTop)
+}
+
+func printTopSection(w io.Writer, title string, summaries []ToolInputSummary) {
+	if len(summaries) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "\n%s (top %d):\n", title, len(summaries))
+	toolWidth := 0
+	countWidth := 0
+	formatted := make([]string, len(summaries))
+	for i, s := range summaries {
+		toolWidth = maxInt(toolWidth, len(s.ToolName))
+		countWidth = maxInt(countWidth, len(humanInt(int64(s.Count))))
+		formatted[i] = formatToolInputLine(s.ToolInput)
+	}
+	for i, s := range summaries {
+		fmt.Fprintf(w, "  %-*s  %*s  %s\n",
+			toolWidth, s.ToolName,
+			countWidth, humanInt(int64(s.Count)),
+			formatted[i])
 	}
 }

--- a/internal/metrics/report.go
+++ b/internal/metrics/report.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/tak848/ccgate/internal/gate"
 )
 
 // DefaultReportDays is the default number of days for metrics reports.
@@ -30,11 +32,9 @@ const maxDisplayToolInput = 200
 // ToolInput is entirely empty. JSON output keeps the empty object instead.
 const noInputPlaceholder = "(no input)"
 
-// llmFallthroughKind is the FallthroughKind value that represents
-// "the LLM decided not to decide". Only fallthroughs of this kind are
-// promotable via permission rule additions, so the "Top fallthrough
-// commands" section filters on it.
-const llmFallthroughKind = "llm"
+// Only fallthroughs with gate.FallthroughKindLLM are promotable via
+// permission rule additions; the other kinds indicate runtime-mode or
+// configuration conditions and are excluded from the top section.
 
 // ReportOptions controls how the report is generated.
 type ReportOptions struct {
@@ -246,7 +246,7 @@ func aggregate(entries []Entry, days int, detailsTop int) FullReport {
 
 		// Top fallthrough commands: only the LLM-driven ones, since those
 		// are the fallthroughs that a new permission rule could eliminate.
-		if e.Decision == "fallthrough" && e.FallthroughKind == llmFallthroughKind {
+		if e.Decision == "fallthrough" && e.FallthroughKind == gate.FallthroughKindLLM {
 			bumpToolInputSummary(fallthroughMap, e)
 		}
 		if e.Decision == "deny" {

--- a/internal/metrics/report.go
+++ b/internal/metrics/report.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"os"
 	"sort"
 	"strconv"
@@ -37,6 +38,15 @@ const noInputPlaceholder = "(no input)"
 // configuration conditions and are excluded from the top section.
 
 // ReportOptions controls how the report is generated.
+//
+// DetailsTop semantics:
+//   - == 0: both fallthrough/deny detail sections are suppressed.
+//   - < 0:  falls back to defaultDetailsTop (10) as an internal safety net.
+//   - > 0:  the top N rows are shown in each section.
+//
+// The Go zero value (0) is "suppress", not "use default", which differs
+// from how the kong CLI flag defaults to 10. Programmatic callers that
+// want the default behavior must set DetailsTop explicitly (e.g. 10).
 type ReportOptions struct {
 	Days       int
 	AsJSON     bool
@@ -429,7 +439,7 @@ func computeColumnWidths(daily []DailySummary) columnWidths {
 		cw.deny = maxInt(cw.deny, len(humanInt(int64(ds.Deny))))
 		cw.fall = maxInt(cw.fall, len(humanInt(int64(ds.Fallthrough))))
 		cw.err = maxInt(cw.err, len(humanInt(int64(ds.Errors))))
-		cw.avg = maxInt(cw.avg, len(humanInt(int64(ds.AvgElapsedMS))))
+		cw.avg = maxInt(cw.avg, len(humanInt(int64(math.Round(ds.AvgElapsedMS)))))
 		cw.inTok = maxInt(cw.inTok, len(humanInt(ds.TotalInputTokens)))
 		cw.outTok = maxInt(cw.outTok, len(humanInt(ds.TotalOutputTokens)))
 	}
@@ -488,7 +498,7 @@ func printTable(w io.Writer, report FullReport, cutoff time.Time) {
 			cw.fall, humanInt(int64(ds.Fallthrough)),
 			cw.err, humanInt(int64(ds.Errors)),
 			autoColWidth, fmt.Sprintf("%.1f%%", ds.AutomationRate*100),
-			cw.avg, humanInt(int64(ds.AvgElapsedMS)),
+			cw.avg, humanInt(int64(math.Round(ds.AvgElapsedMS))),
 			cw.inTok, humanInt(ds.TotalInputTokens),
 			cw.outTok, humanInt(ds.TotalOutputTokens))
 	}

--- a/internal/metrics/report_extra_test.go
+++ b/internal/metrics/report_extra_test.go
@@ -1,0 +1,433 @@
+package metrics
+
+import (
+	"bytes"
+	"encoding/json"
+	"math"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHumanInt(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0"},
+		{1, "1"},
+		{999, "999"},
+		{1000, "1,000"},
+		{12345, "12,345"},
+		{1234567, "1,234,567"},
+		{-1, "-1"},
+		{-999, "-999"},
+		{-1000, "-1,000"},
+		{-1234, "-1,234"},
+		{math.MaxInt64, "9,223,372,036,854,775,807"},
+		{math.MinInt64, "-9,223,372,036,854,775,808"},
+	}
+	for _, tc := range tests {
+		got := humanInt(tc.in)
+		if got != tc.want {
+			t.Errorf("humanInt(%d) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestFormatToolInputLine(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   ToolInputFields
+		want string
+	}{
+		{"all empty", ToolInputFields{}, "(no input)"},
+		{"command only", ToolInputFields{Command: "gh pr list"}, "gh pr list"},
+		{"file_path only", ToolInputFields{FilePath: "/tmp/foo"}, "/tmp/foo"},
+		{"path and pattern", ToolInputFields{Path: "internal/", Pattern: "TODO"}, "TODO @ internal/"},
+		{"path only", ToolInputFields{Path: "**/*.go"}, "**/*.go"},
+		{"pattern only", ToolInputFields{Pattern: "fnord"}, "fnord"},
+		{"command wins over file_path", ToolInputFields{Command: "c", FilePath: "fp"}, "c"},
+		{"command newline collapsed to space", ToolInputFields{Command: "line1\nline2"}, "line1 line2"},
+		{"command tab and carriage return collapsed",
+			ToolInputFields{Command: "a\tb\rc"}, "a b c"},
+		{"long command truncated at display limit",
+			ToolInputFields{Command: strings.Repeat("x", maxDisplayToolInput+10)},
+			strings.Repeat("x", maxDisplayToolInput)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := formatToolInputLine(tc.in)
+			if got != tc.want {
+				t.Errorf("formatToolInputLine(%+v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildReportAutomationRateEmpty(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.jsonl")
+	// Create an empty file (no entries).
+	writeEntries(t, path, nil)
+
+	report, _, err := buildReport(path, ReportOptions{Days: 7})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.AutomationRate != 0 {
+		t.Errorf("AutomationRate = %v, want 0", report.AutomationRate)
+	}
+	if len(report.Daily) != 0 {
+		t.Errorf("len(Daily) = %d, want 0", len(report.Daily))
+	}
+	if len(report.FallthroughTop) != 0 {
+		t.Errorf("len(FallthroughTop) = %d, want 0", len(report.FallthroughTop))
+	}
+	if len(report.DenyTop) != 0 {
+		t.Errorf("len(DenyTop) = %d, want 0", len(report.DenyTop))
+	}
+}
+
+func TestBuildReportAutomationRateWithError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.jsonl")
+
+	now := time.Now().UTC()
+	// 1 allow + 1 error + 1 fallthrough = 3 total; numerator = 1 (allow only).
+	writeEntries(t, path, []Entry{
+		{Timestamp: now, ToolName: "Bash", Decision: "allow", ElapsedMS: 10},
+		{Timestamp: now, ToolName: "Bash", Decision: "error", Error: "boom", ElapsedMS: 20},
+		{Timestamp: now, ToolName: "Bash", Decision: "fallthrough", FallthroughKind: "llm", ElapsedMS: 30},
+	})
+	report, _, err := buildReport(path, ReportOptions{Days: 7})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantRate := 1.0 / 3.0
+	if math.Abs(report.AutomationRate-wantRate) > 1e-9 {
+		t.Errorf("AutomationRate = %v, want ~%v", report.AutomationRate, wantRate)
+	}
+	if report.Daily[0].Errors != 1 {
+		t.Errorf("Errors = %d, want 1", report.Daily[0].Errors)
+	}
+}
+
+func TestBuildReportDetailsTopFallback(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.jsonl")
+	now := time.Now().UTC()
+	// Create 15 distinct llm fallthroughs so the top section would normally have >10 rows.
+	var entries []Entry
+	for i := range 15 {
+		entries = append(entries, Entry{
+			Timestamp:       now,
+			ToolName:        "Bash",
+			Decision:        "fallthrough",
+			FallthroughKind: "llm",
+			ElapsedMS:       100,
+			ToolInput:       ToolInputFields{Command: "cmd" + string(rune('A'+i))},
+		})
+	}
+	writeEntries(t, path, entries)
+
+	cases := []struct {
+		name      string
+		detailsIn int
+		wantLen   int
+	}{
+		{"negative falls back to default 10", -5, 10},
+		{"zero suppresses section", 0, 0},
+		{"positive limits to N", 3, 3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			report, _, err := buildReport(path, ReportOptions{Days: 7, DetailsTop: tc.detailsIn})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := len(report.FallthroughTop); got != tc.wantLen {
+				t.Errorf("len(FallthroughTop) = %d, want %d", got, tc.wantLen)
+			}
+		})
+	}
+}
+
+func TestToolInputTop(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.jsonl")
+	now := time.Now().UTC()
+
+	writeEntries(t, path, []Entry{
+		// llm fallthroughs: grouped by ToolInputFields value
+		{Timestamp: now, ToolName: "Bash", Decision: "fallthrough", FallthroughKind: "llm",
+			ToolInput: ToolInputFields{Command: "gh pr list"}, ElapsedMS: 1},
+		{Timestamp: now, ToolName: "Bash", Decision: "fallthrough", FallthroughKind: "llm",
+			ToolInput: ToolInputFields{Command: "gh pr list"}, ElapsedMS: 1},
+		{Timestamp: now, ToolName: "Bash", Decision: "fallthrough", FallthroughKind: "llm",
+			ToolInput: ToolInputFields{Command: "gh pr list"}, ElapsedMS: 1},
+		// connective-whitespace variant must be a DIFFERENT group (normalize=no)
+		{Timestamp: now, ToolName: "Bash", Decision: "fallthrough", FallthroughKind: "llm",
+			ToolInput: ToolInputFields{Command: "gh  pr   list"}, ElapsedMS: 1},
+		{Timestamp: now, ToolName: "Write", Decision: "fallthrough", FallthroughKind: "llm",
+			ToolInput: ToolInputFields{FilePath: "/tmp/foo"}, ElapsedMS: 1},
+		// non-llm fallthroughs should NOT appear in FallthroughTop
+		{Timestamp: now, ToolName: "Bash", Decision: "fallthrough", FallthroughKind: "bypass",
+			ToolInput: ToolInputFields{Command: "skip-me"}, ElapsedMS: 1},
+		{Timestamp: now, ToolName: "Bash", Decision: "fallthrough", FallthroughKind: "user_interaction",
+			ToolInput: ToolInputFields{Command: "also-skip"}, ElapsedMS: 1},
+		// deny entries
+		{Timestamp: now, ToolName: "Bash", Decision: "deny",
+			ToolInput: ToolInputFields{Command: "rm -rf /"}, ElapsedMS: 1},
+		{Timestamp: now, ToolName: "Bash", Decision: "deny",
+			ToolInput: ToolInputFields{Command: "rm -rf /"}, ElapsedMS: 1},
+	})
+	report, _, err := buildReport(path, ReportOptions{Days: 7, DetailsTop: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// FallthroughTop should contain 3 groups: "gh pr list"(3), "gh  pr   list"(1), Write "/tmp/foo"(1).
+	// Non-llm fallthroughs must be filtered out.
+	if len(report.FallthroughTop) != 3 {
+		t.Fatalf("len(FallthroughTop) = %d, want 3. content: %+v",
+			len(report.FallthroughTop), report.FallthroughTop)
+	}
+	// Top entry is the "gh pr list" group with count=3.
+	if report.FallthroughTop[0].Count != 3 {
+		t.Errorf("top count = %d, want 3", report.FallthroughTop[0].Count)
+	}
+	if report.FallthroughTop[0].ToolInput.Command != "gh pr list" {
+		t.Errorf("top command = %q, want %q",
+			report.FallthroughTop[0].ToolInput.Command, "gh pr list")
+	}
+	// Ensure skipped kinds don't leak in
+	for _, s := range report.FallthroughTop {
+		if s.ToolInput.Command == "skip-me" || s.ToolInput.Command == "also-skip" {
+			t.Errorf("non-llm fallthrough leaked into FallthroughTop: %+v", s)
+		}
+	}
+	// "gh  pr   list" stays a separate group (no whitespace normalization).
+	foundConnWS := false
+	for _, s := range report.FallthroughTop {
+		if s.ToolInput.Command == "gh  pr   list" && s.Count == 1 {
+			foundConnWS = true
+		}
+	}
+	if !foundConnWS {
+		t.Errorf("whitespace variant was not kept as its own group")
+	}
+
+	// DenyTop should have one group with count=2.
+	if len(report.DenyTop) != 1 || report.DenyTop[0].Count != 2 {
+		t.Fatalf("DenyTop = %+v, want 1 group with count 2", report.DenyTop)
+	}
+}
+
+func TestToolInputTopLegacyEntries(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.jsonl")
+	rotatedPath := path + ".1"
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	// Mimic old binary output: no tool_input field at all.
+	legacyLine := `{"ts":"` + now + `","tool":"Bash","decision":"fallthrough","ft_kind":"llm","elapsed_ms":10}`
+	writeRawJSONLines(t, path, []string{legacyLine})
+	writeRawJSONLines(t, rotatedPath, []string{legacyLine})
+
+	report, _, err := buildReport(path, ReportOptions{Days: 7, DetailsTop: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.FallthroughTop) != 1 {
+		t.Fatalf("len(FallthroughTop) = %d, want 1", len(report.FallthroughTop))
+	}
+	got := report.FallthroughTop[0]
+	// Legacy entries should aggregate as zero-value ToolInputFields, and
+	// importantly JSON output must keep it as an empty object, not a sentinel.
+	if got.ToolInput != (ToolInputFields{}) {
+		t.Errorf("ToolInput = %+v, want zero value", got.ToolInput)
+	}
+	if got.Count != 2 {
+		t.Errorf("Count = %d, want 2 (one from each file)", got.Count)
+	}
+	// Marshal the summary and ensure tool_input shows as {} (not omitted, not sentinel).
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"tool_input":{}`) {
+		t.Errorf("marshaled summary = %s, want substring \"tool_input\":{}", string(raw))
+	}
+	if strings.Contains(string(raw), "(no input)") {
+		t.Errorf("marshaled summary must not contain sentinel, got %s", string(raw))
+	}
+}
+
+func TestPrintReportEmpty(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.jsonl")
+	writeEntries(t, path, nil)
+
+	var buf bytes.Buffer
+	if err := PrintReport(&buf, path, ReportOptions{Days: 7, DetailsTop: 10}); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "No data.") {
+		t.Errorf("expected %q in output, got:\n%s", "No data.", out)
+	}
+	// Must NOT print the automation rate footer or details when there is no data.
+	for _, s := range []string{"Automation rate:", "Top fallthrough commands", "Top deny commands"} {
+		if strings.Contains(out, s) {
+			t.Errorf("unexpected %q in empty output:\n%s", s, out)
+		}
+	}
+}
+
+func TestPrintReportNoInputDisplay(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.jsonl")
+	now := time.Now().UTC()
+
+	writeEntries(t, path, []Entry{
+		// All fields empty → (no input) at display time, {} in JSON.
+		{Timestamp: now, ToolName: "Tool", Decision: "fallthrough", FallthroughKind: "llm", ElapsedMS: 5},
+	})
+
+	// TTY: should contain (no input)
+	var buf bytes.Buffer
+	if err := PrintReport(&buf, path, ReportOptions{Days: 7, DetailsTop: 10}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "(no input)") {
+		t.Errorf("TTY output should contain (no input):\n%s", buf.String())
+	}
+
+	// JSON: should contain "tool_input":{} and NOT (no input)
+	var jsonBuf bytes.Buffer
+	if err := PrintReport(&jsonBuf, path, ReportOptions{Days: 7, AsJSON: true, DetailsTop: 10}); err != nil {
+		t.Fatal(err)
+	}
+	j := jsonBuf.String()
+	if !strings.Contains(j, `"tool_input": {}`) {
+		t.Errorf("JSON output should contain tool_input:{}, got:\n%s", j)
+	}
+	if strings.Contains(j, "(no input)") {
+		t.Errorf("JSON output must not contain sentinel, got:\n%s", j)
+	}
+}
+
+func TestPrintReportMultilineCommandDisplay(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.jsonl")
+	now := time.Now().UTC()
+
+	writeEntries(t, path, []Entry{
+		{Timestamp: now, ToolName: "Bash", Decision: "fallthrough", FallthroughKind: "llm",
+			ToolInput: ToolInputFields{Command: "line1\nline2"}, ElapsedMS: 5},
+	})
+
+	// TTY: the \n must NOT remain literal (row must stay on one line).
+	// Concretely, "line1 line2" appears and "line1\nline2" does not.
+	var buf bytes.Buffer
+	if err := PrintReport(&buf, path, ReportOptions{Days: 7, DetailsTop: 10}); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "line1 line2") {
+		t.Errorf("TTY output should contain collapsed form, got:\n%s", out)
+	}
+	// Inspect the details row only: find the line starting with "  Bash" and
+	// ensure it does not contain a literal LF between "line1" and "line2".
+	for row := range strings.SplitSeq(out, "\n") {
+		if strings.Contains(row, "Bash") && strings.Contains(row, "line1") {
+			if !strings.Contains(row, "line1 line2") {
+				t.Errorf("details row should collapse newline: %q", row)
+			}
+		}
+	}
+
+	// JSON: command must be preserved verbatim including the literal LF.
+	var jsonBuf bytes.Buffer
+	if err := PrintReport(&jsonBuf, path, ReportOptions{Days: 7, AsJSON: true, DetailsTop: 10}); err != nil {
+		t.Fatal(err)
+	}
+	var decoded FullReport
+	if err := json.Unmarshal(jsonBuf.Bytes(), &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded.FallthroughTop) != 1 {
+		t.Fatalf("len(FallthroughTop) = %d, want 1", len(decoded.FallthroughTop))
+	}
+	if decoded.FallthroughTop[0].ToolInput.Command != "line1\nline2" {
+		t.Errorf("JSON round-trip: Command = %q, want %q",
+			decoded.FallthroughTop[0].ToolInput.Command, "line1\nline2")
+	}
+}
+
+func TestPrintReportColumnAlignment(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.jsonl")
+	now := time.Now().UTC()
+
+	// Different magnitudes to stress the pre-computed column widths.
+	writeEntries(t, path, []Entry{
+		{Timestamp: now, ToolName: "Bash", Decision: "allow", ElapsedMS: 100,
+			InputTokens: 1234567, OutputTokens: 12345},
+		{Timestamp: now.Add(-24 * time.Hour), ToolName: "Bash", Decision: "allow", ElapsedMS: 100,
+			InputTokens: 5, OutputTokens: 5},
+	})
+
+	var buf bytes.Buffer
+	if err := PrintReport(&buf, path, ReportOptions{Days: 7, DetailsTop: 10}); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	// Find the header and daily rows; they all should contain only ASCII bytes.
+	var header string
+	var dataRows []string
+	for line := range strings.SplitSeq(out, "\n") {
+		if strings.HasPrefix(line, "Date") {
+			header = line
+			continue
+		}
+		if len(line) > 0 && line[0] >= '0' && line[0] <= '9' {
+			dataRows = append(dataRows, line)
+		}
+	}
+	if header == "" {
+		t.Fatalf("header not found in:\n%s", out)
+	}
+	if len(dataRows) != 2 {
+		t.Fatalf("expected 2 data rows, got %d:\n%s", len(dataRows), out)
+	}
+	// The "/" between in/out tokens is a reliable column anchor.
+	anchor := strings.Index(header, "/")
+	if anchor < 0 {
+		t.Fatalf("header has no '/': %q", header)
+	}
+	for _, r := range dataRows {
+		if idx := strings.Index(r, "/"); idx != anchor {
+			t.Errorf("data row '/' column at %d, header at %d\nheader: %q\nrow: %q",
+				idx, anchor, header, r)
+		}
+	}
+	// "1,234,567" should appear somewhere with comma grouping.
+	if !strings.Contains(out, "1,234,567") {
+		t.Errorf("expected grouped number 1,234,567 in output:\n%s", out)
+	}
+}

--- a/internal/metrics/report_extra_test.go
+++ b/internal/metrics/report_extra_test.go
@@ -12,54 +12,62 @@ import (
 
 func TestHumanInt(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
+	tests := map[string]struct {
 		in   int64
 		want string
 	}{
-		{0, "0"},
-		{1, "1"},
-		{999, "999"},
-		{1000, "1,000"},
-		{12345, "12,345"},
-		{1234567, "1,234,567"},
-		{-1, "-1"},
-		{-999, "-999"},
-		{-1000, "-1,000"},
-		{-1234, "-1,234"},
-		{math.MaxInt64, "9,223,372,036,854,775,807"},
-		{math.MinInt64, "-9,223,372,036,854,775,808"},
+		"zero":                {in: 0, want: "0"},
+		"single digit":        {in: 1, want: "1"},
+		"max 3-digit":         {in: 999, want: "999"},
+		"four digits":         {in: 1000, want: "1,000"},
+		"five digits":         {in: 12345, want: "12,345"},
+		"seven digits":        {in: 1234567, want: "1,234,567"},
+		"negative single":     {in: -1, want: "-1"},
+		"negative 3-digit":    {in: -999, want: "-999"},
+		"negative four":       {in: -1000, want: "-1,000"},
+		"negative four alt":   {in: -1234, want: "-1,234"},
+		"int64 max":           {in: math.MaxInt64, want: "9,223,372,036,854,775,807"},
+		"int64 min overflows": {in: math.MinInt64, want: "-9,223,372,036,854,775,808"},
 	}
-	for _, tc := range tests {
-		got := humanInt(tc.in)
-		if got != tc.want {
-			t.Errorf("humanInt(%d) = %q, want %q", tc.in, got, tc.want)
-		}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := humanInt(tc.in)
+			if got != tc.want {
+				t.Errorf("humanInt(%d) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
 	}
 }
 
 func TestFormatToolInputLine(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
-		name string
+	tests := map[string]struct {
 		in   ToolInputFields
 		want string
 	}{
-		{"all empty", ToolInputFields{}, "(no input)"},
-		{"command only", ToolInputFields{Command: "gh pr list"}, "gh pr list"},
-		{"file_path only", ToolInputFields{FilePath: "/tmp/foo"}, "/tmp/foo"},
-		{"path and pattern", ToolInputFields{Path: "internal/", Pattern: "TODO"}, "TODO @ internal/"},
-		{"path only", ToolInputFields{Path: "**/*.go"}, "**/*.go"},
-		{"pattern only", ToolInputFields{Pattern: "fnord"}, "fnord"},
-		{"command wins over file_path", ToolInputFields{Command: "c", FilePath: "fp"}, "c"},
-		{"command newline collapsed to space", ToolInputFields{Command: "line1\nline2"}, "line1 line2"},
-		{"command tab and carriage return collapsed",
-			ToolInputFields{Command: "a\tb\rc"}, "a b c"},
-		{"long command truncated at display limit",
-			ToolInputFields{Command: strings.Repeat("x", maxDisplayToolInput+10)},
-			strings.Repeat("x", maxDisplayToolInput)},
+		"all empty":                   {in: ToolInputFields{}, want: "(no input)"},
+		"command only":                {in: ToolInputFields{Command: "gh pr list"}, want: "gh pr list"},
+		"file_path only":              {in: ToolInputFields{FilePath: "/tmp/foo"}, want: "/tmp/foo"},
+		"path and pattern":            {in: ToolInputFields{Path: "internal/", Pattern: "TODO"}, want: "TODO @ internal/"},
+		"path only":                   {in: ToolInputFields{Path: "**/*.go"}, want: "**/*.go"},
+		"pattern only":                {in: ToolInputFields{Pattern: "fnord"}, want: "fnord"},
+		"command wins over file_path": {in: ToolInputFields{Command: "c", FilePath: "fp"}, want: "c"},
+		"command newline collapsed to space": {
+			in:   ToolInputFields{Command: "line1\nline2"},
+			want: "line1 line2",
+		},
+		"command tab and carriage return collapsed": {
+			in:   ToolInputFields{Command: "a\tb\rc"},
+			want: "a b c",
+		},
+		"long command truncated at display limit": {
+			in:   ToolInputFields{Command: strings.Repeat("x", maxDisplayToolInput+10)},
+			want: strings.Repeat("x", maxDisplayToolInput),
+		},
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			got := formatToolInputLine(tc.in)
 			if got != tc.want {
@@ -138,17 +146,16 @@ func TestBuildReportDetailsTopFallback(t *testing.T) {
 	}
 	writeEntries(t, path, entries)
 
-	cases := []struct {
-		name      string
+	cases := map[string]struct {
 		detailsIn int
 		wantLen   int
 	}{
-		{"negative falls back to default 10", -5, 10},
-		{"zero suppresses section", 0, 0},
-		{"positive limits to N", 3, 3},
+		"negative falls back to default 10": {detailsIn: -5, wantLen: 10},
+		"zero suppresses section":           {detailsIn: 0, wantLen: 0},
+		"positive limits to N":              {detailsIn: 3, wantLen: 3},
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
 			report, _, err := buildReport(path, ReportOptions{Days: 7, DetailsTop: tc.detailsIn})
 			if err != nil {
 				t.Fatal(err)

--- a/internal/metrics/report_extra_test.go
+++ b/internal/metrics/report_extra_test.go
@@ -233,9 +233,85 @@ func TestToolInputTop(t *testing.T) {
 		t.Errorf("whitespace variant was not kept as its own group")
 	}
 
-	// DenyTop should have one group with count=2.
+	// DenyTop: one group "rm -rf /" aggregated from 2 entries.
 	if len(report.DenyTop) != 1 || report.DenyTop[0].Count != 2 {
 		t.Fatalf("DenyTop = %+v, want 1 group with count 2", report.DenyTop)
+	}
+
+	// DetailsTop=2 must slice the ranked list to the top 2 entries.
+	rep2, _, err := buildReport(path, ReportOptions{Days: 7, DetailsTop: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rep2.FallthroughTop) != 2 {
+		t.Errorf("DetailsTop=2: len(FallthroughTop) = %d, want 2", len(rep2.FallthroughTop))
+	}
+	if len(rep2.DenyTop) != 1 {
+		// only one deny group exists overall, so DetailsTop=2 still gives 1.
+		t.Errorf("DetailsTop=2: len(DenyTop) = %d, want 1", len(rep2.DenyTop))
+	}
+}
+
+// TestToolInputTopTieBreaker pins down the full tie-breaker ordering
+// (count desc → tool asc → command asc → file_path asc → path asc →
+// pattern asc). All entries below share count=1, so ordering is
+// determined purely by the later keys.
+func TestToolInputTopTieBreaker(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.jsonl")
+	now := time.Now().UTC()
+
+	// Construct entries across every tie-breaker key. All same count=1,
+	// all Decision="deny" so the LLM filter is irrelevant. Expected order
+	// reflects empty-string sorting before any non-empty value: entries
+	// where an earlier key is empty come first, so Pattern-only rows
+	// precede Command-only rows (Command:"" < Command:"a").
+	entries := []Entry{
+		{Timestamp: now, ToolName: "Bash", Decision: "deny", ElapsedMS: 1, ToolInput: ToolInputFields{Command: "a"}},
+		{Timestamp: now, ToolName: "Bash", Decision: "deny", ElapsedMS: 1, ToolInput: ToolInputFields{Command: "b"}},
+		{Timestamp: now, ToolName: "Bash", Decision: "deny", ElapsedMS: 1, ToolInput: ToolInputFields{FilePath: "a"}},
+		{Timestamp: now, ToolName: "Bash", Decision: "deny", ElapsedMS: 1, ToolInput: ToolInputFields{FilePath: "b"}},
+		{Timestamp: now, ToolName: "Bash", Decision: "deny", ElapsedMS: 1, ToolInput: ToolInputFields{Path: "a"}},
+		// {Path:"b"} alone exercises the Path-only tie-breaker branch so that
+		// removing it from the comparator cannot silently pass this test.
+		{Timestamp: now, ToolName: "Bash", Decision: "deny", ElapsedMS: 1, ToolInput: ToolInputFields{Path: "b"}},
+		{Timestamp: now, ToolName: "Bash", Decision: "deny", ElapsedMS: 1, ToolInput: ToolInputFields{Path: "a", Pattern: "a"}},
+		{Timestamp: now, ToolName: "Bash", Decision: "deny", ElapsedMS: 1, ToolInput: ToolInputFields{Pattern: "a"}},
+		{Timestamp: now, ToolName: "Bash", Decision: "deny", ElapsedMS: 1, ToolInput: ToolInputFields{Pattern: "b"}},
+		{Timestamp: now, ToolName: "Write", Decision: "deny", ElapsedMS: 1, ToolInput: ToolInputFields{Command: "a"}},
+	}
+	writeEntries(t, path, entries)
+
+	report, _, err := buildReport(path, ReportOptions{Days: 7, DetailsTop: 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(report.DenyTop) != len(entries) {
+		t.Fatalf("len(DenyTop) = %d, want %d; content: %+v",
+			len(report.DenyTop), len(entries), report.DenyTop)
+	}
+
+	// Sort order: tool asc, then by command / file_path / path / pattern in
+	// ascending order, where "" (empty) sorts before any non-empty value.
+	want := []ToolInputFields{
+		{Pattern: "a"},            // command="" file_path="" path=""  pattern="a"
+		{Pattern: "b"},            // command="" file_path="" path=""  pattern="b"
+		{Path: "a"},               // command="" file_path="" path="a" pattern=""
+		{Path: "a", Pattern: "a"}, // command="" file_path="" path="a" pattern="a"
+		{Path: "b"},               // command="" file_path="" path="b" pattern=""  (exercises path-only branch)
+		{FilePath: "a"},           // command="" file_path="a"
+		{FilePath: "b"},           // command="" file_path="b"
+		{Command: "a"},            // command="a" (Bash)
+		{Command: "b"},            // command="b" (Bash)
+		{Command: "a"},            // Write (tool asc: Bash < Write)
+	}
+	wantTools := []string{"Bash", "Bash", "Bash", "Bash", "Bash", "Bash", "Bash", "Bash", "Bash", "Write"}
+	for i, s := range report.DenyTop {
+		if s.ToolName != wantTools[i] || s.ToolInput != want[i] {
+			t.Errorf("DenyTop[%d] = (%s, %+v), want (%s, %+v)",
+				i, s.ToolName, s.ToolInput, wantTools[i], want[i])
+		}
 	}
 }
 
@@ -422,18 +498,73 @@ func TestPrintReportColumnAlignment(t *testing.T) {
 	if len(dataRows) != 2 {
 		t.Fatalf("expected 2 data rows, got %d:\n%s", len(dataRows), out)
 	}
-	// The "/" between in/out tokens is a reliable column anchor.
-	anchor := strings.Index(header, "/")
-	if anchor < 0 {
+	// ASCII-only assertion: every row must be plain ASCII so byte indices
+	// equal display columns. If this ever needs to cover non-ASCII output,
+	// switch to rune-width measurement instead.
+	for i, r := range append([]string{header}, dataRows...) {
+		for j := 0; j < len(r); j++ {
+			if r[j] >= 0x80 {
+				t.Fatalf("row %d contains non-ASCII byte at offset %d: %q", i, j, r)
+			}
+		}
+	}
+
+	// All right-aligned columns share the same width between header and
+	// data rows, so the last character of each header label and the last
+	// character of the column value must land at the same byte offset, and
+	// the column separator space sits at that offset + 1. Verifying this
+	// catches any regression in the pre-computed column widths.
+	// "Tokens(in" is the right-aligned header for the input-tokens column
+	// (directly before the literal "/"). Including it here catches regressions
+	// where that column alone is flipped to %-*s (left-align) and values are
+	// padded on the wrong side.
+	rightAlignedLabels := []string{"Total", "Allow", "Deny", "Fall", "Err", "Auto%", "Avg(ms)", "Tokens(in"}
+	for _, label := range rightAlignedLabels {
+		anchor := strings.Index(header, label)
+		if anchor < 0 {
+			t.Fatalf("header missing label %q: %q", label, header)
+		}
+		endOffset := anchor + len(label) - 1
+		for _, r := range dataRows {
+			if endOffset+1 >= len(r) {
+				t.Errorf("label %q: row shorter than header anchor; end=%d row len=%d\nrow: %q",
+					label, endOffset, len(r), r)
+				continue
+			}
+			if r[endOffset] == ' ' {
+				t.Errorf("label %q: expected value char at col %d, got space. row: %q",
+					label, endOffset, r)
+			}
+			if r[endOffset+1] != ' ' {
+				t.Errorf("label %q: expected column separator space at col %d, got %q. row: %q",
+					label, endOffset+1, r[endOffset+1], r)
+			}
+		}
+	}
+	// The literal `/` separator between in/out token columns must sit at
+	// exactly the same byte offset in header and every data row.
+	slashAnchor := strings.Index(header, "/")
+	if slashAnchor < 0 {
 		t.Fatalf("header has no '/': %q", header)
 	}
 	for _, r := range dataRows {
-		if idx := strings.Index(r, "/"); idx != anchor {
+		if idx := strings.Index(r, "/"); idx != slashAnchor {
 			t.Errorf("data row '/' column at %d, header at %d\nheader: %q\nrow: %q",
-				idx, anchor, header, r)
+				idx, slashAnchor, header, r)
 		}
 	}
-	// "1,234,567" should appear somewhere with comma grouping.
+	// The final "out)" column is right-aligned with cw.outTok, so the line
+	// ends at the exact same byte offset for header and every data row.
+	// Comparing total row length catches any cw.outTok desync that the
+	// `/` anchor alone would miss (it only locks columns up to `/`).
+	for _, r := range dataRows {
+		if len(r) != len(header) {
+			t.Errorf("row length = %d, header length = %d (final column desync)\nheader: %q\nrow: %q",
+				len(r), len(header), header, r)
+		}
+	}
+
+	// Comma-grouped big number must appear verbatim.
 	if !strings.Contains(out, "1,234,567") {
 		t.Errorf("expected grouped number 1,234,567 in output:\n%s", out)
 	}

--- a/internal/metrics/report_test.go
+++ b/internal/metrics/report_test.go
@@ -51,6 +51,13 @@ func TestBuildReport(t *testing.T) {
 	if ds.TotalInputTokens != 350 {
 		t.Fatalf("input_tokens = %d, want 350", ds.TotalInputTokens)
 	}
+	// (allow=2 + deny=1) / total=4 = 0.75
+	if ds.AutomationRate != 0.75 {
+		t.Fatalf("AutomationRate = %v, want 0.75", ds.AutomationRate)
+	}
+	if report.AutomationRate != 0.75 {
+		t.Fatalf("report.AutomationRate = %v, want 0.75", report.AutomationRate)
+	}
 
 	if len(report.Tools) != 2 {
 		t.Fatalf("expected 2 tools, got %d", len(report.Tools))
@@ -153,6 +160,23 @@ func writeEntries(t *testing.T, path string, entries []Entry) {
 			t.Fatal(err)
 		}
 		if _, err := f.Write(append(line, '\n')); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// writeRawJSONLines writes pre-constructed JSONL lines without going through
+// Entry serialization. Used to simulate entries written by an older binary
+// that didn't know about tool_input.
+func writeRawJSONLines(t *testing.T, path string, lines []string) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	for _, line := range lines {
+		if _, err := f.WriteString(line + "\n"); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/internal/metrics/report_test.go
+++ b/internal/metrics/report_test.go
@@ -129,21 +129,33 @@ func TestPrintReportTable(t *testing.T) {
 	path := filepath.Join(dir, "test.jsonl")
 
 	now := time.Now().UTC()
+	// Mix allow/deny/fallthrough(llm) so every top section and every
+	// automation-rate branch is exercised in the same rendering.
 	writeEntries(t, path, []Entry{
 		{Timestamp: now, ToolName: "Bash", Decision: "allow", ElapsedMS: 100},
+		{Timestamp: now, ToolName: "Bash", Decision: "deny", ElapsedMS: 100,
+			ToolInput: ToolInputFields{Command: "rm -rf /"}},
+		{Timestamp: now, ToolName: "Bash", Decision: "fallthrough", FallthroughKind: "llm",
+			ToolInput: ToolInputFields{Command: "gh pr list"}, ElapsedMS: 100},
 	})
 
 	var buf bytes.Buffer
-	if err := PrintReport(&buf, path, ReportOptions{Days: 7}); err != nil {
+	if err := PrintReport(&buf, path, ReportOptions{Days: 7, DetailsTop: 10}); err != nil {
 		t.Fatal(err)
 	}
 
 	output := buf.String()
-	if !strings.Contains(output, "ccgate metrics") {
-		t.Fatal("expected header in table output")
-	}
-	if !strings.Contains(output, "Bash") {
-		t.Fatal("expected Bash in table output")
+	for _, want := range []string{
+		"ccgate metrics",
+		"Bash",
+		"Auto%",
+		"Automation rate:",
+		"Top fallthrough commands",
+		"Top deny commands",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected %q in table output; got:\n%s", want, output)
+		}
 	}
 }
 

--- a/internal/metrics/toolinput.go
+++ b/internal/metrics/toolinput.go
@@ -1,0 +1,26 @@
+package metrics
+
+const maxToolInputFieldLen = 2000
+
+// CapToolInput applies a length cap (rune-wise truncate) to each field of
+// ToolInputFields destined for JSONL persistence. It does NOT normalize
+// whitespace: the original command text is preserved verbatim so the entry
+// can be read back without being mangled.
+func CapToolInput(tif ToolInputFields) ToolInputFields {
+	tif.Command = truncateRunes(tif.Command, maxToolInputFieldLen)
+	tif.FilePath = truncateRunes(tif.FilePath, maxToolInputFieldLen)
+	tif.Path = truncateRunes(tif.Path, maxToolInputFieldLen)
+	tif.Pattern = truncateRunes(tif.Pattern, maxToolInputFieldLen)
+	return tif
+}
+
+func truncateRunes(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) > maxLen {
+		return string(runes[:maxLen])
+	}
+	return s
+}

--- a/internal/metrics/toolinput_test.go
+++ b/internal/metrics/toolinput_test.go
@@ -1,0 +1,81 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestCapToolInput(t *testing.T) {
+	t.Parallel()
+
+	longASCII := strings.Repeat("a", maxToolInputFieldLen+1)
+	longASCIIExpected := strings.Repeat("a", maxToolInputFieldLen)
+
+	longMixed := strings.Repeat("あ", maxToolInputFieldLen+1) // each rune is 3 bytes
+	longMixedExpectedRunes := maxToolInputFieldLen
+
+	tests := []struct {
+		name string
+		in   ToolInputFields
+		want ToolInputFields
+	}{
+		{
+			name: "all empty",
+			in:   ToolInputFields{},
+			want: ToolInputFields{},
+		},
+		{
+			name: "whitespace is preserved verbatim (no normalization)",
+			in: ToolInputFields{
+				Command:  "echo \"a   b\"\nline2\t",
+				FilePath: "  /path with  space  ",
+				Path:     "p\n",
+				Pattern:  "\tfoo\t",
+			},
+			want: ToolInputFields{
+				Command:  "echo \"a   b\"\nline2\t",
+				FilePath: "  /path with  space  ",
+				Path:     "p\n",
+				Pattern:  "\tfoo\t",
+			},
+		},
+		{
+			name: "short ascii under cap is unchanged",
+			in:   ToolInputFields{Command: "gh pr list"},
+			want: ToolInputFields{Command: "gh pr list"},
+		},
+		{
+			name: "ascii over cap is rune-truncated",
+			in:   ToolInputFields{Command: longASCII},
+			want: ToolInputFields{Command: longASCIIExpected},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := CapToolInput(tc.in)
+			if got != tc.want {
+				t.Errorf("CapToolInput(%+v) = %+v, want %+v", tc.in, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("unicode multi-byte over cap truncates by rune count", func(t *testing.T) {
+		t.Parallel()
+		got := CapToolInput(ToolInputFields{Command: longMixed})
+		if n := utf8.RuneCountInString(got.Command); n != longMixedExpectedRunes {
+			t.Errorf("rune count = %d, want %d", n, longMixedExpectedRunes)
+		}
+	})
+
+	t.Run("exactly cap length is unchanged", func(t *testing.T) {
+		t.Parallel()
+		exact := strings.Repeat("x", maxToolInputFieldLen)
+		got := CapToolInput(ToolInputFields{Command: exact})
+		if got.Command != exact {
+			t.Error("exactly cap-length input should not be truncated")
+		}
+	})
+}

--- a/internal/metrics/toolinput_test.go
+++ b/internal/metrics/toolinput_test.go
@@ -15,18 +15,15 @@ func TestCapToolInput(t *testing.T) {
 	longMixed := strings.Repeat("あ", maxToolInputFieldLen+1) // each rune is 3 bytes
 	longMixedExpectedRunes := maxToolInputFieldLen
 
-	tests := []struct {
-		name string
+	tests := map[string]struct {
 		in   ToolInputFields
 		want ToolInputFields
 	}{
-		{
-			name: "all empty",
+		"all empty": {
 			in:   ToolInputFields{},
 			want: ToolInputFields{},
 		},
-		{
-			name: "whitespace is preserved verbatim (no normalization)",
+		"whitespace is preserved verbatim (no normalization)": {
 			in: ToolInputFields{
 				Command:  "echo \"a   b\"\nline2\t",
 				FilePath: "  /path with  space  ",
@@ -40,20 +37,18 @@ func TestCapToolInput(t *testing.T) {
 				Pattern:  "\tfoo\t",
 			},
 		},
-		{
-			name: "short ascii under cap is unchanged",
+		"short ascii under cap is unchanged": {
 			in:   ToolInputFields{Command: "gh pr list"},
 			want: ToolInputFields{Command: "gh pr list"},
 		},
-		{
-			name: "ascii over cap is rune-truncated",
+		"ascii over cap is rune-truncated": {
 			in:   ToolInputFields{Command: longASCII},
 			want: ToolInputFields{Command: longASCIIExpected},
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			got := CapToolInput(tc.in)
 			if got != tc.want {

--- a/internal/metrics/writer_test.go
+++ b/internal/metrics/writer_test.go
@@ -1,9 +1,11 @@
 package metrics
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -45,6 +47,118 @@ func TestRecordEmptyPath(t *testing.T) {
 	t.Parallel()
 	// Should not panic or create any file.
 	Record("", 1024, Entry{ToolName: "test"})
+}
+
+// TestRecordToolInputOmitZero locks in the omitzero behavior: an Entry with
+// a zero-value ToolInputFields must produce a JSONL line that does NOT
+// contain the tool_input key at all (so old-file shape is preserved and
+// size overhead is zero).
+func TestRecordToolInputOmitZero(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.jsonl")
+
+	Record(path, 1024*1024, Entry{
+		Timestamp: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		ToolName:  "Bash",
+		Decision:  "allow",
+		ElapsedMS: 10,
+		// ToolInput left as zero value intentionally.
+	})
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(data, []byte("tool_input")) {
+		t.Errorf("zero-value ToolInput must be omitted, got line: %s", data)
+	}
+}
+
+// TestRecordToolInputPopulated locks in the nested omitempty behavior:
+// populated fields appear in JSONL, unset sibling fields are dropped.
+func TestRecordToolInputPopulated(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.jsonl")
+
+	Record(path, 1024*1024, Entry{
+		Timestamp: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		ToolName:  "Bash",
+		Decision:  "fallthrough",
+		ElapsedMS: 10,
+		ToolInput: ToolInputFields{Command: "gh pr list"},
+	})
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	if !strings.Contains(s, `"tool_input":{"command":"gh pr list"}`) {
+		t.Errorf("expected populated tool_input substring, got: %s", s)
+	}
+	// Unset fields must be omitted from the nested object.
+	for _, f := range []string{"file_path", "path", "pattern"} {
+		if strings.Contains(s, `"`+f+`"`) {
+			t.Errorf("unset field %q should be omitted from JSONL, got: %s", f, s)
+		}
+	}
+
+	// Round-trip: decoding must restore the value.
+	var decoded Entry
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.ToolInput.Command != "gh pr list" {
+		t.Errorf("round-trip Command = %q, want %q", decoded.ToolInput.Command, "gh pr list")
+	}
+}
+
+// TestRecordToolInputMultiline verifies that the JSONL representation
+// escapes literal LF as \n (two bytes 0x5C 0x6E) and that the Go value
+// restored via json.Unmarshal contains a literal LF. This proves the
+// display-layer \n→space collapse has not leaked into the write path.
+func TestRecordToolInputMultiline(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.jsonl")
+
+	Record(path, 1024*1024, Entry{
+		Timestamp: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		ToolName:  "Bash",
+		Decision:  "fallthrough",
+		ElapsedMS: 10,
+		ToolInput: ToolInputFields{Command: "line1\nline2"},
+	})
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Expect exactly one record line (one trailing LF for the line itself).
+	trimmed := bytes.TrimRight(data, "\n")
+	if bytes.Count(trimmed, []byte{'\n'}) != 0 {
+		t.Errorf("record must occupy a single JSONL line, got: %q", data)
+	}
+	// Literal LF inside the JSON string must be escaped on disk.
+	if !bytes.Contains(data, []byte(`line1\nline2`)) {
+		t.Errorf("expected escaped \\n in JSONL, got: %s", data)
+	}
+
+	var decoded Entry
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.ToolInput.Command != "line1\nline2" {
+		t.Errorf("Unmarshal should restore literal LF, got: %q", decoded.ToolInput.Command)
+	}
+	// And the display-layer collapse must NOT have leaked in.
+	if strings.Contains(decoded.ToolInput.Command, "line1 line2") &&
+		!strings.Contains(decoded.ToolInput.Command, "\n") {
+		t.Errorf("display-layer \\n→space leaked into write path: %q", decoded.ToolInput.Command)
+	}
 }
 
 func TestRotateIfNeeded(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -228,6 +228,14 @@ func buildMetricsEntry(start time.Time, elapsed time.Duration, input hookctx.Hoo
 		entry.OutputTokens = result.Usage.OutputTokens
 	}
 
+	cmd, fp, path, pattern := input.MetricsFields()
+	entry.ToolInput = metrics.CapToolInput(metrics.ToolInputFields{
+		Command:  cmd,
+		FilePath: fp,
+		Path:     path,
+		Pattern:  pattern,
+	})
+
 	return entry
 }
 

--- a/main.go
+++ b/main.go
@@ -46,8 +46,9 @@ type InitCmd struct {
 }
 
 type MetricsCmd struct {
-	Days int  `help:"Show last N days." default:"7"`
-	JSON bool `help:"Output as JSON." name:"json"`
+	Days    int  `help:"Show last N days." default:"7"`
+	JSON    bool `help:"Output as JSON." name:"json"`
+	Details int  `help:"Show top-N fallthrough/deny commands per section (0 to hide both, negative falls back to default)." default:"10"`
 }
 
 func main() { os.Exit(_main()) }
@@ -75,8 +76,9 @@ func _main() int {
 				return 1
 			}
 			if err := metrics.PrintReport(os.Stdout, lr.Config.ResolveMetricsPath(), metrics.ReportOptions{
-				Days:   cli.Metrics.Days,
-				AsJSON: cli.Metrics.JSON,
+				Days:       cli.Metrics.Days,
+				AsJSON:     cli.Metrics.JSON,
+				DetailsTop: cli.Metrics.Details,
 			}); err != nil {
 				fmt.Fprintf(os.Stderr, "error: %v\n", err)
 				return 1
@@ -87,7 +89,7 @@ func _main() int {
 
 	// No args: if tty, show usage; if pipe, run hook.
 	if term.IsTerminal(int(os.Stdin.Fd())) {
-		fmt.Fprintf(os.Stderr, "ccgate %s\n\nClaude Code PermissionRequest hook.\nReads HookInput JSON from stdin, returns allow/deny/fallthrough to stdout.\n\nCommands:\n  ccgate init [-p] [-o FILE] [-f]   Output default configuration\n  ccgate metrics [--days N] [--json] Show usage metrics summary\n\nFlags:\n  --version    Print version and exit\n  --help       Show help\n", version)
+		fmt.Fprintf(os.Stderr, "ccgate %s\n\nClaude Code PermissionRequest hook.\nReads HookInput JSON from stdin, returns allow/deny/fallthrough to stdout.\n\nCommands:\n  ccgate init [-p] [-o FILE] [-f]                        Output default configuration\n  ccgate metrics [--days N] [--json] [--details N]       Show usage metrics summary\n                                                         (also prints top fallthrough/deny commands)\n\nFlags:\n  --version    Print version and exit\n  --help       Show help\n", version)
 		return 0
 	}
 

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ type InitCmd struct {
 type MetricsCmd struct {
 	Days    int  `help:"Show last N days." default:"7"`
 	JSON    bool `help:"Output as JSON." name:"json"`
-	Details int  `help:"Show top-N fallthrough/deny commands per section (0 to hide both, negative falls back to default)." default:"10"`
+	Details int  `help:"Show top-N fallthrough/deny commands per section. Use 0 to hide both sections." default:"10"`
 }
 
 func main() { os.Exit(_main()) }


### PR DESCRIPTION
## Why

`ccgate metrics` currently shows aggregate counts (allow/deny/fallthrough) but not the actual commands behind them, so it is impossible to tell which permission rule should be added to reduce fallthroughs. Large token counts also overflow mentally without any grouping, and there is no single "how automated am I" number to track improvement against.

## What

- Record structured `tool_input` (`command` / `file_path` / `path` / `pattern`) on every entry. Uses Go 1.24+ `omitzero` so legacy-shape lines are preserved and empty inputs add zero bytes. `description` / `content` / `content_updates` / raw JSON are intentionally not stored.
- Add `automation_rate = (allow + deny) / total` to daily and overall report. `error` is in the denominator so error bursts drag the rate down rather than inflate it.
- Add `Top fallthrough commands` (filtered to `FallthroughKind == "llm"` — the other kinds cannot be fixed by permission rules) and `Top deny commands` sections, grouped by `(tool_name, ToolInputFields)` with a deterministic tie-breaker (`count desc → tool asc → command asc → file_path asc → path asc → pattern asc`).
- Format integers with thousands separators via a custom `humanInt` (string-based, so `math.MinInt64` works). `AvgElapsedMS` continues to round (via `math.Round`) rather than truncate. Column widths are pre-computed so grouping never breaks table alignment.
- Add `--details N` flag: `0` hides both top sections; default `10`.
- TTY details section collapses `\n` / `\r` / `\t` to spaces so rows never wrap. Whitespace inside commands is **not** normalized at write time, so `echo "a   b"` is preserved verbatim. `--json` output keeps the raw value (literal LF restored via `json.Unmarshal`).
- Extract `FallthroughKind*` constants in `internal/gate` so the metrics filter no longer depends on a loose `"llm"` literal.
- Tests lock in `omitzero` / per-field `omitempty` / multiline escape at the write path, and column alignment / tie-breaker ordering at the report path. Mutation-verified.

### Compatibility

- **JSONL**: `tool_input` added with `omitzero` → old binary ignores the unknown key; new binary reads missing key as a zero-value struct. Bidirectional OK.
- **`--json` output**: new top-level fields (`automation_rate`, `fallthrough_top`, `deny_top`) are additive. Tolerant consumers are unaffected; strict ones using `DisallowUnknownFields` would need a one-line update (no in-repo consumers).
- **CLI**: `--details` defaults to `10`; existing invocations unchanged.
- **TTY table**: one new `Auto%` column and two new footer sections. Scripts parsing TTY columns (rather than `--json`) would shift; parsing TTY output is not a supported pattern.
- **Storage size**: `+0 B` for zero-value entries, `+80–150 B` for populated ones (average `+70 B`/line). `metrics_max_size` default unchanged; users hitting the cap can enlarge it in config or set `metrics_disabled: true`.

### Sensitive data

`command` is stored verbatim, including any `--token ghp_…` that happens to appear. metrics are kept local in `~/.local/state/ccgate/metrics.jsonl` and are never transmitted. Claude Code already keeps session history with equivalent fidelity under `~/.claude/projects/`, so masking here would only add a second copy to manage. Users who prefer not to retain this data can set `metrics_disabled: true`.

### Test plan

- [x] `mise run vet` clean
- [x] `mise run test` green (race + coverage); `internal/metrics` coverage ≥ 90%
- [x] Local `bin/ccgate metrics --days 7` shows `Auto%`, `Automation rate:` footer, `1,234,567` grouping, and Top sections
- [x] `bin/ccgate metrics --json | jq '.automation_rate, .fallthrough_top[].tool_input'` returns structured data
- [x] Synthetic hook input: `tool_input` is `{"command":"echo hello"}` for Bash, `{"path":"...","pattern":"..."}` for Grep, and the `tool_input` key is absent for `ExitPlanMode` (omitzero)
- [x] `--details 0` suppresses both top sections; `--details=-5` falls back to the internal default
- [x] Multiline command stored as JSON-escaped `\n` on disk, restored via `json.Unmarshal`, collapsed to a single space in TTY details
