### PR TITLE
refactor(metrics)!: rename non_anthropic fallthrough kind to unknown_provider

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,7 +57,7 @@ Only LLM-driven uncertainty is affected. The runtime-mode fallthroughs continue 
 
 - API call truncated or refused (`api_unusable`)
 - No API key set (`no_apikey`)
-- `provider.name` is not one of `anthropic` / `openai` / `gemini` (`non_anthropic` — kind name kept for backward compatibility)
+- `provider.name` is not one of `anthropic` / `openai` / `gemini` (`unknown_provider`)
 - Claude `permission_mode == "bypassPermissions"` or `"dontAsk"`
 - Claude `tool_name` in `{ExitPlanMode, AskUserQuestion}` (user-interaction tools)
 
@@ -120,7 +120,7 @@ ccgate codex  metrics --days 7         # same shape, codex side
 }
 ```
 
-`ft_kind` is filled when the LLM returned (or the runtime forced) a fallthrough; the value tells you which fallback path fired (`llm`, `api_unusable`, `no_apikey`, `non_anthropic`, `bypass`, `dontask`, `user_interaction`). `forced=true` means `fallthrough_strategy` promoted an LLM `fallthrough` into the recorded `decision`.
+`ft_kind` is filled when the LLM returned (or the runtime forced) a fallthrough; the value tells you which fallback path fired (`llm`, `api_unusable`, `no_apikey`, `unknown_provider`, `bypass`, `dontask`, `user_interaction`). `forced=true` means `fallthrough_strategy` promoted an LLM `fallthrough` into the recorded `decision`.
 
 ### Drill-down sections
 

--- a/docs/ja/configuration.md
+++ b/docs/ja/configuration.md
@@ -57,7 +57,7 @@ LLM は `allow` / `deny` / `fallthrough` のいずれかを返します。`fallt
 
 - API 応答が truncate / refused された (`api_unusable`)
 - API キー未設定 (`no_apikey`)
-- `provider.name` が `anthropic` / `openai` / `gemini` のいずれでもない (`non_anthropic` — kind 名は後方互換のため維持)
+- `provider.name` が `anthropic` / `openai` / `gemini` のいずれでもない (`unknown_provider`)
 - Claude `permission_mode == "bypassPermissions"` または `"dontAsk"`
 - Claude `tool_name` が `{ExitPlanMode, AskUserQuestion}` (ユーザーインタラクション専用 tool)
 
@@ -120,7 +120,7 @@ ccgate codex  metrics --days 7         # codex 側も同 shape
 }
 ```
 
-`ft_kind` は LLM (またはランタイム) が fallthrough を返したときに埋まり、どの fallback path が発火したかを示します (`llm`, `api_unusable`, `no_apikey`, `non_anthropic`, `bypass`, `dontask`, `user_interaction`)。`forced=true` は `fallthrough_strategy` が LLM `fallthrough` を `decision` に promote したことを意味します。
+`ft_kind` は LLM (またはランタイム) が fallthrough を返したときに埋まり、どの fallback path が発火したかを示します (`llm`, `api_unusable`, `no_apikey`, `unknown_provider`, `bypass`, `dontask`, `user_interaction`)。`forced=true` は `fallthrough_strategy` が LLM `fallthrough` を `decision` に promote したことを意味します。
 
 ### ドリルダウン節
 

--- a/internal/llm/strategy.go
+++ b/internal/llm/strategy.go
@@ -21,7 +21,7 @@ const (
 	FallthroughKindUserInteraction = "user_interaction"
 	FallthroughKindBypass          = "bypass"
 	FallthroughKindDontAsk         = "dontask"
-	FallthroughKindNonAnthropic    = "non_anthropic"
+	FallthroughKindUnknownProvider = "unknown_provider"
 	FallthroughKindNoAPIKey        = "no_apikey"
 	FallthroughKindLLM             = "llm"
 	FallthroughKindAPIUnusable     = "api_unusable"

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -289,7 +289,7 @@ func decide(ctx context.Context, cfg config.Config, in HookInput, ro runtimeOpti
 			return llm.Decision{}, false, llm.FallthroughKindNoAPIKey, "", nil, nil
 		default:
 			slog.Info("unknown provider, falling through", "provider", cfg.Provider.Name)
-			return llm.Decision{}, false, llm.FallthroughKindNonAnthropic, "", nil, nil
+			return llm.Decision{}, false, llm.FallthroughKindUnknownProvider, "", nil, nil
 		}
 	}
 


### PR DESCRIPTION
## Why

`non_anthropic` was a single-provider-era name. After #54 / #55 the kind only fires when `provider.name` is *unknown* (anthropic / openai / gemini are all valid now), so the label no longer matches what the code does. Keeping it under a "for backward compatibility" disclaimer in the docs (added in #55) was the wrong call — better to rename and move on.

## What

- `internal/llm/strategy.go`: `FallthroughKindNonAnthropic = "non_anthropic"` → `FallthroughKindUnknownProvider = "unknown_provider"`.
- `internal/runner/runner.go`: switch the call site at the unknown-provider branch.
- `docs/configuration.md` + `docs/ja/configuration.md`: drop the legacy note, update the `ft_kind` enum.

## Breaking

`metrics.jsonl` will stop emitting `ft_kind: "non_anthropic"`. Any external script grepping that string needs to look for `unknown_provider` instead. ccgate's own `ccgate <target> metrics` aggregator just passes the value through, so it picks up the new name automatically.

`vet` + `test` clean.