### PR TITLE
docs: note minimum mise / aqua-registry versions for ccgate install

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ ccgate
 
 ### mise (recommended)
 
-Requires mise `2026.4.20` or later (mise embeds the aqua registry at build time, and ccgate first appears in registry `v4.498.0`, which mise picked up in that release). Older versions fail with `registry not available: no aqua-registry found for tak848/ccgate`; run `mise self-update` first.
+Requires mise `2026.4.20` or later — the first release whose bundled aqua registry (pinned to `v4.498.0`) includes ccgate. Older versions fail with `registry not available: no aqua-registry found for tak848/ccgate`; run `mise self-update` first.
 
 ```bash
 mise use -g aqua:tak848/ccgate

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ ccgate
 
 ### mise (recommended)
 
-Requires mise `2026.4.20` or later — the first release whose bundled aqua registry (pinned to `v4.498.0`) includes ccgate. Older versions fail with `registry not available: no aqua-registry found for tak848/ccgate`; run `mise self-update` first.
+Requires mise `2026.4.20` or later (older versions ship an aqua registry snapshot without ccgate).
 
 ```bash
 mise use -g aqua:tak848/ccgate

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ ccgate
 
 ### mise (recommended)
 
-Requires mise `2026.4.20` or later (older versions ship an aqua registry snapshot without ccgate).
+Requires mise `2026.4.20` or later. Earlier releases bundle an aqua registry snapshot from before ccgate was added.
 
 ```bash
 mise use -g aqua:tak848/ccgate

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ ccgate
 
 ### mise (recommended)
 
+Requires mise `2026.4.20` or later (mise embeds the aqua registry at build time, and ccgate first appears in registry `v4.498.0`, which mise picked up in that release). Older versions fail with `registry not available: no aqua-registry found for tak848/ccgate`; run `mise self-update` first.
+
 ```bash
 mise use -g aqua:tak848/ccgate
 ```
@@ -43,7 +45,7 @@ If you want to keep this no-install style for the Claude Code hook itself, set t
 
 ### aqua
 
-Via the [aqua](https://aquaproj.github.io/) standard registry. In an aqua-managed project (run `aqua init` first if you don't have an `aqua.yaml` yet):
+Via the [aqua](https://aquaproj.github.io/) standard registry (requires registry `v4.498.0` or later — ccgate's first registered version). In an aqua-managed project (run `aqua init` first if you don't have an `aqua.yaml` yet):
 
 ```bash
 aqua g -i tak848/ccgate

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -25,7 +25,7 @@ ccgate
 
 ### mise (推奨)
 
-mise `2026.4.20` 以降が必要です — bundle される aqua registry (`v4.498.0` に pin) が ccgate を含むのはこの release から。古い mise だと `registry not available: no aqua-registry found for tak848/ccgate` で失敗するので、まず `mise self-update` を実行してください。
+mise `2026.4.20` 以降が必要です (古い mise は ccgate を含まない aqua registry snapshot を bundle している)。
 
 ```bash
 mise use -g aqua:tak848/ccgate

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -25,6 +25,8 @@ ccgate
 
 ### mise (推奨)
 
+mise `2026.4.20` 以降が必要です (mise はビルド時に aqua registry を埋め込み、ccgate は registry `v4.498.0` で初登録された。mise 側ではこの release で追従)。古い mise だと `registry not available: no aqua-registry found for tak848/ccgate` で失敗するので、まず `mise self-update` を実行してください。
+
 ```bash
 mise use -g aqua:tak848/ccgate
 ```
@@ -39,7 +41,7 @@ mise exec aqua:tak848/ccgate -- ccgate --version
 
 ### aqua
 
-[aqua](https://aquaproj.github.io/) 標準 registry 経由。aqua 管理下のプロジェクトで (`aqua.yaml` がない場合は `aqua init` を先に走らせる):
+[aqua](https://aquaproj.github.io/) 標準 registry 経由 (registry `v4.498.0` 以降が必要 — ccgate が初めて登録された version)。aqua 管理下のプロジェクトで (`aqua.yaml` がない場合は `aqua init` を先に走らせる):
 
 ```bash
 aqua g -i tak848/ccgate

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -25,7 +25,7 @@ ccgate
 
 ### mise (推奨)
 
-mise `2026.4.20` 以降が必要です (古い mise は ccgate を含まない aqua registry snapshot を bundle している)。
+mise `2026.4.20` 以降が必要です。これより前のリリースは aqua registry に ccgate が登録される前のスナップショットを同梱しています。
 
 ```bash
 mise use -g aqua:tak848/ccgate

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -25,7 +25,7 @@ ccgate
 
 ### mise (推奨)
 
-mise `2026.4.20` 以降が必要です (mise はビルド時に aqua registry を埋め込み、ccgate は registry `v4.498.0` で初登録された。mise 側ではこの release で追従)。古い mise だと `registry not available: no aqua-registry found for tak848/ccgate` で失敗するので、まず `mise self-update` を実行してください。
+mise `2026.4.20` 以降が必要です — bundle される aqua registry (`v4.498.0` に pin) が ccgate を含むのはこの release から。古い mise だと `registry not available: no aqua-registry found for tak848/ccgate` で失敗するので、まず `mise self-update` を実行してください。
 
 ```bash
 mise use -g aqua:tak848/ccgate

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -25,7 +25,7 @@ ccgate
 
 ### mise (推奨)
 
-mise `2026.4.20` 以降が必要です。これより前のリリースは aqua registry に ccgate が登録される前のスナップショットを同梱しています。
+mise `2026.4.20` 以降が必要です。このリリースから、同梱の aqua registry に ccgate が含まれます。
 
 ```bash
 mise use -g aqua:tak848/ccgate


### PR DESCRIPTION
## Why

Follow-up to #48. Codex's review on that PR pointed out that `mise use -g aqua:tak848/ccgate` fails on `mise 2026.1.1` with:

```
registry not available: no aqua-registry found for tak848/ccgate
```

The reason is that mise embeds the aqua registry at build time. ccgate first appears in aqua-registry `v4.498.0`, and mise picked that registry up in `2026.4.20`. So the recommended install command works on recent mise but silently breaks on older releases.

## What

- `README.md` — add a short prerequisite line above the `mise use -g aqua:tak848/ccgate` block stating the minimum mise version (`2026.4.20`), the underlying reason (registry pickup), and the suggested fix (`mise self-update`).
- `README.md` — add the analogous prerequisite to the `### aqua` subsection (`aqua-registry v4.498.0` or later).
- `docs/README.ja.md` — mirror both notes on the Japanese side.

No changes to install commands themselves; only the surrounding prose.

## Verification

- The error message in the new note matches what Codex observed on `mise 2026.1.1`.
- The minimum versions match aqua-registry v4.498.0's release date (2026-04-24) and mise's registry refresh in `2026.4.20`.