### PR TITLE
feat(ci,release): cover macOS/Windows in CI; publish Windows binaries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+*.png binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,11 @@ permissions:
   contents: read
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,11 +14,18 @@ builds:
     goos:
       - darwin
       - linux
+      - windows
     goarch:
       - amd64
       - arm64
 archives:
   - name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}'
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
 release:
   prerelease: auto
 checksum:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,8 +4,26 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
+	"runtime"
 	"testing"
 )
+
+// setHomeEnv sets the env var that os.UserHomeDir consults on the current OS.
+// Mirrors homeEnvName in the Go stdlib (cmd/go/internal/vcweb/script.go) so
+// tests that need to redirect the user home dir work identically on Windows
+// (USERPROFILE), plan9 (home), and everything else (HOME).
+func setHomeEnv(t *testing.T, dir string) {
+	t.Helper()
+	switch runtime.GOOS {
+	case "windows":
+		t.Setenv("USERPROFILE", dir)
+	case "plan9":
+		t.Setenv("home", dir)
+	default:
+		t.Setenv("HOME", dir)
+	}
+}
 
 func TestDefaultConfig(t *testing.T) {
 	t.Parallel()
@@ -174,15 +192,18 @@ func TestMergeConfigFileOverridesProvider(t *testing.T) {
 func TestProjectLocalConfigPaths(t *testing.T) {
 	t.Parallel()
 
-	got := projectLocalConfigPaths("/tmp/repo/subdir")
-	if len(got) != 2 {
-		t.Fatalf("unexpected path count: %d", len(got))
+	const cwd = "/tmp/repo/subdir"
+	got := projectLocalConfigPaths(cwd)
+
+	// Contract: two candidates, cwd-direct first (higher priority), cwd/.claude/ second.
+	// Path separators are OS-native, so expected values are composed with filepath.Join
+	// (mirrors Go stdlib's cross-platform path test pattern in path/filepath/path_test.go).
+	want := []string{
+		filepath.Join(cwd, LocalConfigName),
+		filepath.Join(cwd, ".claude", LocalConfigName),
 	}
-	if got[0] != "/tmp/repo/subdir/ccgate.local.jsonnet" {
-		t.Fatalf("unexpected first path: %s", got[0])
-	}
-	if got[1] != "/tmp/repo/subdir/.claude/ccgate.local.jsonnet" {
-		t.Fatalf("unexpected second path: %s", got[1])
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("projectLocalConfigPaths(%q) = %v, want %v", cwd, got, want)
 	}
 }
 
@@ -259,7 +280,7 @@ func TestLoadFallsBackToDefaultsWhenNoGlobalConfig(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(dir, ".claude"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("HOME", dir)
+	setHomeEnv(t, dir)
 
 	lr, err := Load("")
 	if err != nil {
@@ -287,7 +308,7 @@ func TestLoadUsesGlobalConfigWhenPresent(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(claudeDir, BaseConfigName), []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("HOME", dir)
+	setHomeEnv(t, dir)
 
 	lr, err := Load("")
 	if err != nil {

--- a/internal/hookctx/paths_test.go
+++ b/internal/hookctx/paths_test.go
@@ -1,7 +1,9 @@
 package hookctx
 
 import (
+	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 )
 
@@ -177,17 +179,26 @@ func TestExtractBashPaths(t *testing.T) {
 func TestExpandPaths(t *testing.T) {
 	t.Parallel()
 
+	// "absolute path" depends on OS semantics: filepath.IsAbs returns false
+	// for "/usr/bin/foo" on Windows, so we feed an OS-native absolute path
+	// instead (mirrors Go stdlib's TestClean / TestJoin approach of swapping
+	// winXxxtests for OS-specific cases).
+	absIn, absWant := "/usr/bin/foo", "/usr/bin/foo"
+	if runtime.GOOS == "windows" {
+		absIn, absWant = `C:\usr\bin\foo`, `C:\usr\bin\foo`
+	}
+
 	tests := []struct {
 		name   string
 		cwd    string
 		values []string
-		want   []string
+		want   []string // forward-slash form; converted to OS-native via filepath.FromSlash below
 	}{
 		{
 			name:   "absolute path",
 			cwd:    "/cwd",
-			values: []string{"/usr/bin/foo"},
-			want:   []string{"/usr/bin/foo"},
+			values: []string{absIn},
+			want:   []string{absWant},
 		},
 		{
 			name:   "relative path",
@@ -212,8 +223,12 @@ func TestExpandPaths(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := expandPaths(tt.cwd, tt.values...)
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("expandPaths(%q, %v) = %v, want %v", tt.cwd, tt.values, got, tt.want)
+			want := make([]string, len(tt.want))
+			for i, w := range tt.want {
+				want[i] = filepath.FromSlash(w)
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("expandPaths(%q, %v) = %v, want %v", tt.cwd, tt.values, got, want)
 			}
 		})
 	}


### PR DESCRIPTION
## Why

The code itself has no `//go:build` constraints or `runtime.GOOS` branches and uses only cross-platform APIs (`syscall.SIGTERM`, `os/exec`, `filepath.*`, `os.UserHomeDir`), so nothing in ccgate actively prevents Windows from working. Only the release and CI plumbing was gating it. This PR opens that gate so Windows users can grab a binary from the Releases page, and expands the CI matrix so all three supported platforms are exercised.

macOS is already a release target but was never in the CI matrix — the day-to-day development platform for the maintainer is macOS, so breakage is unlikely, but this closes the "works on my machine" gap.

The maintainer does not use Windows and has not personally verified end-to-end interaction with Claude Code. CI coverage (compile + unit tests) is the intended guarantee level for Windows. README is intentionally left unchanged — Windows is not a "strongly supported" platform, just a best-effort build. If it breaks for you, please open an issue.

## What

- `.goreleaser.yml`
  - Add `windows` to `goos` (amd64 / arm64 are already listed under `goarch`).
  - Set archives `formats: [tar.gz]` explicitly and override Windows to `zip` via `format_overrides` (goreleaser v2.6+ plural `formats` syntax).
- `.github/workflows/ci.yml`
  - Matrix `vet` + `test` across `ubuntu-latest`, `macos-latest`, and `windows-latest` with `fail-fast: false`. The mise tasks used in CI (`vet`, `test`) are pure `go` invocations, so they work on all three without the shell-ism concerns of the `build` / `clean` tasks.
- `.gitattributes` (new)
  - `* text=auto eol=lf` so the default `core.autocrlf=true` on Windows does not inject CRLF into files embedded via `//go:embed defaults.jsonnet`.

### Test portability fixes (test-only; runtime code was already portable)

Turning on the windows-latest job surfaced three failures that were all test-side issues — the runtime already uses `filepath.*` and `os.UserHomeDir` correctly. Fixes follow the canonical Go stdlib patterns:

- `internal/config/config_test.go`
  - Added a `setHomeEnv(t, dir)` helper that mirrors stdlib's `homeEnvName` in `cmd/go/internal/vcweb/script.go`. It sets `USERPROFILE` on Windows, `home` on plan9, `HOME` elsewhere — whichever env var `os.UserHomeDir` actually consults on that OS. Used in the two `Load()` tests that previously redirected `$HOME` directly.
  - Rewrote `TestProjectLocalConfigPaths` to build expected paths with `filepath.Join` instead of hard-coded forward-slash literals. The length/order assertion (the load-priority contract: cwd-direct first, then `cwd/.claude/`) is preserved — deleting the test would have dropped a meaningful regression guard.
- `internal/hookctx/paths_test.go`
  - `TestExpandPaths`: for the "absolute path" case, switched the input to an OS-native absolute (`C:\...` on Windows, `/...` elsewhere) because `filepath.IsAbs` is OS-dependent. Remaining expected paths are written with forward slashes and converted via `filepath.FromSlash` at comparison time — same pattern as stdlib `TestJoin` in `path/filepath/path_test.go`.

## Out of scope (intentionally)

- README / `docs/README.ja.md` — no "we support Windows" messaging.
- `stateDir()` in `internal/config/config.go` — the `XDG_STATE_HOME` / `~/.local/state/ccgate` fallback works on Windows but is not idiomatic. Users can override via `log_path` / `metrics_path`.
- `mise.toml`'s `build` / `clean` shell-dependent tasks — not invoked by CI.

## Verification

- `go vet ./...` and `go test -race -cover ./...` pass locally on macOS.
- `GOOS=windows GOARCH=amd64` and `GOOS=windows GOARCH=arm64` cross-compile succeed for both the main binary and the per-package test binaries (`go test -c`), confirming the test files themselves compile on Windows.
- CI matrix (`ubuntu-latest` / `macos-latest` / `windows-latest`) passes on the latest commit.