### PR TITLE
docs: refresh README (fallthrough_strategy, metrics, known limitations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ If a global config file exists, embedded defaults are not used. The global confi
 Project-local configs always append to the base (allow/deny/environment are appended, provider fields are overwritten).
 Project-local configs are only loaded if **not tracked by Git**.
 
+> **Note:** This "global replaces defaults, project-local only appends" asymmetry is a known wart — users cannot narrow or override rules from the project layer today. Tracked as a breaking-change refactor in [#38](https://github.com/tak848/ccgate/issues/38).
+
 ### Config fields
 
 | Field | Type | Default | Description |
@@ -107,6 +109,9 @@ Project-local configs are only loaded if **not tracked by Git**.
 | `log_path` | string | `"~/.claude/logs/ccgate.log"` | Log file path. Supports `~` for home directory. |
 | `log_disabled` | bool | `false` | Disable logging entirely |
 | `log_max_size` | int | `5242880` | Max log file size in bytes before rotation (default 5MB) |
+| `metrics_path` | string | `"$XDG_STATE_HOME/ccgate/metrics.jsonl"` | Metrics JSONL file path. Supports `~` for home directory. |
+| `metrics_disabled` | bool | `false` | Disable metrics collection entirely |
+| `metrics_max_size` | int | `2097152` | Max metrics file size in bytes before rotation (default 2MB) |
 | `fallthrough_strategy` | `"ask"` / `"allow"` / `"deny"` | `"ask"` | How to resolve LLM uncertainty (`fallthrough`). See [Unattended automation](#unattended-automation-fallthrough_strategy). |
 | `allow` | string[] | `[]` | Allow guidance rules (natural language, interpreted by the LLM) |
 | `deny` | string[] | `[]` | Deny guidance rules (mandatory). Supports inline `deny_message:` hints |
@@ -162,6 +167,34 @@ To change the log path or disable logging:
   // log_disabled: true,
 }
 ```
+
+## Metrics
+
+Every invocation is recorded as a JSONL entry (`$XDG_STATE_HOME/ccgate/metrics.jsonl` by default, 2 MB rotation). To summarize:
+
+```bash
+ccgate metrics                     # last 7 days, TTY table
+ccgate metrics --days 30           # wider window
+ccgate metrics --json              # machine-readable output
+ccgate metrics --details 5         # top-5 fallthrough / deny commands
+ccgate metrics --details 0         # suppress the drill-down sections
+```
+
+The daily table shows per-day counts (Allow, Deny, Fall, F.Allow, F.Deny, Err), automation rate, average latency, and token usage. The "Top fallthrough commands" / "Top deny commands" drill-downs surface which operations you could eliminate by adding a permission rule.
+
+To move or disable the metrics file:
+
+```jsonnet
+{
+  metrics_path: '~/my-state/ccgate-metrics.jsonl',
+  // metrics_disabled: true,
+}
+```
+
+## Known limitations
+
+- **Plan mode does not fully prevent implementation writes.** ccgate currently relies on the LLM plus prose in the system prompt to be stricter under `permission_mode == "plan"`, which still lets some "safe-looking" writes slip through. Tracked in [#37](https://github.com/tak848/ccgate/issues/37).
+- **Config file layering is asymmetric.** `~/.claude/ccgate.jsonnet` *replaces* embedded defaults while project-local files only *append*. Narrowing / overriding rules from the project layer is not supported today. Tracked as a breaking-change refactor in [#38](https://github.com/tak848/ccgate/issues/38).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Project-local configs are only loaded if **not tracked by Git**.
 | `log_path` | string | `"~/.claude/logs/ccgate.log"` | Log file path. Supports `~` for home directory. |
 | `log_disabled` | bool | `false` | Disable logging entirely |
 | `log_max_size` | int | `5242880` | Max log file size in bytes before rotation (default 5MB) |
+| `fallthrough_strategy` | `"ask"` / `"allow"` / `"deny"` | `"ask"` | How to resolve LLM uncertainty (`fallthrough`). See [Unattended automation](#unattended-automation-fallthrough_strategy). |
 | `allow` | string[] | `[]` | Allow guidance rules (natural language, interpreted by the LLM) |
 | `deny` | string[] | `[]` | Deny guidance rules (mandatory). Supports inline `deny_message:` hints |
 | `environment` | string[] | `[]` | Context strings passed to the LLM (trust level, policies, etc.) |
@@ -125,6 +126,29 @@ Run `ccgate init` to see the full default configuration. To customize, redirect 
 ccgate init > ~/.claude/ccgate.jsonnet    # Global config (replaces defaults)
 ccgate init -p > ccgate.local.jsonnet     # Project-local template (appended)
 ```
+
+## Unattended automation (`fallthrough_strategy`)
+
+By default, when the LLM is not confident enough to decide, ccgate returns `fallthrough` and Claude Code shows its interactive permission prompt. That is the right behavior for a human-in-the-loop session but blocks schedulers, bots, and any unattended run that has no one to click "approve".
+
+Set `fallthrough_strategy` to force a fixed verdict on LLM uncertainty:
+
+```jsonnet
+{
+  // Safer: when the LLM is unsure, refuse. Recommended for anything that runs unattended.
+  fallthrough_strategy: 'deny',
+}
+```
+
+Values:
+
+- `ask` (default) — defer to Claude Code's prompt. No behavior change.
+- `deny` — auto-refuse uncertain operations. The deny message tells Claude not to re-ask and not to work around the restriction, so the run keeps moving instead of stalling.
+- `allow` — auto-approve uncertain operations. **Riskier**: you are letting ccgate green-light operations the LLM itself was unsure about. Also note that Claude Code's hook spec only delivers `decision.message` on `deny`, so Claude never sees a warning on forced-allow. Pick this only if that trade-off is acceptable.
+
+Only LLM-driven uncertainty is affected. Truncated/refused API responses, missing API keys, `bypassPermissions`/`dontAsk` mode, and `ExitPlanMode` / `AskUserQuestion` continue to defer to Claude Code regardless — so `fallthrough_strategy=allow` cannot silently auto-approve a request the LLM never actually classified.
+
+`ccgate metrics` surfaces how often the override fired through the `F.Allow` / `F.Deny` columns in the daily table (and `forced_allow` / `forced_deny` in JSON output), so you can audit whether the strategy you chose is making decisions you are comfortable with.
 
 ## Logging
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -93,6 +93,8 @@ ccgate init > ~/.claude/ccgate.jsonnet
 プロジェクトローカル設定は常にベースに追加されます (allow/deny/environment は追加、provider は上書き)。
 プロジェクトローカル設定は **Git に追跡されていないファイルのみ** 読み込まれます。
 
+> **Note:** 「グローバルはデフォルトを置換、プロジェクトローカルは追加のみ」という非対称仕様は既知の課題です (プロジェクト層からルールを狭める/上書きする手段がない)。互換性を壊す破壊的リファクタとして [#38](https://github.com/tak848/ccgate/issues/38) で追跡しています。
+
 ### 設定項目
 
 | フィールド | 型 | デフォルト | 説明 |
@@ -103,6 +105,9 @@ ccgate init > ~/.claude/ccgate.jsonnet
 | `log_path` | string | `"~/.claude/logs/ccgate.log"` | ログファイルパス。`~` でホームディレクトリ展開 |
 | `log_disabled` | bool | `false` | ログ出力を完全に無効化 |
 | `log_max_size` | int | `5242880` | ローテーション閾値 (bytes, デフォルト 5MB) |
+| `metrics_path` | string | `"$XDG_STATE_HOME/ccgate/metrics.jsonl"` | メトリクス JSONL のパス。`~` でホームディレクトリ展開 |
+| `metrics_disabled` | bool | `false` | メトリクス収集を完全に無効化 |
+| `metrics_max_size` | int | `2097152` | ローテーション閾値 (bytes, デフォルト 2MB) |
 | `fallthrough_strategy` | `"ask"` / `"allow"` / `"deny"` | `"ask"` | LLM が判定に迷った (`fallthrough`) 際の扱い。[完全自動運転モード](#完全自動運転モード-fallthrough_strategy) 参照 |
 | `allow` | string[] | `[]` | 許可ルール (自然言語、LLM が解釈) |
 | `deny` | string[] | `[]` | 拒否ルール (mandatory)。`deny_message:` ヒント対応 |
@@ -158,6 +163,34 @@ ccgate init -p > ccgate.local.jsonnet     # プロジェクトローカルテン
   // log_disabled: true,
 }
 ```
+
+## メトリクス
+
+呼び出しごとに JSONL レコードを記録します (デフォルトは `$XDG_STATE_HOME/ccgate/metrics.jsonl`、2MB でローテーション)。集計表示は:
+
+```bash
+ccgate metrics                     # 直近 7 日間、TTY テーブル
+ccgate metrics --days 30           # 集計範囲を拡張
+ccgate metrics --json              # JSON 出力 (機械可読)
+ccgate metrics --details 5         # 上位 5 件の fallthrough / deny コマンドを表示
+ccgate metrics --details 0         # ドリルダウン節を非表示
+```
+
+日次テーブルには Allow / Deny / Fall / F.Allow / F.Deny / Err、自動化率、平均レイテンシ、トークン使用量が並びます。「Top fallthrough commands」「Top deny commands」のドリルダウンを見ると、ルール追加で削減できる操作が特定できます。
+
+メトリクスファイルの移動・無効化:
+
+```jsonnet
+{
+  metrics_path: '~/my-state/ccgate-metrics.jsonl',
+  // metrics_disabled: true,
+}
+```
+
+## 既知の制約
+
+- **Plan mode でも実装系 write が漏れる場合がある。** 現状は LLM とシステムプロンプトの指示文で `permission_mode == "plan"` の挙動を絞っているだけなので、「一見安全」な write が通ってしまうケースがあります。[#37](https://github.com/tak848/ccgate/issues/37) で追跡しています。
+- **設定ファイル layering の非対称。** `~/.claude/ccgate.jsonnet` は組み込みデフォルトを*置換*するのに対し、プロジェクトローカルは*追加のみ*。プロジェクト層からルールを狭める/上書きする手段がありません。互換性を壊す破壊的リファクタとして [#38](https://github.com/tak848/ccgate/issues/38) で追跡しています。
 
 ## 開発
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -103,6 +103,7 @@ ccgate init > ~/.claude/ccgate.jsonnet
 | `log_path` | string | `"~/.claude/logs/ccgate.log"` | ログファイルパス。`~` でホームディレクトリ展開 |
 | `log_disabled` | bool | `false` | ログ出力を完全に無効化 |
 | `log_max_size` | int | `5242880` | ローテーション閾値 (bytes, デフォルト 5MB) |
+| `fallthrough_strategy` | `"ask"` / `"allow"` / `"deny"` | `"ask"` | LLM が判定に迷った (`fallthrough`) 際の扱い。[完全自動運転モード](#完全自動運転モード-fallthrough_strategy) 参照 |
 | `allow` | string[] | `[]` | 許可ルール (自然言語、LLM が解釈) |
 | `deny` | string[] | `[]` | 拒否ルール (mandatory)。`deny_message:` ヒント対応 |
 | `environment` | string[] | `[]` | LLM に渡すコンテキスト (信頼レベル、ポリシー等) |
@@ -121,6 +122,29 @@ ccgate init > ~/.claude/ccgate.jsonnet
 ccgate init > ~/.claude/ccgate.jsonnet    # グローバル設定 (デフォルトを置換)
 ccgate init -p > ccgate.local.jsonnet     # プロジェクトローカルテンプレート (追加)
 ```
+
+## 完全自動運転モード (`fallthrough_strategy`)
+
+デフォルトでは、LLM が判定に自信を持てない場合 ccgate は `fallthrough` を返し、Claude Code のインタラクティブ確認画面にフォールバックします。対話セッションでは妥当ですが、スケジューラやボットなど人間が「許可」を押せない環境では処理が止まります。
+
+`fallthrough_strategy` を設定すると、LLM の判定迷いを allow/deny に強制変換できます:
+
+```jsonnet
+{
+  // 安全側: 迷ったら拒否。無人実行ではこちらを推奨
+  fallthrough_strategy: 'deny',
+}
+```
+
+値:
+
+- `ask` (デフォルト) — Claude Code の確認画面に委ねる (既存の挙動)
+- `deny` — 迷ったら自動拒否。deny メッセージには「user に聞くな、別コマンドで回避するな」という指示が含まれるため、実行が止まらず前に進む
+- `allow` — 迷ったら自動許可。**危険側**: LLM 自身が判断に迷った操作を無条件に通すことになります。加えて Claude Code の hook 仕様上 `decision.message` は `deny` のときしか Claude に届かないため、強制 allow の際 Claude には警告が渡りません。このトレードオフを理解した上で選択してください
+
+対象は **LLM 判定の fallthrough に限定** です。API 応答の打ち切り/拒否、API キー欠損、`bypassPermissions`/`dontAsk` モード、`ExitPlanMode` / `AskUserQuestion` はいずれも従来通り Claude Code へフォールスルーされます (LLM が呼ばれないケースを `fallthrough_strategy=allow` が黙って自動承認することはありません)。
+
+強制発火した回数は `ccgate metrics` の `F.Allow` / `F.Deny` 列 (JSON では `forced_allow` / `forced_deny`) で確認できるため、選んだ戦略が妥当に機能しているか後から監査できます。
 
 ## ログ
 


### PR DESCRIPTION
## Why

#35 added `fallthrough_strategy` but the README was not updated alongside it. While going through the README I also found a few pre-existing gaps — `metrics_*` config fields are missing from the table, `ccgate metrics` isn't mentioned at all, and the "global replaces defaults, project-local only appends" asymmetry is implicit — so this PR cleans the README up as a single pass instead of leaving those as follow-ups.

## What

### `fallthrough_strategy`

- Config fields table: new row linking to the dedicated section.
- New "Unattended automation (`fallthrough_strategy`)" section: when to reach for `deny` vs `allow`, the allow-side caveat (Claude Code's hook spec only delivers `decision.message` on `deny`, so forced-allow is silent to Claude), the scope-limit to LLM-driven uncertainty (truncate/refusal/bypass/dontAsk etc. still defer), and where to audit how often it fired (`ccgate metrics` F.Allow / F.Deny).

### Metrics

- Config fields table: add `metrics_path` / `metrics_disabled` / `metrics_max_size`.
- New "Metrics" section documenting the `ccgate metrics` subcommand (flags, what the daily table / drill-downs show, how to relocate or disable the JSONL file).

### Known limitations

- New "Known limitations" section linking to:
  - #37 — plan-mode-aware permission handling (LLM still allows some implementation-flavored writes under `permission_mode == "plan"`).
  - #38 — config file layering asymmetry (breaking change, global replaces defaults vs project-local only appends).
- "Config file loading order" section: inline callout pointing at #38 so readers hitting the layering description see the caveat immediately.

### Mirror

All wording is mirrored in `docs/README.ja.md`.

## Verification

Prose-only change; code is untouched. `mise run vet` / `mise run test` already green on `main`. Anchor sanity-check: the new section headers match the fragments used from the Config fields table row (`#unattended-automation-fallthrough_strategy` / `#完全自動運転モード-fallthrough_strategy`).