### PR TITLE
feat: add OpenAI and Gemini provider support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/openai/openai-go v1.12.0 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uO
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/openai/openai-go v1.12.0 h1:NBQCnXzqOTv5wsgNC36PrFEiskGfO5wccfCWDo9S1U0=
+github.com/openai/openai-go v1.12.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=

--- a/internal/cmd/claude/defaults.jsonnet
+++ b/internal/cmd/claude/defaults.jsonnet
@@ -8,6 +8,9 @@
   provider: {
     name: 'anthropic',
     model: 'claude-haiku-4-5',
+    // Alternatives:
+    //   name: 'openai',  model: 'gpt-4o-mini',       (env: OPENAI_API_KEY)
+    //   name: 'gemini',  model: 'gemini-2.0-flash',   (env: GEMINI_API_KEY)
     // timeout_ms defaults to 20000 (from Go constant DefaultTimeoutMS).
     // Uncomment to override: timeout_ms: 40000,
   },

--- a/internal/cmd/codex/defaults.jsonnet
+++ b/internal/cmd/codex/defaults.jsonnet
@@ -18,6 +18,9 @@
   provider: {
     name: 'anthropic',
     model: 'claude-haiku-4-5',
+    // Alternatives:
+    //   name: 'openai',  model: 'gpt-4o-mini',       (env: OPENAI_API_KEY)
+    //   name: 'gemini',  model: 'gemini-2.0-flash',   (env: GEMINI_API_KEY)
   },
 
   // What to do when the LLM is uncertain (returns "fallthrough"):

--- a/internal/llm/gemini/client.go
+++ b/internal/llm/gemini/client.go
@@ -1,0 +1,44 @@
+// Package gemini implements llm.Provider against the Google Gemini API
+// via its OpenAI-compatible endpoint. Internally it delegates to the
+// openai.Client so no separate HTTP logic is needed.
+package gemini
+
+import (
+	"context"
+	"errors"
+
+	"github.com/tak848/ccgate/internal/llm"
+	"github.com/tak848/ccgate/internal/llm/openai"
+)
+
+// DefaultBaseURL is the Gemini OpenAI-compatible endpoint.
+// See https://ai.google.dev/gemini-api/docs/openai
+const DefaultBaseURL = "https://generativelanguage.googleapis.com/v1beta/openai/"
+
+// ErrNoAPIKey is returned by Decide when neither
+// CCGATE_GEMINI_API_KEY nor GEMINI_API_KEY is set.
+var ErrNoAPIKey = errors.New("gemini: no API key set (CCGATE_GEMINI_API_KEY / GEMINI_API_KEY)")
+
+// Client implements llm.Provider against the Gemini OpenAI-compatible
+// endpoint. APIKey is required; BaseURL overrides the default endpoint
+// for testing.
+type Client struct {
+	APIKey  string
+	BaseURL string
+}
+
+// Decide delegates to openai.Client pointed at the Gemini endpoint.
+func (c *Client) Decide(ctx context.Context, p llm.Prompt) (llm.Result, error) {
+	if c.APIKey == "" {
+		return llm.Result{}, ErrNoAPIKey
+	}
+	baseURL := c.BaseURL
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+	inner := &openai.Client{
+		APIKey:  c.APIKey,
+		BaseURL: baseURL,
+	}
+	return inner.Decide(ctx, p)
+}

--- a/internal/llm/openai/client.go
+++ b/internal/llm/openai/client.go
@@ -1,0 +1,139 @@
+// Package openai implements llm.Provider against the OpenAI Chat
+// Completions API. The client is target-agnostic: callers build their
+// own Prompt and feed it through Decide.
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/invopop/jsonschema"
+	openaigo "github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+	"github.com/openai/openai-go/packages/param"
+
+	"github.com/tak848/ccgate/internal/llm"
+)
+
+const (
+	maxTokens  = 4096
+	maxRetries = 5
+)
+
+// ErrNoAPIKey is returned by Decide when neither
+// CCGATE_OPENAI_API_KEY nor OPENAI_API_KEY is set.
+var ErrNoAPIKey = errors.New("openai: no API key set (CCGATE_OPENAI_API_KEY / OPENAI_API_KEY)")
+
+// Client is a stateless wrapper around the OpenAI SDK that implements
+// llm.Provider. APIKey is required; BaseURL lets callers point the
+// client at a compatible endpoint (e.g. Gemini, local LLMs).
+type Client struct {
+	APIKey  string
+	BaseURL string
+}
+
+// Decide sends a single classification request and parses the
+// structured response into llm.Result.
+func (c *Client) Decide(ctx context.Context, p llm.Prompt) (llm.Result, error) {
+	if c.APIKey == "" {
+		return llm.Result{}, ErrNoAPIKey
+	}
+
+	if p.TimeoutMS > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(p.TimeoutMS)*time.Millisecond)
+		defer cancel()
+	}
+
+	opts := []option.RequestOption{
+		option.WithAPIKey(c.APIKey),
+		option.WithMaxRetries(maxRetries),
+	}
+	if c.BaseURL != "" {
+		opts = append(opts, option.WithBaseURL(c.BaseURL))
+	}
+	client := openaigo.NewClient(opts...)
+
+	schema, err := outputSchema()
+	if err != nil {
+		return llm.Result{}, fmt.Errorf("generate output schema: %w", err)
+	}
+
+	message, err := client.Chat.Completions.New(ctx, openaigo.ChatCompletionNewParams{
+		Model: openaigo.ChatModel(p.Model),
+		Messages: []openaigo.ChatCompletionMessageParamUnion{
+			openaigo.SystemMessage(p.System),
+			openaigo.UserMessage(p.User),
+		},
+		ResponseFormat: openaigo.ChatCompletionNewParamsResponseFormatUnion{
+			OfJSONSchema: &openaigo.ResponseFormatJSONSchemaParam{
+				JSONSchema: openaigo.ResponseFormatJSONSchemaJSONSchemaParam{
+					Name:   "permission_decision",
+					Strict: param.NewOpt(true),
+					Schema: schema,
+				},
+			},
+		},
+		MaxCompletionTokens: param.NewOpt(int64(maxTokens)),
+		Temperature:         param.NewOpt(float64(0)),
+	})
+	if err != nil {
+		return llm.Result{}, fmt.Errorf("openai API: %w", err)
+	}
+
+	usage := &llm.Usage{
+		InputTokens:  message.Usage.PromptTokens,
+		OutputTokens: message.Usage.CompletionTokens,
+	}
+
+	if len(message.Choices) == 0 {
+		slog.Warn("openai response had no choices")
+		return llm.Result{Usage: usage, Unusable: true}, nil
+	}
+
+	choice := message.Choices[0]
+	switch choice.FinishReason {
+	case "length", "content_filter":
+		slog.Warn("openai response truncated or filtered", "finish_reason", choice.FinishReason)
+		return llm.Result{Usage: usage, Unusable: true}, nil
+	}
+
+	text := strings.TrimSpace(choice.Message.Content)
+	slog.Info("openai response", "raw", text)
+	if text == "" {
+		slog.Warn("openai response had no text content")
+		return llm.Result{Usage: usage, Unusable: true}, nil
+	}
+
+	var output llm.Output
+	if err := json.Unmarshal([]byte(text), &output); err != nil {
+		return llm.Result{Usage: usage}, fmt.Errorf("parse LLM response: %w", err)
+	}
+	if output.Behavior == llm.BehaviorDeny && strings.TrimSpace(output.DenyMessage) == "" {
+		output.DenyMessage = llm.DefaultDenyMessage
+	}
+
+	return llm.Result{Output: output, Usage: usage}, nil
+}
+
+func outputSchema() (map[string]any, error) {
+	reflector := jsonschema.Reflector{
+		AllowAdditionalProperties: false,
+		DoNotReference:            true,
+	}
+	schema := reflector.Reflect(llm.Output{})
+	data, err := json.Marshal(schema)
+	if err != nil {
+		return nil, fmt.Errorf("marshal schema: %w", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("unmarshal schema: %w", err)
+	}
+	return out, nil
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -31,6 +31,8 @@ import (
 	"github.com/tak848/ccgate/internal/gitutil"
 	"github.com/tak848/ccgate/internal/llm"
 	"github.com/tak848/ccgate/internal/llm/anthropic"
+	"github.com/tak848/ccgate/internal/llm/gemini"
+	"github.com/tak848/ccgate/internal/llm/openai"
 	"github.com/tak848/ccgate/internal/metrics"
 	"github.com/tak848/ccgate/internal/prompt"
 )
@@ -278,15 +280,17 @@ func decide(ctx context.Context, cfg config.Config, in HookInput, ro runtimeOpti
 		return llm.Decision{}, false, llm.FallthroughKindDontAsk, "", nil, nil
 	}
 
-	if !strings.EqualFold(cfg.Provider.Name, "anthropic") {
-		slog.Info("provider not anthropic, falling through", "provider", cfg.Provider.Name)
-		return llm.Decision{}, false, llm.FallthroughKindNonAnthropic, "", nil, nil
-	}
-
-	apiKey, ok := resolveAPIKey()
+	providerName := strings.ToLower(cfg.Provider.Name)
+	apiKey, ok := resolveAPIKey(providerName)
 	if !ok {
-		slog.Warn("no API key found (CCGATE_ANTHROPIC_API_KEY / ANTHROPIC_API_KEY)")
-		return llm.Decision{}, false, llm.FallthroughKindNoAPIKey, "", nil, nil
+		switch providerName {
+		case "anthropic", "openai", "gemini":
+			slog.Warn("no API key found", "provider", cfg.Provider.Name)
+			return llm.Decision{}, false, llm.FallthroughKindNoAPIKey, "", nil, nil
+		default:
+			slog.Info("unknown provider, falling through", "provider", cfg.Provider.Name)
+			return llm.Decision{}, false, llm.FallthroughKindNonAnthropic, "", nil, nil
+		}
 	}
 
 	p, err := buildPrompt(cfg, in, ro)
@@ -294,14 +298,15 @@ func decide(ctx context.Context, cfg config.Config, in HookInput, ro runtimeOpti
 		return llm.Decision{}, false, "", "", nil, fmt.Errorf("build prompt: %w", err)
 	}
 
-	slog.Info("anthropic request",
+	slog.Info("llm request",
+		"provider", cfg.Provider.Name,
 		"model", p.Model,
 		"timeout_ms", p.TimeoutMS,
 		"system_prompt", p.System,
 		"user_message", redactedUserMessage(p.User),
 	)
 
-	client := &anthropic.Client{APIKey: apiKey}
+	client := newProviderClient(providerName, apiKey)
 	res, err := client.Decide(ctx, p)
 	if err != nil {
 		return llm.Decision{}, false, "", "", res.Usage, err
@@ -422,14 +427,34 @@ func redactedUserMessage(user string) string {
 	return string(out)
 }
 
-func resolveAPIKey() (string, bool) {
-	if key := strings.TrimSpace(os.Getenv("CCGATE_ANTHROPIC_API_KEY")); key != "" {
+func resolveAPIKey(providerName string) (string, bool) {
+	var primary, fallback string
+	switch providerName {
+	case "openai":
+		primary, fallback = "CCGATE_OPENAI_API_KEY", "OPENAI_API_KEY"
+	case "gemini":
+		primary, fallback = "CCGATE_GEMINI_API_KEY", "GEMINI_API_KEY"
+	default: // anthropic
+		primary, fallback = "CCGATE_ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY"
+	}
+	if key := strings.TrimSpace(os.Getenv(primary)); key != "" {
 		return key, true
 	}
-	if key := strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY")); key != "" {
+	if key := strings.TrimSpace(os.Getenv(fallback)); key != "" {
 		return key, true
 	}
 	return "", false
+}
+
+func newProviderClient(providerName, apiKey string) llm.Provider {
+	switch providerName {
+	case "openai":
+		return &openai.Client{APIKey: apiKey}
+	case "gemini":
+		return &gemini.Client{APIKey: apiKey}
+	default: // anthropic
+		return &anthropic.Client{APIKey: apiKey}
+	}
 }
 
 const maxTruncateLen = 200


### PR DESCRIPTION
Closes #53

## Why

ccgate currently requires an Anthropic API key, which limits adoption for users who already have OpenAI or Gemini API access. The `llm.Provider` interface introduced in v0.6 is the natural extension point for additional backends.

## What

- Add `openai` and `gemini` as supported `provider.name` values.
- Gemini reuses the OpenAI client via its OpenAI-compatible endpoint.
- Unknown provider names continue to fall through as before.

## Usage

```jsonnet
provider: {
  name: 'openai',        // or 'gemini'
  model: 'gpt-4o-mini',  // or 'gemini-2.0-flash'
}
```

Set `OPENAI_API_KEY` or `GEMINI_API_KEY` and run as before.