### PR TITLE
docs: document OpenAI / Gemini provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,11 @@ If `ccgate` is not on your `PATH` (e.g. when relying on `mise exec` instead of a
 
 Set the API key for your chosen provider. `CCGATE_*_API_KEY` is preferred and overrides the bare variable, so you can keep ccgate's key separate from the AI tool's own key.
 
-| `provider.name` | Preferred                  | Fallback             |
-|-----------------|----------------------------|----------------------|
-| `anthropic`     | `CCGATE_ANTHROPIC_API_KEY` | `ANTHROPIC_API_KEY`  |
-| `openai`        | `CCGATE_OPENAI_API_KEY`    | `OPENAI_API_KEY`     |
-| `gemini`        | `CCGATE_GEMINI_API_KEY`    | `GEMINI_API_KEY`     |
+| `provider.name` | Preferred                  | Fallback             | Get API key |
+|-----------------|----------------------------|----------------------|-------------|
+| `anthropic`     | `CCGATE_ANTHROPIC_API_KEY` | `ANTHROPIC_API_KEY`  | <https://platform.claude.com/settings/keys> |
+| `openai`        | `CCGATE_OPENAI_API_KEY`    | `OPENAI_API_KEY`     | <https://platform.openai.com/api-keys>      |
+| `gemini`        | `CCGATE_GEMINI_API_KEY`    | `GEMINI_API_KEY`     | <https://aistudio.google.com/app/api-keys>  |
 
 ## Setup — Codex CLI (experimental)
 

--- a/README.md
+++ b/README.md
@@ -207,13 +207,13 @@ Set `provider.name` (and optionally `provider.model`) in any layer:
 ```jsonnet
 {
   provider: {
-    name: 'gemini',
-    model: 'gemini-3-flash-preview',
+    name: 'openai',
+    model: 'gpt-5.4-nano-2026-03-17',
   },
 }
 ```
 
-Then export the matching API key (`CCGATE_GEMINI_API_KEY` / `CCGATE_OPENAI_API_KEY` — see the [provider table](#3-api-key)). If the key is missing, ccgate falls through to the upstream tool's permission prompt, so flipping providers cannot break the hook.
+Then export the matching API key (`CCGATE_OPENAI_API_KEY` / `CCGATE_GEMINI_API_KEY` — see the [provider table](#3-api-key)). If the key is missing, ccgate falls through to the upstream tool's permission prompt, so flipping providers cannot break the hook.
 
 ## Default Rules
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,13 @@ If `ccgate` is not on your `PATH` (e.g. when relying on `mise exec` instead of a
 
 ### 3. API key
 
-Set the `CCGATE_ANTHROPIC_API_KEY` or `ANTHROPIC_API_KEY` environment variable.
+Set the API key for your chosen provider. `CCGATE_*_API_KEY` is preferred and overrides the bare variable, so you can keep ccgate's key separate from the AI tool's own key.
+
+| `provider.name` | Preferred                  | Fallback             |
+|-----------------|----------------------------|----------------------|
+| `anthropic`     | `CCGATE_ANTHROPIC_API_KEY` | `ANTHROPIC_API_KEY`  |
+| `openai`        | `CCGATE_OPENAI_API_KEY`    | `OPENAI_API_KEY`     |
+| `gemini`        | `CCGATE_GEMINI_API_KEY`    | `GEMINI_API_KEY`     |
 
 ## Setup — Codex CLI (experimental)
 
@@ -149,7 +155,7 @@ Refer to the [Codex hooks documentation](https://developers.openai.com/codex/hoo
 
 ### 3. API key
 
-Same env vars as Claude Code (`CCGATE_ANTHROPIC_API_KEY` / `ANTHROPIC_API_KEY`).
+Same env vars as Claude Code — see the [provider table](#3-api-key).
 
 ## Configuration
 
@@ -175,8 +181,8 @@ Project-local configs are loaded only when **not tracked by Git**.
 
 | Field                    | Type                              | Default                                                                       | Description                                                                                            |
 |--------------------------|-----------------------------------|-------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
-| `provider.name`          | string                            | `"anthropic"`                                                                 | Provider name. Only `"anthropic"` is supported.                                                        |
-| `provider.model`         | string                            | `"claude-haiku-4-5"`                                                          | Model name (e.g. `claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-6`)                           |
+| `provider.name`          | string                            | `"anthropic"`                                                                 | Provider name. One of `"anthropic"`, `"openai"`, `"gemini"`.                                            |
+| `provider.model`         | string                            | `"claude-haiku-4-5"`                                                          | Model name. Examples: `claude-haiku-4-5` / `claude-sonnet-4-6` (anthropic), `gpt-5.4-nano-2026-03-17` (openai), `gemini-3-flash-preview` (gemini). |
 | `provider.timeout_ms`    | int                               | `20000`                                                                       | API timeout (ms). `0` = no timeout.                                                                    |
 | `log_path`               | string                            | `$XDG_STATE_HOME/ccgate/<target>/ccgate.log`                                  | Log file path. Supports `~` for home directory.                                                        |
 | `log_disabled`           | bool                              | `false`                                                                       | Disable logging entirely                                                                               |
@@ -193,6 +199,21 @@ Project-local configs are loaded only when **not tracked by Git**.
 | `append_environment`     | string[]                          | `[]`                                                                          | Environment context appended on top of the carried-over list.                                          |
 
 `<target>` is `claude` or `codex` depending on which hook is invoked. When `XDG_STATE_HOME` is unset, ccgate falls back to `~/.local/state/ccgate/<target>/...`.
+
+### Switching to OpenAI / Gemini
+
+Set `provider.name` (and optionally `provider.model`) in any layer:
+
+```jsonnet
+{
+  provider: {
+    name: 'gemini',
+    model: 'gemini-3-flash-preview',
+  },
+}
+```
+
+Then export the matching API key (`CCGATE_GEMINI_API_KEY` / `CCGATE_OPENAI_API_KEY` — see the [provider table](#3-api-key)). If the key is missing, ccgate falls through to the upstream tool's permission prompt, so flipping providers cannot break the hook.
 
 ## Default Rules
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,7 +57,7 @@ Only LLM-driven uncertainty is affected. The runtime-mode fallthroughs continue 
 
 - API call truncated or refused (`api_unusable`)
 - No API key set (`no_apikey`)
-- `provider.name != "anthropic"` (`non_anthropic`)
+- `provider.name` is not one of `anthropic` / `openai` / `gemini` (`non_anthropic` — kind name kept for backward compatibility)
 - Claude `permission_mode == "bypassPermissions"` or `"dontAsk"`
 - Claude `tool_name` in `{ExitPlanMode, AskUserQuestion}` (user-interaction tools)
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -128,7 +128,13 @@ ccgate claude init > ~/.claude/ccgate.jsonnet
 
 ### 3. API キー
 
-環境変数 `CCGATE_ANTHROPIC_API_KEY` または `ANTHROPIC_API_KEY` を設定してください。
+選択した provider の API キーを設定してください。`CCGATE_*_API_KEY` が優先され bare 変数を上書きするので、AI ツール本体の API キーと ccgate 用キーを分離できます。
+
+| `provider.name` | 優先                       | フォールバック        |
+|-----------------|----------------------------|-----------------------|
+| `anthropic`     | `CCGATE_ANTHROPIC_API_KEY` | `ANTHROPIC_API_KEY`   |
+| `openai`        | `CCGATE_OPENAI_API_KEY`    | `OPENAI_API_KEY`      |
+| `gemini`        | `CCGATE_GEMINI_API_KEY`    | `GEMINI_API_KEY`      |
 
 ## セットアップ — Codex CLI (experimental)
 
@@ -148,7 +154,7 @@ defaults は Claude Code と同じ思想 (allow + deny + environment)。Codex ho
 
 ### 3. API キー
 
-Claude Code と同じ環境変数 (`CCGATE_ANTHROPIC_API_KEY` / `ANTHROPIC_API_KEY`) を共有します。
+Claude Code と同じ環境変数を使います — [provider table](#3-api-キー) を参照してください。
 
 ## 設定
 
@@ -173,8 +179,8 @@ Claude Code と同じ環境変数 (`CCGATE_ANTHROPIC_API_KEY` / `ANTHROPIC_API_K
 
 | フィールド               | 型                                | デフォルト                                                                       | 説明                                                                                                       |
 |--------------------------|-----------------------------------|---------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
-| `provider.name`          | string                            | `"anthropic"`                                                                   | プロバイダー名。`"anthropic"` のみ対応                                                                     |
-| `provider.model`         | string                            | `"claude-haiku-4-5"`                                                            | モデル名 (例: `claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-6`)                                  |
+| `provider.name`          | string                            | `"anthropic"`                                                                   | プロバイダー名。`"anthropic"` / `"openai"` / `"gemini"` のいずれか                                          |
+| `provider.model`         | string                            | `"claude-haiku-4-5"`                                                            | モデル名。例: `claude-haiku-4-5` / `claude-sonnet-4-6` (anthropic)、`gpt-5.4-nano-2026-03-17` (openai)、`gemini-3-flash-preview` (gemini) |
 | `provider.timeout_ms`    | int                               | `20000`                                                                         | API タイムアウト (ms)。`0` = タイムアウトなし                                                              |
 | `log_path`               | string                            | `$XDG_STATE_HOME/ccgate/<target>/ccgate.log`                                    | ログファイルパス。`~` でホームディレクトリ展開                                                             |
 | `log_disabled`           | bool                              | `false`                                                                         | ログ出力を完全に無効化                                                                                     |
@@ -191,6 +197,21 @@ Claude Code と同じ環境変数 (`CCGATE_ANTHROPIC_API_KEY` / `ANTHROPIC_API_K
 | `append_environment`     | string[]                          | `[]`                                                                            | 引き継いだ environment list の末尾に追加                                                                   |
 
 `<target>` は Claude / Codex どちらの hook が呼ばれたかで `claude` / `codex` になります。`XDG_STATE_HOME` が未設定の場合は `~/.local/state/ccgate/<target>/...` が fallback として使われます。
+
+### OpenAI / Gemini に切り替える
+
+任意の layer で `provider.name`（必要に応じて `provider.model` も）を書き換えるだけです:
+
+```jsonnet
+{
+  provider: {
+    name: 'gemini',
+    model: 'gemini-3-flash-preview',
+  },
+}
+```
+
+対応する API キー (`CCGATE_GEMINI_API_KEY` / `CCGATE_OPENAI_API_KEY` — [provider table](#3-api-キー)) を export してください。キーが見つからない場合 ccgate は上流ツールの確認画面に fallthrough するため、provider 切替で hook が壊れることはありません。
 
 ## デフォルトルール
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -130,11 +130,11 @@ ccgate claude init > ~/.claude/ccgate.jsonnet
 
 選択した provider の API キーを設定してください。`CCGATE_*_API_KEY` が優先され bare 変数を上書きするので、AI ツール本体の API キーと ccgate 用キーを分離できます。
 
-| `provider.name` | 優先                       | フォールバック        |
-|-----------------|----------------------------|-----------------------|
-| `anthropic`     | `CCGATE_ANTHROPIC_API_KEY` | `ANTHROPIC_API_KEY`   |
-| `openai`        | `CCGATE_OPENAI_API_KEY`    | `OPENAI_API_KEY`      |
-| `gemini`        | `CCGATE_GEMINI_API_KEY`    | `GEMINI_API_KEY`      |
+| `provider.name` | 優先                       | フォールバック        | API キー発行ページ |
+|-----------------|----------------------------|-----------------------|--------------------|
+| `anthropic`     | `CCGATE_ANTHROPIC_API_KEY` | `ANTHROPIC_API_KEY`   | <https://platform.claude.com/settings/keys> |
+| `openai`        | `CCGATE_OPENAI_API_KEY`    | `OPENAI_API_KEY`      | <https://platform.openai.com/api-keys>      |
+| `gemini`        | `CCGATE_GEMINI_API_KEY`    | `GEMINI_API_KEY`      | <https://aistudio.google.com/app/api-keys>  |
 
 ## セットアップ — Codex CLI (experimental)
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -205,13 +205,13 @@ Claude Code と同じ環境変数を使います — [provider table](#3-api-キ
 ```jsonnet
 {
   provider: {
-    name: 'gemini',
-    model: 'gemini-3-flash-preview',
+    name: 'openai',
+    model: 'gpt-5.4-nano-2026-03-17',
   },
 }
 ```
 
-対応する API キー (`CCGATE_GEMINI_API_KEY` / `CCGATE_OPENAI_API_KEY` — [provider table](#3-api-キー)) を export してください。キーが見つからない場合 ccgate は上流ツールの確認画面に fallthrough するため、provider 切替で hook が壊れることはありません。
+対応する API キー (`CCGATE_OPENAI_API_KEY` / `CCGATE_GEMINI_API_KEY` — [provider table](#3-api-キー)) を export してください。キーが見つからない場合 ccgate は上流ツールの確認画面に fallthrough するため、provider 切替で hook が壊れることはありません。
 
 ## デフォルトルール
 

--- a/docs/ja/configuration.md
+++ b/docs/ja/configuration.md
@@ -57,7 +57,7 @@ LLM は `allow` / `deny` / `fallthrough` のいずれかを返します。`fallt
 
 - API 応答が truncate / refused された (`api_unusable`)
 - API キー未設定 (`no_apikey`)
-- `provider.name != "anthropic"` (`non_anthropic`)
+- `provider.name` が `anthropic` / `openai` / `gemini` のいずれでもない (`non_anthropic` — kind 名は後方互換のため維持)
 - Claude `permission_mode == "bypassPermissions"` または `"dontAsk"`
 - Claude `tool_name` が `{ExitPlanMode, AskUserQuestion}` (ユーザーインタラクション専用 tool)
 


### PR DESCRIPTION
## Why

PR #54 added OpenAI and Gemini provider support, but README and `docs/` still claim "Only `anthropic` is supported" and only document `CCGATE_ANTHROPIC_API_KEY`. The new providers are not discoverable from the docs.

## What

Docs-only update across the README and the four mirrored docs files:

- Per-provider API-key table (`CCGATE_*_API_KEY` preferred, bare env as fallback) in the Claude Code setup section; Codex setup links to it.
- `provider.name` / `provider.model` config-fields rows updated to list `anthropic` / `openai` / `gemini` and per-provider model examples.
- New "Switching to OpenAI / Gemini" subsection with a minimal jsonnet recipe.
- Stale `provider.name != "anthropic"` note in `docs/configuration.md` aligned with current behavior (only an unknown provider name now hits the `non_anthropic` fallthrough).

Out of scope: examples/ baselines, schemas, embedded defaults — already handled by #54.