### PR TITLE
fix!: replace-by-default + opt-in append_* keys for config layering (#38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,13 @@ Same env vars as Claude Code (`CCGATE_ANTHROPIC_API_KEY` / `ANTHROPIC_API_KEY`).
 | 2     | `~/.claude/ccgate.jsonnet` — global (layered on top) | `~/.codex/ccgate.jsonnet` — global (same) |
 | 3     | `{repo_root}/.claude/ccgate.local.jsonnet` — project-local (untracked only, layered on top) | `{repo_root}/.codex/ccgate.local.jsonnet` — project-local (same) |
 
-All three layers compose with the same rules: **lists** (`allow` / `deny` / `environment`) are appended, **scalars** (`provider.*`, `log_*`, `metrics_*`, `fallthrough_strategy`) are overwritten when the layer sets them. Embedded defaults are always present, so a global config that only sets `provider.model` keeps every embedded `allow` / `deny` rule.
+All three layers compose with the same rules:
+
+- **Lists** — `allow` / `deny` / `environment` **replace** the value carried over from earlier layers when the layer sets them (even to `[]`). The `append_*` siblings (`append_allow`, `append_deny`, `append_environment`) **add** entries on top of whatever the earlier layers produced.
+- **Scalars** — `provider.*`, `log_*`, `metrics_*`, `fallthrough_strategy` are overwritten per-field when the layer sets them, otherwise the earlier value survives.
+
+So `~/.<target>/ccgate.jsonnet` that only sets `provider.model` keeps every embedded `allow` / `deny` rule. A `~/.<target>/ccgate.jsonnet` that writes `allow: [...]` swaps the embedded allow list for its own (this is what most pre-v0.6 global configs already did, so it stays idempotent). Project-local configs typically use `append_deny: [...]` / `append_environment: [...]` to add restrictions on top of the inherited base.
+
 Project-local configs are loaded only when **not tracked by Git**.
 
 
@@ -179,9 +185,12 @@ Project-local configs are loaded only when **not tracked by Git**.
 | `metrics_disabled`       | bool                              | `false`                                                                       | Disable metrics collection entirely                                                                    |
 | `metrics_max_size`       | int                               | `2097152`                                                                     | Max metrics file size in bytes before rotation (default 2MB). `0` = no rotation.                       |
 | `fallthrough_strategy`   | `"ask"` / `"allow"` / `"deny"`    | `"ask"`                                                                       | How to resolve LLM uncertainty (`fallthrough`). See [Unattended automation](#unattended-automation-fallthrough_strategy). |
-| `allow`                  | string[]                          | `[]`                                                                          | Allow guidance rules (natural language, interpreted by the LLM)                                        |
-| `deny`                   | string[]                          | `[]`                                                                          | Deny guidance rules (mandatory). Supports inline `deny_message:` hints                                 |
-| `environment`            | string[]                          | `[]`                                                                          | Context strings passed to the LLM (trust level, policies, etc.)                                        |
+| `allow`                  | string[]                          | `[]`                                                                          | Allow guidance rules. **Replaces** the value carried over from earlier layers when set.                |
+| `deny`                   | string[]                          | `[]`                                                                          | Deny guidance rules (mandatory). Supports inline `deny_message:` hints. Same replace semantics as `allow`. |
+| `environment`            | string[]                          | `[]`                                                                          | Context strings passed to the LLM (trust level, policies, etc.). Same replace semantics as `allow`.    |
+| `append_allow`           | string[]                          | `[]`                                                                          | Allow guidance rules **appended** on top of the carried-over list. Use this in project-local configs.   |
+| `append_deny`            | string[]                          | `[]`                                                                          | Deny guidance rules appended on top of the carried-over list.                                          |
+| `append_environment`     | string[]                          | `[]`                                                                          | Environment context appended on top of the carried-over list.                                          |
 
 `<target>` is `claude` or `codex` depending on which hook is invoked. When `XDG_STATE_HOME` is unset, ccgate falls back to `~/.local/state/ccgate/<target>/...`.
 
@@ -252,7 +261,7 @@ The daily table shows per-day counts (Allow, Deny, Fall, F.Allow, F.Deny, Err), 
 ## Known limitations
 
 - **Plan mode correctness is prompt-only (Claude only).** Under `permission_mode == "plan"`, ccgate relies on the LLM plus prose in the system prompt to (a) reject implementation-side writes and (b) allow read-only queries without requiring an allow-guidance match. Either side can misfire. Tracked in [#37](https://github.com/tak848/ccgate/issues/37).
-- **No reset/override for individual embedded default rules.** Layered configs can only **add** rules and **overwrite scalars**. Deleting a specific embedded `allow` / `deny` rule from a global or project-local config is not supported today.
+- **No surgical reset for a single embedded default rule.** A layer can either **replace** a list wholesale (`allow: [...]`) or **append** to it (`append_allow: [...]`). Removing one specific embedded `allow` / `deny` rule while keeping the rest of the embedded list requires re-stating the whole list under `allow:` / `deny:` minus that one entry.
 - **Codex hook is upstream-experimental.** Schema and behavior may change. ccgate does not currently expose `permission_mode` from Codex, parse the Codex transcript JSONL, ingest `~/.codex/config.toml`, or apply MCP-server-specific trust hints; classification runs from `tool_name` + `tool_input` + `cwd` only.
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -157,12 +157,11 @@ Same env vars as Claude Code (`CCGATE_ANTHROPIC_API_KEY` / `ANTHROPIC_API_KEY`).
 
 | Order | Claude Code | Codex CLI |
 |------:|-------------|-----------|
-| 1     | Embedded defaults (fallback when no global config exists) | Embedded defaults (same) |
-| 2     | `~/.claude/ccgate.jsonnet` — global (**replaces** embedded defaults entirely) | `~/.codex/ccgate.jsonnet` — global (same) |
-| 3     | `{repo_root}/.claude/ccgate.local.jsonnet` — project-local (untracked only, **appended**) | `{repo_root}/.codex/ccgate.local.jsonnet` — project-local (same) |
+| 1     | Embedded defaults (always applied as the base) | Embedded defaults (same) |
+| 2     | `~/.claude/ccgate.jsonnet` — global (layered on top) | `~/.codex/ccgate.jsonnet` — global (same) |
+| 3     | `{repo_root}/.claude/ccgate.local.jsonnet` — project-local (untracked only, layered on top) | `{repo_root}/.codex/ccgate.local.jsonnet` — project-local (same) |
 
-If a global config file exists, embedded defaults are **not** used. The global config is the complete base.
-Project-local configs always **append** to the base (allow/deny/environment are appended, provider fields are overwritten).
+All three layers compose with the same rules: **lists** (`allow` / `deny` / `environment`) are appended, **scalars** (`provider.*`, `log_*`, `metrics_*`, `fallthrough_strategy`) are overwritten when the layer sets them. Embedded defaults are always present, so a global config that only sets `provider.model` keeps every embedded `allow` / `deny` rule.
 Project-local configs are loaded only when **not tracked by Git**.
 
 
@@ -188,19 +187,22 @@ Project-local configs are loaded only when **not tracked by Git**.
 
 ## Default Rules
 
-When no global config file exists, ccgate uses built-in default rules (per target):
+ccgate ships built-in default rules per target. They are always applied as the base; your global / project-local configs layer on top.
 
 **Allow:** Read-only operations, local development commands (build / test against project scripts), git feature-branch operations, package-manager installs scoped to the repo.
 
 **Deny:** Download-and-execute (`curl|bash`), direct one-shot remote package execution (`npx`/`pnpx`/`bunx` etc.), git destructive operations on protected branches, out-of-repo deletion, privilege escalation.
 
-Run `ccgate claude init` / `ccgate codex init` to inspect the full default configuration. To customize, redirect to a file and edit:
+Run `ccgate claude init` / `ccgate codex init` to inspect the full default configuration. The `init` output is the **embedded defaults** -- a reference document, not the starting template. For your own overrides, write a minimal jsonnet that adds / overrides only what you need:
 
 ```bash
-ccgate claude init    > ~/.claude/ccgate.jsonnet           # Global, claude (replaces defaults)
-ccgate claude init -p > .claude/ccgate.local.jsonnet       # Project-local template, claude (appended)
-ccgate codex  init    > ~/.codex/ccgate.jsonnet            # Global, codex
+ccgate claude init           | less                   # Read the embedded Claude defaults.
+ccgate codex  init           | less                   # Same for Codex.
+ccgate claude init -p > .claude/ccgate.local.jsonnet  # Project-local skeleton you can extend.
+ccgate codex  init -p > .codex/ccgate.local.jsonnet   # Same for Codex.
 ```
+
+Need to drop one of the embedded default rules? That requires an explicit reset/override syntax which does not exist yet -- open an issue describing the rule and your motivation.
 
 ## Unattended automation (`fallthrough_strategy`)
 
@@ -250,7 +252,7 @@ The daily table shows per-day counts (Allow, Deny, Fall, F.Allow, F.Deny, Err), 
 ## Known limitations
 
 - **Plan mode correctness is prompt-only (Claude only).** Under `permission_mode == "plan"`, ccgate relies on the LLM plus prose in the system prompt to (a) reject implementation-side writes and (b) allow read-only queries without requiring an allow-guidance match. Either side can misfire. Tracked in [#37](https://github.com/tak848/ccgate/issues/37).
-- **Config file layering is asymmetric.** Global config *replaces* embedded defaults while project-local files only *append*. Narrowing / overriding rules from the project layer is not supported today. Tracked as a breaking-change refactor in [#38](https://github.com/tak848/ccgate/issues/38).
+- **No reset/override for individual embedded default rules.** Layered configs can only **add** rules and **overwrite scalars**. Deleting a specific embedded `allow` / `deny` rule from a global or project-local config is not supported today.
 - **Codex hook is upstream-experimental.** Schema and behavior may change. ccgate does not currently expose `permission_mode` from Codex, parse the Codex transcript JSONL, ingest `~/.codex/config.toml`, or apply MCP-server-specific trust hints; classification runs from `tool_name` + `tool_input` + `cwd` only.
 
 ## Documentation

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -96,5 +96,5 @@ See [docs/codex.md](codex.md) for the Codex side.
 ## Known limitations
 
 - **Plan mode is prompt-only** ([#37](https://github.com/tak848/ccgate/issues/37)).
-- **Layering asymmetry** between global (replaces) and project-local (appends) ([#38](https://github.com/tak848/ccgate/issues/38)).
+- **No reset/override for individual embedded default rules.** Layered configs can only **add** rules and **overwrite scalars**; removing a specific embedded `allow` / `deny` rule from a global / project-local config is not supported today.
 - **No deterministic short-circuit on `settings.json` deny patterns**. ccgate routes every Claude Code PermissionRequest through the LLM today; a deterministic prefilter that exits early on a literal `settings.json` deny match is a possible future optimization, not a current behavior.

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -96,5 +96,5 @@ See [docs/codex.md](codex.md) for the Codex side.
 ## Known limitations
 
 - **Plan mode is prompt-only** ([#37](https://github.com/tak848/ccgate/issues/37)).
-- **No reset/override for individual embedded default rules.** Layered configs can only **add** rules and **overwrite scalars**; removing a specific embedded `allow` / `deny` rule from a global / project-local config is not supported today.
+- **No surgical reset for a single embedded default rule.** A layer either replaces a list wholesale (`allow: [...]`) or appends to it (`append_allow: [...]`); removing one specific embedded entry while keeping the rest requires re-stating the whole list under `allow` / `deny` minus that one entry.
 - **No deterministic short-circuit on `settings.json` deny patterns**. ccgate routes every Claude Code PermissionRequest through the LLM today; a deterministic prefilter that exits early on a literal `settings.json` deny match is a possible future optimization, not a current behavior.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,12 +23,13 @@ ccgate evaluates three layers, in order, per target. Every layer composes with t
 
 | Field group | Merge behavior | Example |
 |---|---|---|
-| Lists: `allow`, `deny`, `environment` | Each layer **appends** its entries on top of the previous result. | Embedded `deny: ["A"]` + global `deny: ["B"]` + project `deny: ["C"]` → final `deny: ["A","B","C"]`. |
-| Scalars: `provider.*`, `log_*`, `metrics_*`, `fallthrough_strategy` | Each layer **overwrites** the previous value when it sets the field; layers that omit it leave the previous value untouched. | Embedded `provider.model: "claude-haiku-4-5"` + global `provider: {model: "claude-sonnet-4-6"}` → final `provider.model: "claude-sonnet-4-6"`, embedded provider.name still in effect. |
+| Lists: `allow`, `deny`, `environment` | A layer that sets the field **replaces** the carried-over list (even with `[]`). A layer that omits the field leaves the carried-over list untouched. | Embedded `allow: ["A","B"]` + global `allow: ["X"]` → final `allow: ["X"]`. |
+| Lists: `append_allow`, `append_deny`, `append_environment` | A layer that sets the field **appends** its entries to whatever the previous layers produced. | Embedded `deny: ["A"]` + project `append_deny: ["P"]` → final `deny: ["A","P"]`. |
+| Scalars: `provider.*`, `log_*`, `metrics_*`, `fallthrough_strategy` | A layer **overwrites** the value per-field when it sets it; layers that omit a field leave the previous value untouched. | Embedded `provider.model: "claude-haiku-4-5"` + global `provider: {model: "claude-sonnet-4-6"}` → final `provider.model: "claude-sonnet-4-6"`, embedded `provider.name` still in effect. |
 
-There is currently no way to **remove** an entry from a list a previous layer added. If you need to drop a specific embedded `allow` / `deny` rule from your overrides, open an issue describing the rule and the motivation. An explicit reset/override syntax is being tracked separately.
+`allow` and `append_allow` (same for the other lists) can coexist in the same layer: the replace runs first, then the append stacks onto the result. Use the pattern when you want to **swap** the embedded list for a curated one and **also** add a couple of project-specific extras: `{ allow: ['only this base'], append_allow: ['plus this project rule'] }`.
 
-> Pre-v0.6 ccgate skipped the embedded defaults whenever a global config existed (the global layer "replaced" instead of layered). v0.6 unified the semantics; see issue [#38](https://github.com/tak848/ccgate/issues/38). If your global config is a copy of `ccgate <target> init`, dedupe it after upgrading -- otherwise rules are applied twice.
+> Pre-v0.6 ccgate skipped the embedded defaults whenever a global config existed (the global layer "replaced" instead of layered). v0.6 makes embedded defaults the always-present base and uses explicit `append_*` for opt-in extension; see issue [#38](https://github.com/tak848/ccgate/issues/38). Pre-v0.6 global configs (which already used `allow:` / `deny:` to fully replace) keep their behavior with no edits. Pre-v0.6 project-local configs that used `allow:` / `deny:` / `environment:` to **add** restrictions need to rename those keys to `append_allow:` / `append_deny:` / `append_environment:` -- otherwise they now wholesale replace the inherited list.
 
 ### Why tracked files are skipped
 
@@ -148,6 +149,6 @@ The same fields exist for the log file (`log_path`, `log_disabled`, `log_max_siz
 ## Known limitations
 
 - **Plan mode (Claude only) is prompt-only.** Under `permission_mode == "plan"`, ccgate relies on the LLM plus prose in the system prompt to (a) reject implementation-side writes and (b) allow read-only queries without an explicit allow-guidance match. Either side can misfire. Tracked in [#37](https://github.com/tak848/ccgate/issues/37).
-- **No reset/override for individual embedded default rules.** Layered configs can only **add** rules and **overwrite scalars**. Removing a specific embedded `allow` / `deny` rule from a global / project-local config is not supported today.
+- **No surgical reset for a single embedded default rule.** A layer either replaces a list wholesale or appends to it; removing one specific embedded entry while keeping the rest requires re-stating the whole list under `allow` / `deny` minus that one entry.
 - **Codex hook is upstream-experimental.** The hook schema may change without notice.
 - **Codex `~/.codex/config.toml` ingestion** (`approval_policy`, `sandbox_mode`, `prefix_rules`) is not implemented yet. ccgate decides purely from the hook payload + ccgate config; if Codex's own settings would have rejected something, that signal does not reach the LLM today.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,26 +6,29 @@ Cross-target configuration reference. The [root README](../README.md) lists the 
 
 ## Where ccgate looks for config
 
-ccgate evaluates three layers, in order, per target:
+ccgate evaluates three layers, in order, per target. Every layer composes with the same merge semantics (see "How layers compose" below):
 
-1. **Embedded defaults.** Compiled into the binary. Used only when no global config exists. Inspect with `ccgate <target> init`.
-2. **Global config**, replaces the embedded defaults entirely (no merge):
+1. **Embedded defaults.** Compiled into the binary. Always applied as the base. Inspect with `ccgate <target> init`.
+2. **Global config**, layered on top of the embedded defaults if present:
    - Claude Code: `~/.claude/ccgate.jsonnet`
    - Codex CLI:   `~/.codex/ccgate.jsonnet`
-3. **Project-local overrides**, appended on top of the active base. Tracked files are ignored (see "Why tracked files are skipped" below):
+3. **Project-local overrides**, layered on top of (1)+(2). Tracked files are ignored (see "Why tracked files are skipped" below):
    - Claude Code: `{repo_root}/.claude/ccgate.local.jsonnet`
    - Codex CLI:   `{repo_root}/.codex/ccgate.local.jsonnet`
 
 `{repo_root}` is the git repo root, resolved via `git rev-parse --show-toplevel` from the hook's `cwd`. Outside a git repo the `cwd` itself is used.
 
 
-### What "replaces" vs "appends" means
+### How layers compose
 
-When the global config exists, `provider`, `log_*`, `metrics_*`, `fallthrough_strategy`, `allow`, `deny`, and `environment` are taken **entirely** from there. The embedded defaults are not merged in -- so a global config with an empty `allow` list means there is no allow guidance at all.
+| Field group | Merge behavior | Example |
+|---|---|---|
+| Lists: `allow`, `deny`, `environment` | Each layer **appends** its entries on top of the previous result. | Embedded `deny: ["A"]` + global `deny: ["B"]` + project `deny: ["C"]` → final `deny: ["A","B","C"]`. |
+| Scalars: `provider.*`, `log_*`, `metrics_*`, `fallthrough_strategy` | Each layer **overwrites** the previous value when it sets the field; layers that omit it leave the previous value untouched. | Embedded `provider.model: "claude-haiku-4-5"` + global `provider: {model: "claude-sonnet-4-6"}` → final `provider.model: "claude-sonnet-4-6"`, embedded provider.name still in effect. |
 
-Project-local configs always **append**: `allow`, `deny`, and `environment` are concatenated to the base; scalar fields (`provider`, `log_*`, `metrics_*`, `fallthrough_strategy`) are overwritten.
+There is currently no way to **remove** an entry from a list a previous layer added. If you need to drop a specific embedded `allow` / `deny` rule from your overrides, open an issue describing the rule and the motivation. An explicit reset/override syntax is being tracked separately.
 
-This asymmetry is a known wart and is tracked as a refactor in [#38](https://github.com/tak848/ccgate/issues/38).
+> Pre-v0.6 ccgate skipped the embedded defaults whenever a global config existed (the global layer "replaced" instead of layered). v0.6 unified the semantics; see issue [#38](https://github.com/tak848/ccgate/issues/38). If your global config is a copy of `ccgate <target> init`, dedupe it after upgrading -- otherwise rules are applied twice.
 
 ### Why tracked files are skipped
 
@@ -145,6 +148,6 @@ The same fields exist for the log file (`log_path`, `log_disabled`, `log_max_siz
 ## Known limitations
 
 - **Plan mode (Claude only) is prompt-only.** Under `permission_mode == "plan"`, ccgate relies on the LLM plus prose in the system prompt to (a) reject implementation-side writes and (b) allow read-only queries without an explicit allow-guidance match. Either side can misfire. Tracked in [#37](https://github.com/tak848/ccgate/issues/37).
-- **Layering asymmetry** between global (replaces) and project-local (appends). See "What 'replaces' vs 'appends' means" above. Tracked in [#38](https://github.com/tak848/ccgate/issues/38).
+- **No reset/override for individual embedded default rules.** Layered configs can only **add** rules and **overwrite scalars**. Removing a specific embedded `allow` / `deny` rule from a global / project-local config is not supported today.
 - **Codex hook is upstream-experimental.** The hook schema may change without notice.
 - **Codex `~/.codex/config.toml` ingestion** (`approval_policy`, `sandbox_mode`, `prefix_rules`) is not implemented yet. ccgate decides purely from the hook payload + ccgate config; if Codex's own settings would have rejected something, that signal does not reach the LLM today.

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -160,7 +160,12 @@ Claude Code と同じ環境変数 (`CCGATE_ANTHROPIC_API_KEY` / `ANTHROPIC_API_K
 | 2 | `~/.claude/ccgate.jsonnet` — グローバル (上に重ねる) | `~/.codex/ccgate.jsonnet` — グローバル (同じ) |
 | 3 | `{repo_root}/.claude/ccgate.local.jsonnet` — プロジェクトローカル (Git 未追跡のみ、上に重ねる) | `{repo_root}/.codex/ccgate.local.jsonnet` — プロジェクトローカル (同じ) |
 
-3 つの layer はすべて同じ merge ルールで合成されます: **list** (`allow` / `deny` / `environment`) は append、**スカラー** (`provider.*`, `log_*`, `metrics_*`, `fallthrough_strategy`) はその layer が値を設定していれば overwrite。組み込みデフォルトは常に適用されるため、グローバル設定で `provider.model` だけ書き換えても embedded の `allow` / `deny` ルールはすべて生きたままです。
+3 つの layer はすべて同じ merge ルールで合成されます:
+
+- **list**: `allow` / `deny` / `environment` は値を設定した layer が前の layer から引き継いだ list を **置き換える** (`[]` を書けば空 list に置き換え)。`append_*` 系 (`append_allow` / `append_deny` / `append_environment`) は前の layer の累積 list の **末尾に追加** する。
+- **スカラー**: `provider.*` / `log_*` / `metrics_*` / `fallthrough_strategy` はその layer がフィールドを設定していれば per-field で上書き、設定していなければ前の値を保持。
+
+`~/.<target>/ccgate.jsonnet` で `provider.model` だけ書き換えれば embedded の `allow` / `deny` はそのまま残ります。`allow: [...]` を書けば embedded の allow を完全に差し替え (これは v0.6 以前のグローバル設定がすでに行っていた挙動なので、そのまま冪等)。プロジェクトローカル設定は典型的に `append_deny: [...]` / `append_environment: [...]` で追加制限を載せます。
 プロジェクトローカル設定は **Git に追跡されていないファイルのみ** 読み込まれます。
 
 
@@ -178,9 +183,12 @@ Claude Code と同じ環境変数 (`CCGATE_ANTHROPIC_API_KEY` / `ANTHROPIC_API_K
 | `metrics_disabled`       | bool                              | `false`                                                                         | メトリクス収集を完全に無効化                                                                               |
 | `metrics_max_size`       | int                               | `2097152`                                                                       | ローテーション閾値 (bytes, デフォルト 2MB)。`0` = ローテーションなし                                       |
 | `fallthrough_strategy`   | `"ask"` / `"allow"` / `"deny"`    | `"ask"`                                                                         | LLM が判定に迷った (`fallthrough`) 際の扱い。[完全自動運転モード](#完全自動運転モード-fallthrough_strategy) 参照 |
-| `allow`                  | string[]                          | `[]`                                                                            | 許可ルール (自然言語、LLM が解釈)                                                                          |
-| `deny`                   | string[]                          | `[]`                                                                            | 拒否ルール (mandatory)。`deny_message:` ヒント対応                                                         |
-| `environment`            | string[]                          | `[]`                                                                            | LLM に渡すコンテキスト (信頼レベル、ポリシー等)                                                            |
+| `allow`                  | string[]                          | `[]`                                                                            | 許可ルール。設定すると前の layer から引き継いだ list を **完全置換**                                       |
+| `deny`                   | string[]                          | `[]`                                                                            | 拒否ルール (mandatory)。`deny_message:` ヒント対応。`allow` と同じく置換                                   |
+| `environment`            | string[]                          | `[]`                                                                            | LLM に渡すコンテキスト (信頼レベル、ポリシー等)。`allow` と同じく置換                                       |
+| `append_allow`           | string[]                          | `[]`                                                                            | 引き継いだ list の末尾に **追加**。プロジェクトローカル設定で典型的に使用                                  |
+| `append_deny`            | string[]                          | `[]`                                                                            | 引き継いだ deny list の末尾に追加                                                                          |
+| `append_environment`     | string[]                          | `[]`                                                                            | 引き継いだ environment list の末尾に追加                                                                   |
 
 `<target>` は Claude / Codex どちらの hook が呼ばれたかで `claude` / `codex` になります。`XDG_STATE_HOME` が未設定の場合は `~/.local/state/ccgate/<target>/...` が fallback として使われます。
 
@@ -251,7 +259,7 @@ ccgate codex  metrics --days 7        # codex 側、同じシェイプ
 ## 既知の制約
 
 - **Plan mode の正しさはプロンプトのみに依存 (Claude のみ)。** `permission_mode == "plan"` では、(a) 実装系 write を拒絶する判定と (b) allow guidance に載っていない read-only クエリを許可する判定の両方を、LLM とシステムプロンプトの指示文に委ねています。プロンプトで記述する以上、どちらの方向にも誤判定の余地があります。[#37](https://github.com/tak848/ccgate/issues/37) で追跡しています。
-- **embedded default ルール単位の reset/override 手段なし。** 重ねる層は **追加 (list)** と **スカラー上書き** しかできません。embedded の特定の `allow` / `deny` ルールをグローバル / プロジェクトローカル設定から削除する仕組みは現状ありません。
+- **embedded default の特定ルールだけを部分削除する手段なし。** layer は list を **完全置換** (`allow: [...]`) するか **末尾追加** (`append_allow: [...]`) するかのどちらかです。embedded の中の 1 ルールだけ消したい場合は、その 1 件を除いた残り全部を `allow:` / `deny:` に書き直すしかありません。
 - **Codex hook は upstream で experimental。** スキーマや挙動が変わる可能性があります。ccgate は現在 Codex 側の `permission_mode` を expose せず、transcript JSONL を parse せず、`~/.codex/config.toml` も取り込まず、MCP server 単位の trust hint も適用しません。判定は `tool_name` + `tool_input` + `cwd` のみで行います。
 
 ## ドキュメント

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -156,12 +156,11 @@ Claude Code と同じ環境変数 (`CCGATE_ANTHROPIC_API_KEY` / `ANTHROPIC_API_K
 
 | 順序 | Claude Code | Codex CLI |
 |----:|-------------|-----------|
-| 1 | 組み込みデフォルト (グローバル設定がない場合のフォールバック) | 同じ |
-| 2 | `~/.claude/ccgate.jsonnet` — グローバル (組み込みデフォルトを**完全に置換**) | `~/.codex/ccgate.jsonnet` — グローバル (同じ) |
-| 3 | `{repo_root}/.claude/ccgate.local.jsonnet` — プロジェクトローカル (Git 未追跡のみ、**追加**) | `{repo_root}/.codex/ccgate.local.jsonnet` — プロジェクトローカル (同じ) |
+| 1 | 組み込みデフォルト (常にベースとして適用) | 同じ |
+| 2 | `~/.claude/ccgate.jsonnet` — グローバル (上に重ねる) | `~/.codex/ccgate.jsonnet` — グローバル (同じ) |
+| 3 | `{repo_root}/.claude/ccgate.local.jsonnet` — プロジェクトローカル (Git 未追跡のみ、上に重ねる) | `{repo_root}/.codex/ccgate.local.jsonnet` — プロジェクトローカル (同じ) |
 
-グローバル設定が存在する場合、組み込みデフォルトは**使われません**。グローバル設定が完全なベースです。
-プロジェクトローカル設定は常にベースに**追加**されます (allow/deny/environment は append、provider 系は overwrite)。
+3 つの layer はすべて同じ merge ルールで合成されます: **list** (`allow` / `deny` / `environment`) は append、**スカラー** (`provider.*`, `log_*`, `metrics_*`, `fallthrough_strategy`) はその layer が値を設定していれば overwrite。組み込みデフォルトは常に適用されるため、グローバル設定で `provider.model` だけ書き換えても embedded の `allow` / `deny` ルールはすべて生きたままです。
 プロジェクトローカル設定は **Git に追跡されていないファイルのみ** 読み込まれます。
 
 
@@ -187,19 +186,22 @@ Claude Code と同じ環境変数 (`CCGATE_ANTHROPIC_API_KEY` / `ANTHROPIC_API_K
 
 ## デフォルトルール
 
-グローバル設定がない場合、ccgate は組み込みのデフォルトルールを使用します (target ごと):
+ccgate は target ごとに組み込みのデフォルトルールを持っています。常にベースとして適用され、その上にグローバル / プロジェクトローカル設定が重なります。
 
 **許可:** 読み取り専用操作、ローカル開発コマンド (project script 経由の build / test)、git フィーチャーブランチ操作、リポジトリ内に閉じたパッケージインストール。
 
 **拒否:** リモートコードのダウンロード実行 (`curl|bash`)、direct one-shot remote package execution (`npx`/`pnpx`/`bunx` 等)、git 破壊的操作 (protected branch 含む)、リポジトリ外の削除、特権昇格。
 
-`ccgate claude init` / `ccgate codex init` でデフォルト設定の全容を確認できます。カスタマイズする場合:
+`ccgate claude init` / `ccgate codex init` でデフォルト設定の全容を確認できます。`init` の出力は **embedded defaults そのもの** = リファレンス文書であって、コピペして使う出発点ではありません。自分のオーバーライドは追加 / 上書きしたい分だけを書く最小限の jsonnet にしてください:
 
 ```bash
-ccgate claude init    > ~/.claude/ccgate.jsonnet           # グローバル, claude (デフォルトを置換)
-ccgate claude init -p > .claude/ccgate.local.jsonnet       # プロジェクトローカルテンプレート, claude (追加)
-ccgate codex  init    > ~/.codex/ccgate.jsonnet            # グローバル, codex
+ccgate claude init           | less                   # Claude embedded defaults を確認
+ccgate codex  init           | less                   # Codex も同じ
+ccgate claude init -p > .claude/ccgate.local.jsonnet  # プロジェクトローカルのスケルトン
+ccgate codex  init -p > .codex/ccgate.local.jsonnet   # Codex も同じ
 ```
+
+embedded のルールを **削除** したい場合は明示的な reset/override 構文が必要ですが、現状そのような仕組みはありません。ルールと動機を Issue に書いてもらえれば検討します。
 
 ## 完全自動運転モード (`fallthrough_strategy`)
 
@@ -249,7 +251,7 @@ ccgate codex  metrics --days 7        # codex 側、同じシェイプ
 ## 既知の制約
 
 - **Plan mode の正しさはプロンプトのみに依存 (Claude のみ)。** `permission_mode == "plan"` では、(a) 実装系 write を拒絶する判定と (b) allow guidance に載っていない read-only クエリを許可する判定の両方を、LLM とシステムプロンプトの指示文に委ねています。プロンプトで記述する以上、どちらの方向にも誤判定の余地があります。[#37](https://github.com/tak848/ccgate/issues/37) で追跡しています。
-- **設定ファイル layering の非対称。** グローバル設定は組み込みデフォルトを*置換*するのに対し、プロジェクトローカルは*追加のみ*。プロジェクト層からルールを狭める/上書きする手段がありません。互換性を壊す破壊的リファクタとして [#38](https://github.com/tak848/ccgate/issues/38) で追跡しています。
+- **embedded default ルール単位の reset/override 手段なし。** 重ねる層は **追加 (list)** と **スカラー上書き** しかできません。embedded の特定の `allow` / `deny` ルールをグローバル / プロジェクトローカル設定から削除する仕組みは現状ありません。
 - **Codex hook は upstream で experimental。** スキーマや挙動が変わる可能性があります。ccgate は現在 Codex 側の `permission_mode` を expose せず、transcript JSONL を parse せず、`~/.codex/config.toml` も取り込まず、MCP server 単位の trust hint も適用しません。判定は `tool_name` + `tool_input` + `cwd` のみで行います。
 
 ## ドキュメント

--- a/docs/ja/claude.md
+++ b/docs/ja/claude.md
@@ -96,5 +96,5 @@ Codex 側の詳細は [docs/ja/codex.md](codex.md) を参照。
 ## 既知の制約
 
 - **Plan mode はプロンプト依存** ([#37](https://github.com/tak848/ccgate/issues/37))
-- **layering 非対称**: global (置換) と project-local (追加) の差 ([#38](https://github.com/tak848/ccgate/issues/38))
+- **embedded default ルール単位の reset/override 手段なし**: 重ねる層は **追加 (list)** と **スカラー上書き** のみ。embedded の特定の `allow` / `deny` ルールを設定から削除する仕組みは現状なし
 - **`settings.json` の deny パターンに対する deterministic short-circuit なし**: ccgate は現状すべての Claude Code PermissionRequest を LLM に通します。literal な `settings.json` deny match で early exit する deterministic prefilter は将来の最適化候補で、現時点の挙動ではありません

--- a/docs/ja/claude.md
+++ b/docs/ja/claude.md
@@ -96,5 +96,5 @@ Codex 側の詳細は [docs/ja/codex.md](codex.md) を参照。
 ## 既知の制約
 
 - **Plan mode はプロンプト依存** ([#37](https://github.com/tak848/ccgate/issues/37))
-- **embedded default ルール単位の reset/override 手段なし**: 重ねる層は **追加 (list)** と **スカラー上書き** のみ。embedded の特定の `allow` / `deny` ルールを設定から削除する仕組みは現状なし
+- **embedded default の特定ルールだけを部分削除する手段なし**: layer は list を **完全置換** (`allow: [...]`) するか **末尾追加** (`append_allow: [...]`) するかのどちらかで、embedded の中の 1 ルールだけ消したい場合は残り全部を `allow:` / `deny:` に書き直すしかない
 - **`settings.json` の deny パターンに対する deterministic short-circuit なし**: ccgate は現状すべての Claude Code PermissionRequest を LLM に通します。literal な `settings.json` deny match で early exit する deterministic prefilter は将来の最適化候補で、現時点の挙動ではありません

--- a/docs/ja/configuration.md
+++ b/docs/ja/configuration.md
@@ -6,26 +6,29 @@ target 横断の設定リファレンス。[ルート README (docs/ja/README.md)
 
 ## ccgate が config を探す場所
 
-ccgate は target ごとに 3 layer を順に評価します:
+ccgate は target ごとに 3 layer を順に評価します。すべての layer は同じ merge セマンティクスで合成されます (後述「layer の合成ルール」参照):
 
-1. **埋込デフォルト**: バイナリに同梱。グローバル設定が無い場合のみ使用。`ccgate <target> init` で確認可能
-2. **グローバル設定**: 埋込デフォルトを**完全に置換** (merge しない):
+1. **埋込デフォルト**: バイナリに同梱。常にベースとして適用。`ccgate <target> init` で確認可能
+2. **グローバル設定**: 存在すれば埋込デフォルトの上に重ねる:
    - Claude Code: `~/.claude/ccgate.jsonnet`
    - Codex CLI:   `~/.codex/ccgate.jsonnet`
-3. **プロジェクトローカル**: 上記ベースに**追加** (append)。tracked file は無視される (後述「tracked file が無視される理由」):
+3. **プロジェクトローカル**: (1)+(2) の上に重ねる。tracked file は無視される (後述「tracked file が無視される理由」):
    - Claude Code: `{repo_root}/.claude/ccgate.local.jsonnet`
    - Codex CLI:   `{repo_root}/.codex/ccgate.local.jsonnet`
 
 `{repo_root}` は git repo root で、hook の `cwd` から `git rev-parse --show-toplevel` で解決します。git repo 外では `cwd` 自体が使われます。
 
 
-### 「置換」と「追加」の意味
+### layer の合成ルール
 
-グローバル設定が存在する場合、`provider` / `log_*` / `metrics_*` / `fallthrough_strategy` / `allow` / `deny` / `environment` は**全て**そこから取られます。埋込デフォルトは merge されないので、グローバル設定で `allow` を空にすると allow guidance が一切無い状態になります。
+| field 群 | merge 動作 | 例 |
+|---|---|---|
+| list: `allow` / `deny` / `environment` | 各 layer が前の結果に対して **append** する | embedded `deny: ["A"]` + global `deny: ["B"]` + project `deny: ["C"]` → 最終 `deny: ["A","B","C"]` |
+| スカラー: `provider.*` / `log_*` / `metrics_*` / `fallthrough_strategy` | 各 layer が値を設定していれば **overwrite**、設定していなければ前の値を保持 | embedded `provider.model: "claude-haiku-4-5"` + global `provider: {model: "claude-sonnet-4-6"}` → 最終 `provider.model: "claude-sonnet-4-6"`、embedded の `provider.name` は生きたまま |
 
-プロジェクトローカル設定は常に**追加**です: `allow` / `deny` / `environment` はベースに concatenate、scalar field (`provider` / `log_*` / `metrics_*` / `fallthrough_strategy`) は overwrite。
+前の layer が追加した list 要素を **削除** する仕組みは現在ありません。embedded の特定の `allow` / `deny` ルールを削除したい場合は、ルール内容と動機を Issue に書いてもらえれば検討します。明示的な reset/override 構文は別途追跡しています。
 
-この非対称仕様は既知の課題で、refactor として [#38](https://github.com/tak848/ccgate/issues/38) で追跡しています。
+> v0.6 以前の ccgate はグローバル設定が存在すると埋込デフォルトをスキップしていました (グローバル層が「置換」していた)。v0.6 でセマンティクスを統一しています。詳細は [#38](https://github.com/tak848/ccgate/issues/38) を参照。グローバル設定が `ccgate <target> init` のコピーになっている場合は、アップグレード後に重複ルールを掃除してください (そうしないとルールが二重適用されます)。
 
 ### tracked file が無視される理由
 
@@ -145,6 +148,6 @@ ccgate codex  metrics --days 7         # codex 側も同 shape
 ## 既知の制約
 
 - **Plan mode (Claude のみ) はプロンプト依存**: `permission_mode == "plan"` では (a) 実装系 write を拒絶する判定と (b) 明示的な allow guidance なしの read-only クエリ許可 を、LLM とシステムプロンプトの指示文に委ねています。どちらの方向にも誤判定の余地あり。[#37](https://github.com/tak848/ccgate/issues/37) で追跡
-- **layering 非対称**: global (置換) と project-local (追加) の差。前述「『置換』と『追加』の意味」参照。[#38](https://github.com/tak848/ccgate/issues/38) で追跡
+- **embedded default ルール単位の reset/override 手段なし**: 重ねる層は **追加 (list)** と **スカラー上書き** のみ。embedded の特定の `allow` / `deny` ルールをグローバル / プロジェクトローカル設定から削除する仕組みは現状なし
 - **Codex hook は upstream で experimental**: hook schema が予告なく変更される可能性あり
 - **Codex `~/.codex/config.toml` 取り込み未実装** (`approval_policy`, `sandbox_mode`, `prefix_rules`): ccgate は hook payload + ccgate config だけで判定するため、Codex 自身の設定が拒絶するはずだった操作のシグナルは LLM に届かない (現状)

--- a/docs/ja/configuration.md
+++ b/docs/ja/configuration.md
@@ -23,12 +23,13 @@ ccgate は target ごとに 3 layer を順に評価します。すべての laye
 
 | field 群 | merge 動作 | 例 |
 |---|---|---|
-| list: `allow` / `deny` / `environment` | 各 layer が前の結果に対して **append** する | embedded `deny: ["A"]` + global `deny: ["B"]` + project `deny: ["C"]` → 最終 `deny: ["A","B","C"]` |
-| スカラー: `provider.*` / `log_*` / `metrics_*` / `fallthrough_strategy` | 各 layer が値を設定していれば **overwrite**、設定していなければ前の値を保持 | embedded `provider.model: "claude-haiku-4-5"` + global `provider: {model: "claude-sonnet-4-6"}` → 最終 `provider.model: "claude-sonnet-4-6"`、embedded の `provider.name` は生きたまま |
+| list: `allow` / `deny` / `environment` | 値を設定した layer が前の layer から引き継いだ list を **置き換える** (`[]` でも置換)。設定していない layer は前の値を保持 | embedded `allow: ["A","B"]` + global `allow: ["X"]` → 最終 `allow: ["X"]` |
+| list: `append_allow` / `append_deny` / `append_environment` | 値を設定した layer が前の layer の累積 list の **末尾に追加** | embedded `deny: ["A"]` + project `append_deny: ["P"]` → 最終 `deny: ["A","P"]` |
+| スカラー: `provider.*` / `log_*` / `metrics_*` / `fallthrough_strategy` | 各 layer が値を設定していれば per-field で **overwrite**、設定していなければ前の値を保持 | embedded `provider.model: "claude-haiku-4-5"` + global `provider: {model: "claude-sonnet-4-6"}` → 最終 `provider.model: "claude-sonnet-4-6"`、embedded の `provider.name` は生きたまま |
 
-前の layer が追加した list 要素を **削除** する仕組みは現在ありません。embedded の特定の `allow` / `deny` ルールを削除したい場合は、ルール内容と動機を Issue に書いてもらえれば検討します。明示的な reset/override 構文は別途追跡しています。
+`allow` と `append_allow` (他 list も同じ) は同じ layer に共存可能 — 先に置換、その結果に対して append が積まれる。embedded の list を厳選版に **差し替えつつ** プロジェクト固有のルールを **追加** したいときに使います: `{ allow: ['only this base'], append_allow: ['plus this project rule'] }`。
 
-> v0.6 以前の ccgate はグローバル設定が存在すると埋込デフォルトをスキップしていました (グローバル層が「置換」していた)。v0.6 でセマンティクスを統一しています。詳細は [#38](https://github.com/tak848/ccgate/issues/38) を参照。グローバル設定が `ccgate <target> init` のコピーになっている場合は、アップグレード後に重複ルールを掃除してください (そうしないとルールが二重適用されます)。
+> v0.6 以前の ccgate はグローバル設定が存在すると埋込デフォルトをスキップしていました (グローバル層が「置換」していた)。v0.6 では embedded を常にベースとして適用しつつ、明示的な opt-in 拡張として `append_*` を導入しています。詳細は [#38](https://github.com/tak848/ccgate/issues/38) を参照。v0.6 以前のグローバル設定 (もともと `allow:` / `deny:` で完全置換していた) は無編集で同じ挙動になります。v0.6 以前のプロジェクトローカル設定で `allow:` / `deny:` / `environment:` を **追加** 目的で使っていた人だけ、`append_allow:` / `append_deny:` / `append_environment:` への rename が必要です (そのままだと累積 list を完全置換してしまいます)。
 
 ### tracked file が無視される理由
 
@@ -148,6 +149,6 @@ ccgate codex  metrics --days 7         # codex 側も同 shape
 ## 既知の制約
 
 - **Plan mode (Claude のみ) はプロンプト依存**: `permission_mode == "plan"` では (a) 実装系 write を拒絶する判定と (b) 明示的な allow guidance なしの read-only クエリ許可 を、LLM とシステムプロンプトの指示文に委ねています。どちらの方向にも誤判定の余地あり。[#37](https://github.com/tak848/ccgate/issues/37) で追跡
-- **embedded default ルール単位の reset/override 手段なし**: 重ねる層は **追加 (list)** と **スカラー上書き** のみ。embedded の特定の `allow` / `deny` ルールをグローバル / プロジェクトローカル設定から削除する仕組みは現状なし
+- **embedded default の特定ルールだけを部分削除する手段なし**: layer は list を **完全置換** (`allow: [...]`) するか **末尾追加** (`append_allow: [...]`) するかのどちらかで、embedded の中の 1 ルールだけ消したい場合は残り全部を `allow:` / `deny:` に書き直すしかない
 - **Codex hook は upstream で experimental**: hook schema が予告なく変更される可能性あり
 - **Codex `~/.codex/config.toml` 取り込み未実装** (`approval_policy`, `sandbox_mode`, `prefix_rules`): ccgate は hook payload + ccgate config だけで判定するため、Codex 自身の設定が拒絶するはずだった操作のシグナルは LLM に届かない (現状)

--- a/internal/cmd/claude/defaults_project.jsonnet
+++ b/internal/cmd/claude/defaults_project.jsonnet
@@ -15,14 +15,19 @@
   //                                  // (Claude Code only delivers hook messages on deny, so
   //                                  //  Claude will not see any warning when this fires.)
 
-  deny: [
+  // `allow` / `deny` / `environment` REPLACE the value carried over
+  // from earlier layers (embedded defaults + ~/.claude/ccgate.jsonnet).
+  // For project-local overrides you almost always want to ADD on top
+  // instead -- use the `append_*` keys below.
+
+  append_deny: [
     // Add project-specific deny rules here.
     // Examples:
     // 'Network Access: Deny curl, wget, or HTTP requests to external services. deny_message: Network access is restricted in this project.',
     // 'Script Execution: Deny running shell scripts (.sh, .bash) from this repository. deny_message: Script execution is restricted in this project.',
   ],
 
-  environment: [
+  append_environment: [
     // Describe the project context for the LLM.
     // Examples:
     // '**Untrusted repository**: Apply strict security policies.',

--- a/internal/cmd/codex/defaults_project.jsonnet
+++ b/internal/cmd/codex/defaults_project.jsonnet
@@ -14,14 +14,19 @@
   //                                  // (Codex only delivers hook messages on deny, so
   //                                  //  Codex will not see any warning when this fires.)
 
-  deny: [
+  // `allow` / `deny` / `environment` REPLACE the value carried over
+  // from earlier layers (embedded defaults + ~/.codex/ccgate.jsonnet).
+  // For project-local overrides you almost always want to ADD on top
+  // instead -- use the `append_*` keys below.
+
+  append_deny: [
     // Add project-specific deny rules here.
     // Examples:
     // 'Network Access: Deny curl, wget, or HTTP requests to external services. deny_message: Network access is restricted in this project.',
     // 'Script Execution: Deny running shell scripts (.sh, .bash) from this repository. deny_message: Script execution is restricted in this project.',
   ],
 
-  environment: [
+  append_environment: [
     // Describe the project context for the LLM.
     // Examples:
     // '**Untrusted repository**: Apply strict security policies.',

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -201,12 +201,14 @@ type LoadOptions struct {
 	GlobalConfigPath string
 	// ProjectLocalRelativePaths lists project-local config locations
 	// relative to the repo root (or cwd when not in a git repo).
-	// Each candidate is read in order and **appended** on top of the
-	// global / embedded base. Tracked files are skipped via gitutil.
+	// Each candidate is read in order and layered on top of the
+	// global / embedded base using the same replace-or-append-*
+	// semantics every layer follows (see Load). Tracked files are
+	// skipped via gitutil.
 	ProjectLocalRelativePaths []string
-	// EmbedDefaults is the embedded jsonnet snippet applied when the
-	// global config is absent. Targets ship their own defaults via
-	// //go:embed.
+	// EmbedDefaults is the embedded jsonnet snippet always applied
+	// as the first layer (the always-present base ccgate ships
+	// with). Targets ship their own defaults via //go:embed.
 	EmbedDefaults string
 	// DefaultLogPath is used when neither the global nor any
 	// project-local config sets log_path. Empty string falls back
@@ -225,7 +227,17 @@ func StateDir(sub string) string {
 }
 
 // Load composes the runtime config from three layers, all using the
-// same merge semantics (lists append, scalars overwrite):
+// same merge semantics:
+//
+//   - lists `allow` / `deny` / `environment` REPLACE the carried-over
+//     value when the layer sets them (an explicit empty list clears),
+//   - lists `append_allow` / `append_deny` / `append_environment` ADD
+//     onto the carried-over value (can coexist with the replace-mode
+//     field; replace runs first, append stacks),
+//   - scalars (`provider.*` / `log_*` / `metrics_*` /
+//     `fallthrough_strategy`) overwrite per-field when set.
+//
+// Layers, applied in order:
 //
 //  1. opts.EmbedDefaults -- always applied first, the always-present
 //     base ccgate ships with.
@@ -235,9 +247,9 @@ func StateDir(sub string) string {
 //
 // Pre-v0.6 ccgate skipped step 1 whenever step 2 succeeded, which
 // made the global layer "replace" embedded defaults while project
-// layers always "appended". v0.6 unifies the two so users no longer
-// have to copy the embedded defaults verbatim into their global
-// config just to keep them; see issue #38 for the discussion.
+// layers always "appended". v0.6 makes embedded defaults the
+// always-present base and adds explicit `append_*` keys for opt-in
+// extension; see issue #38 for the discussion.
 func Load(opts LoadOptions, cwd string) (LoadResult, error) {
 	cfg := Default()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -211,21 +211,30 @@ func StateDir(sub string) string {
 	return filepath.Join(stateDir(), sub)
 }
 
-// Load reads the base config from opts.GlobalConfigPath and merges
-// project-local overrides found at opts.ProjectLocalRelativePaths
-// (resolved against the git repo root, or cwd when not in a repo).
-// If no global config exists, opts.EmbedDefaults is used as fallback.
+// Load composes the runtime config from three layers, all using the
+// same merge semantics (lists append, scalars overwrite):
+//
+//  1. opts.EmbedDefaults -- always applied first, the always-present
+//     base ccgate ships with.
+//  2. opts.GlobalConfigPath -- if the file exists, layered on top.
+//  3. opts.ProjectLocalRelativePaths -- each existing untracked file
+//     under the repo root, layered on top in the order given.
+//
+// Pre-v0.6 ccgate skipped step 1 whenever step 2 succeeded, which
+// made the global layer "replace" embedded defaults while project
+// layers always "appended". v0.6 unifies the two so users no longer
+// have to copy the embedded defaults verbatim into their global
+// config just to keep them; see issue #38 for the discussion.
 func Load(opts LoadOptions, cwd string) (LoadResult, error) {
 	cfg := Default()
 
+	if err := mergeConfigString(opts.EmbedDefaults, &cfg); err != nil {
+		return LoadResult{Config: cfg}, fmt.Errorf("embedded defaults: %w", err)
+	}
+
 	source := SourceEmbeddedDefaults
 	if err := mergeConfigFile(opts.GlobalConfigPath, &cfg); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			// No global config: use embedded defaults as fallback.
-			if err := mergeConfigString(opts.EmbedDefaults, &cfg); err != nil {
-				return LoadResult{Config: cfg}, fmt.Errorf("embedded defaults: %w", err)
-			}
-		} else {
+		if !errors.Is(err, os.ErrNotExist) {
 			return LoadResult{Config: cfg}, fmt.Errorf("base config %s: %w", opts.GlobalConfigPath, err)
 		}
 	} else {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,9 +43,22 @@ type Config struct {
 	MetricsDisabled     *bool          `json:"metrics_disabled,omitempty"`
 	MetricsMaxSize      *int64         `json:"metrics_max_size,omitempty"`
 	FallthroughStrategy *string        `json:"fallthrough_strategy,omitempty"`
-	Allow               []string       `json:"allow,omitempty"`
-	Deny                []string       `json:"deny,omitempty"`
-	Environment         []string       `json:"environment,omitempty"`
+	// Allow / Deny / Environment replace the value carried over from
+	// previous layers when the layer sets them (even to []). Embedded
+	// defaults are always layer 0, so writing `allow: [...]` in your
+	// global or project-local config completely overrides ccgate's
+	// shipped allow list. Use AppendAllow / AppendDeny / AppendEnvironment
+	// when you want to add on top instead.
+	Allow       []string `json:"allow,omitempty"`
+	Deny        []string `json:"deny,omitempty"`
+	Environment []string `json:"environment,omitempty"`
+	// AppendAllow / AppendDeny / AppendEnvironment append onto the
+	// list carried over from previous layers regardless of whether
+	// the same layer also sets the replace-mode field. Typical
+	// project-local use is `append_deny: ['<repo-specific>']`.
+	AppendAllow       []string `json:"append_allow,omitempty"`
+	AppendDeny        []string `json:"append_deny,omitempty"`
+	AppendEnvironment []string `json:"append_environment,omitempty"`
 }
 
 // GetFallthroughStrategy returns the configured strategy for LLM fallthrough,
@@ -369,9 +382,32 @@ func mergeConfigJSON(data string, cfg *Config) error {
 		cfg.FallthroughStrategy = override.FallthroughStrategy
 	}
 
-	cfg.Allow = append(cfg.Allow, override.Allow...)
-	cfg.Deny = append(cfg.Deny, override.Deny...)
-	cfg.Environment = append(cfg.Environment, override.Environment...)
+	// Lists: `allow` / `deny` / `environment` REPLACE the value
+	// carried over from earlier layers when the current layer sets
+	// the field (non-nil, even an explicit empty list). Layers that
+	// omit the field leave the prior value untouched. `append_*`
+	// extends instead of replacing -- both forms can coexist in the
+	// same layer, in which case the replace runs first and the
+	// append stacks onto the result.
+	if override.Allow != nil {
+		cfg.Allow = override.Allow
+	}
+	cfg.Allow = append(cfg.Allow, override.AppendAllow...)
+	if override.Deny != nil {
+		cfg.Deny = override.Deny
+	}
+	cfg.Deny = append(cfg.Deny, override.AppendDeny...)
+	if override.Environment != nil {
+		cfg.Environment = override.Environment
+	}
+	cfg.Environment = append(cfg.Environment, override.AppendEnvironment...)
+
+	// `append_*` is parse-time-only; clear so the resolved Config
+	// reflects the merged final lists in `Allow` / `Deny` /
+	// `Environment` and never leaks the per-layer extensions.
+	cfg.AppendAllow = nil
+	cfg.AppendDeny = nil
+	cfg.AppendEnvironment = nil
 
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -278,14 +278,20 @@ func TestLoadFallsBackToEmbedDefaultsWhenNoGlobalConfig(t *testing.T) {
 	}
 }
 
-func TestLoadUsesGlobalConfigWhenPresent(t *testing.T) {
+func TestLoadGlobalConfigLayersOnTopOfEmbeddedDefaults(t *testing.T) {
 	// t.Setenv is incompatible with t.Parallel.
 	dir := t.TempDir()
 	fakeDir := filepath.Join(dir, ".fake")
 	if err := os.MkdirAll(fakeDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	content := `{ provider: { name: 'anthropic', model: 'claude-haiku-4-5' }, allow: ['Custom allow'] }`
+	// Issue #38: the global layer must compose with embedded defaults
+	// (lists append, scalars overwrite) instead of replacing them
+	// outright. fakeLoadOptions seeds the embedded defaults with
+	// allow=["default-allow"] and deny=["default-deny"]; the global
+	// config below adds one extra allow rule and overrides the model
+	// scalar without touching deny.
+	content := `{ provider: { model: 'claude-sonnet-4-6' }, allow: ['Custom allow'] }`
 	if err := os.WriteFile(filepath.Join(fakeDir, BaseConfigName), []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -298,13 +304,16 @@ func TestLoadUsesGlobalConfigWhenPresent(t *testing.T) {
 	if lr.Source != SourceGlobalConfig {
 		t.Fatalf("source = %q, want %q", lr.Source, SourceGlobalConfig)
 	}
-	if len(lr.Config.Allow) != 1 || lr.Config.Allow[0] != "Custom allow" {
-		t.Fatalf("unexpected allow: %v", lr.Config.Allow)
+	wantAllow := []string{"default-allow", "Custom allow"}
+	if !reflect.DeepEqual(lr.Config.Allow, wantAllow) {
+		t.Fatalf("allow = %v, want %v (embedded defaults must survive the global layer)", lr.Config.Allow, wantAllow)
 	}
-	// Deny should be empty (embed defaults not applied because the
-	// global config replaces them).
-	if len(lr.Config.Deny) != 0 {
-		t.Fatalf("expected no deny rules (embed defaults not applied), got %v", lr.Config.Deny)
+	wantDeny := []string{"default-deny"}
+	if !reflect.DeepEqual(lr.Config.Deny, wantDeny) {
+		t.Fatalf("deny = %v, want %v (embedded defaults must survive when global layer omits the field)", lr.Config.Deny, wantDeny)
+	}
+	if lr.Config.Provider.Model != "claude-sonnet-4-6" {
+		t.Fatalf("provider.model = %q, want %q (scalar overwrite must beat embedded default)", lr.Config.Provider.Model, "claude-sonnet-4-6")
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -135,7 +135,7 @@ func TestValidateZeroTimeoutIsValid(t *testing.T) {
 	}
 }
 
-func TestMergeConfigFileAppendsGuidance(t *testing.T) {
+func TestMergeConfigFileLoadsGuidance(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -148,6 +148,9 @@ func TestMergeConfigFileAppendsGuidance(t *testing.T) {
 	if err := mergeConfigFile(path, &cfg); err != nil {
 		t.Fatal(err)
 	}
+	// Default() ships an empty allow list, so replace and append both
+	// observe the same result here. The replace-vs-append distinction
+	// when the base is non-empty lives in TestLoadLayerSemantics.
 	if len(cfg.Allow) != 1 || cfg.Allow[0] != "Read-only test guidance" {
 		t.Fatalf("unexpected allow: %v", cfg.Allow)
 	}
@@ -278,42 +281,101 @@ func TestLoadFallsBackToEmbedDefaultsWhenNoGlobalConfig(t *testing.T) {
 	}
 }
 
-func TestLoadGlobalConfigLayersOnTopOfEmbeddedDefaults(t *testing.T) {
-	// t.Setenv is incompatible with t.Parallel.
-	dir := t.TempDir()
-	fakeDir := filepath.Join(dir, ".fake")
-	if err := os.MkdirAll(fakeDir, 0o755); err != nil {
-		t.Fatal(err)
+func TestLoadLayerSemantics(t *testing.T) {
+	// fakeLoadOptions seeds the embedded layer with
+	// allow=["default-allow"] and deny=["default-deny"]; each test
+	// layers a global config on top with a different shape so the
+	// per-field merge contract is exercised end-to-end (replace via
+	// `allow`, extend via `append_allow`, scalar overwrite, omitted
+	// fields fall through to the embedded value).
+	type want struct {
+		allow []string
+		deny  []string
+		model string
 	}
-	// Issue #38: the global layer must compose with embedded defaults
-	// (lists append, scalars overwrite) instead of replacing them
-	// outright. fakeLoadOptions seeds the embedded defaults with
-	// allow=["default-allow"] and deny=["default-deny"]; the global
-	// config below adds one extra allow rule and overrides the model
-	// scalar without touching deny.
-	content := `{ provider: { model: 'claude-sonnet-4-6' }, allow: ['Custom allow'] }`
-	if err := os.WriteFile(filepath.Join(fakeDir, BaseConfigName), []byte(content), 0o644); err != nil {
-		t.Fatal(err)
+	cases := map[string]struct {
+		global string
+		want   want
+	}{
+		"global omits lists -- embedded survives": {
+			global: `{ provider: { model: 'claude-sonnet-4-6' } }`,
+			want: want{
+				allow: []string{"default-allow"},
+				deny:  []string{"default-deny"},
+				model: "claude-sonnet-4-6",
+			},
+		},
+		"global allow replaces embedded allow": {
+			global: `{ allow: ['Custom allow'] }`,
+			want: want{
+				allow: []string{"Custom allow"},
+				deny:  []string{"default-deny"},
+				model: "claude-haiku-4-5",
+			},
+		},
+		"global append_allow extends embedded allow": {
+			global: `{ append_allow: ['Custom allow'] }`,
+			want: want{
+				allow: []string{"default-allow", "Custom allow"},
+				deny:  []string{"default-deny"},
+				model: "claude-haiku-4-5",
+			},
+		},
+		"global allow=[] replaces embedded allow with empty": {
+			global: `{ allow: [] }`,
+			want: want{
+				allow: []string{},
+				deny:  []string{"default-deny"},
+				model: "claude-haiku-4-5",
+			},
+		},
+		"global allow + append_allow stack": {
+			global: `{ allow: ['Replaced'], append_allow: ['Then appended'] }`,
+			want: want{
+				allow: []string{"Replaced", "Then appended"},
+				deny:  []string{"default-deny"},
+				model: "claude-haiku-4-5",
+			},
+		},
 	}
-	setHomeEnv(t, dir)
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// t.Setenv is incompatible with t.Parallel.
+			dir := t.TempDir()
+			fakeDir := filepath.Join(dir, ".fake")
+			if err := os.MkdirAll(fakeDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(fakeDir, BaseConfigName), []byte(tc.global), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			setHomeEnv(t, dir)
 
-	lr, err := Load(fakeLoadOptions(dir), "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if lr.Source != SourceGlobalConfig {
-		t.Fatalf("source = %q, want %q", lr.Source, SourceGlobalConfig)
-	}
-	wantAllow := []string{"default-allow", "Custom allow"}
-	if !reflect.DeepEqual(lr.Config.Allow, wantAllow) {
-		t.Fatalf("allow = %v, want %v (embedded defaults must survive the global layer)", lr.Config.Allow, wantAllow)
-	}
-	wantDeny := []string{"default-deny"}
-	if !reflect.DeepEqual(lr.Config.Deny, wantDeny) {
-		t.Fatalf("deny = %v, want %v (embedded defaults must survive when global layer omits the field)", lr.Config.Deny, wantDeny)
-	}
-	if lr.Config.Provider.Model != "claude-sonnet-4-6" {
-		t.Fatalf("provider.model = %q, want %q (scalar overwrite must beat embedded default)", lr.Config.Provider.Model, "claude-sonnet-4-6")
+			lr, err := Load(fakeLoadOptions(dir), "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if lr.Source != SourceGlobalConfig {
+				t.Fatalf("source = %q, want %q", lr.Source, SourceGlobalConfig)
+			}
+			if !reflect.DeepEqual(lr.Config.Allow, tc.want.allow) {
+				t.Errorf("allow = %v, want %v", lr.Config.Allow, tc.want.allow)
+			}
+			if !reflect.DeepEqual(lr.Config.Deny, tc.want.deny) {
+				t.Errorf("deny = %v, want %v", lr.Config.Deny, tc.want.deny)
+			}
+			if lr.Config.Provider.Model != tc.want.model {
+				t.Errorf("provider.model = %q, want %q", lr.Config.Provider.Model, tc.want.model)
+			}
+			// AppendAllow / AppendDeny / AppendEnvironment are
+			// parse-time-only knobs. They must not leak into the
+			// resolved Config, otherwise downstream consumers (e.g.
+			// schema-export, debug dumps) would see duplicate state.
+			if lr.Config.AppendAllow != nil || lr.Config.AppendDeny != nil || lr.Config.AppendEnvironment != nil {
+				t.Errorf("append_* fields leaked into resolved config: allow=%v deny=%v env=%v",
+					lr.Config.AppendAllow, lr.Config.AppendDeny, lr.Config.AppendEnvironment)
+			}
+		})
 	}
 }
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -223,10 +223,6 @@ func Run(stdin io.Reader, stdout io.Writer, opts config.LoadOptions, runOpts ...
 	defer cleanup()
 	slog.SetDefault(logger)
 
-	if lr.Source == config.SourceGlobalConfig && len(cfg.Allow) == 0 && len(cfg.Deny) == 0 {
-		slog.Warn("allow and deny rules are both empty; embedded defaults were not applied because a global config exists")
-	}
-
 	slog.Info("hook invoked",
 		"tool", input.ToolName,
 		"permission_mode", input.PermissionMode,

--- a/schemas/claude.schema.json
+++ b/schemas/claude.schema.json
@@ -60,6 +60,24 @@
       },
       "type": "array"
     },
+    "append_allow": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "append_deny": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "append_environment": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
     "$schema": {
       "type": "string",
       "format": "uri",

--- a/schemas/codex.schema.json
+++ b/schemas/codex.schema.json
@@ -60,6 +60,24 @@
       },
       "type": "array"
     },
+    "append_allow": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "append_deny": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "append_environment": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
     "$schema": {
       "type": "string",
       "format": "uri",


### PR DESCRIPTION
## Why

Pre-v0.6 ccgate skipped its embedded defaults whenever a global
\`~/.<target>/ccgate.jsonnet\` existed, while project-local
\`{repo_root}/.<target>/ccgate.local.jsonnet\` always appended on top.
The asymmetric \"global replaces, project appends\" contract surprised
every user who tried to write a global config expecting to extend
the embedded rules instead of swap them out (issue #38).

The first attempt at a fix made every layer append onto the
embedded defaults symmetrically. That was non-idempotent: a global
config that copied the embedded defaults verbatim (typical
post-\`ccgate <target> init\` shape) saw every default rule applied
twice after upgrade. Walk that back and implement the design the
maintainer asked for in the PR review.

## What

- Embedded defaults are always the base (the only piece of the
  \"symmetric layering\" first attempt that survives).
- \`allow\` / \`deny\` / \`environment\` REPLACE the value carried over
  from earlier layers when the layer sets them, including the
  explicit empty list (\`allow: []\` clears the carried-over allow).
  When the layer omits the field the prior value passes through
  unchanged. Each list is judged independently.
- New \`append_allow\` / \`append_deny\` / \`append_environment\` fields
  ADD on top of the carried-over list. They can coexist with the
  replace-mode field in the same layer (replace runs first, append
  stacks onto the result).
- Per-field scalar overwrite for \`provider.*\` / \`log_*\` /
  \`metrics_*\` / \`fallthrough_strategy\` is unchanged from v0.5.
- Both targets' \`defaults_project.jsonnet\` templates now use
  \`append_deny\` / \`append_environment\` so the \`init -p\` output
  guides users into the additive pattern by default.
- Schemas regenerated to expose the new keys to editor validation.

### Migration

- Pre-v0.6 global configs (the ones that already used \`allow:\` /
  \`deny:\` to fully replace) keep their behavior with no edits --
  **idempotent**.
- Pre-v0.6 project-local configs that used \`allow:\` / \`deny:\` /
  \`environment:\` to **add** restrictions need to rename those keys
  to \`append_allow:\` / \`append_deny:\` / \`append_environment:\`,
  otherwise they now wholesale replace the inherited list. This is
  the **only** breaking case.

### Tests

\`TestLoadLayerSemantics\` is a table-driven matrix covering the
cases the maintainer walked through in review:

- nothing -> embedded
- replace
- append
- replace + append in the same layer
- \`allow: []\` clears
- project on top of global, replace and append variants

Plus an assertion that the parse-time \`append_*\` fields are cleared
from the resolved Config so downstream consumers (debug dumps,
schema-export) never see them.