### PR TITLE
docs: fix default log path documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Project-local configs are only loaded if **not tracked by Git**.
 | `provider.name` | string | `"anthropic"` | Provider name. Only `"anthropic"` is supported. |
 | `provider.model` | string | `"claude-haiku-4-5"` | Model name (e.g. `claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-6`) |
 | `provider.timeout_ms` | int | `20000` | API timeout (ms) |
-| `log_path` | string | `"~/.claude/logs/ccgate.log"` | Log file path. Supports `~` for home directory. |
+| `log_path` | string | `"$XDG_STATE_HOME/ccgate/ccgate.log"` | Log file path. Supports `~` for home directory. |
 | `log_disabled` | bool | `false` | Disable logging entirely |
 | `log_max_size` | int | `5242880` | Max log file size in bytes before rotation (default 5MB) |
 | `metrics_path` | string | `"$XDG_STATE_HOME/ccgate/metrics.jsonl"` | Metrics JSONL file path. Supports `~` for home directory. |
@@ -180,7 +180,8 @@ Only LLM-driven uncertainty is affected. Truncated/refused API responses, missin
 
 ## Logging
 
-Logs are written to `~/.claude/logs/ccgate.log` by default with 5 MB rotation (`.log.1`).
+Logs are written to `$XDG_STATE_HOME/ccgate/ccgate.log` by default with 5 MB rotation (`.log.1`).
+If `XDG_STATE_HOME` is unset, ccgate falls back to `~/.local/state/ccgate/ccgate.log`.
 
 To change the log path or disable logging:
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -125,7 +125,7 @@ ccgate init > ~/.claude/ccgate.jsonnet
 | `provider.name` | string | `"anthropic"` | プロバイダー名。`"anthropic"` のみ対応 |
 | `provider.model` | string | `"claude-haiku-4-5"` | モデル名 (例: `claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-6`) |
 | `provider.timeout_ms` | int | `20000` | API タイムアウト (ms) |
-| `log_path` | string | `"~/.claude/logs/ccgate.log"` | ログファイルパス。`~` でホームディレクトリ展開 |
+| `log_path` | string | `"$XDG_STATE_HOME/ccgate/ccgate.log"` | ログファイルパス。`~` でホームディレクトリ展開 |
 | `log_disabled` | bool | `false` | ログ出力を完全に無効化 |
 | `log_max_size` | int | `5242880` | ローテーション閾値 (bytes, デフォルト 5MB) |
 | `metrics_path` | string | `"$XDG_STATE_HOME/ccgate/metrics.jsonl"` | メトリクス JSONL のパス。`~` でホームディレクトリ展開 |
@@ -176,7 +176,7 @@ ccgate init -p > ccgate.local.jsonnet     # プロジェクトローカルテン
 
 ## ログ
 
-デフォルトでは `~/.claude/logs/ccgate.log` に出力されます。5MB でローテーション (`.log.1`)。
+デフォルトでは `$XDG_STATE_HOME/ccgate/ccgate.log` に出力されます。`XDG_STATE_HOME` が未設定の場合は `~/.local/state/ccgate/ccgate.log` にフォールバックします。5MB でローテーション (`.log.1`)。
 
 ログパスの変更・無効化:
 


### PR DESCRIPTION
## Why

The README files documented the default `log_path` as `~/.claude/logs/ccgate.log`, but the implementation and JSON schema use `$XDG_STATE_HOME/ccgate/ccgate.log` with a fallback under `~/.local/state`. This could send users to the wrong log location when troubleshooting.

## What

- Update the English and Japanese README config tables to show `$XDG_STATE_HOME/ccgate/ccgate.log`.
- Update both Logging sections to document the `~/.local/state/ccgate/ccgate.log` fallback when `XDG_STATE_HOME` is unset.

## Test plan

- `mise run vet`
- `mise run test`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/ccgate/pull/51" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
