### PR TITLE
docs: spell out Codex CLI hook setup with hooks.json + config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Codex reads hooks from `~/.codex/hooks.json` and `~/.codex/config.toml` (with `<
 
 ```toml
 [features]
-codex_hooks = true   # required on Codex versions that still gate hooks behind a feature flag
+codex_hooks = true   # required: Codex hooks are still experimental and gated behind this feature flag
 
 [[hooks.PermissionRequest]]
 matcher = ""

--- a/README.md
+++ b/README.md
@@ -151,7 +151,45 @@ The defaults follow Claude Code parity (allow + deny + environment guidance). Co
 
 ### 2. Register as a Codex hook
 
-Refer to the [Codex hooks documentation](https://developers.openai.com/codex/hooks) for the canonical setup; ccgate plugs in as a `PermissionRequest` hook command. Make sure your `~/.codex/config.toml` enables the hooks feature flag if your Codex version still gates them behind one.
+Codex reads hooks from `~/.codex/hooks.json` and `~/.codex/config.toml` (with `<repo>/.codex/{hooks.json,config.toml}` overlays once the project is trusted). Pick whichever fits your setup.
+
+`~/.codex/hooks.json`:
+
+```json
+{
+  "hooks": {
+    "PermissionRequest": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ccgate codex",
+            "statusMessage": "ccgate evaluating request"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`~/.codex/config.toml`:
+
+```toml
+[features]
+codex_hooks = true   # required on Codex versions that still gate hooks behind a feature flag
+
+[[hooks.PermissionRequest]]
+matcher = ""
+
+[[hooks.PermissionRequest.hooks]]
+type    = "command"
+command = "ccgate codex"
+statusMessage = "ccgate evaluating request"
+```
+
+See [docs/codex.md](docs/codex.md) for the full lookup order, project-local overlays, and a `go run` recipe for in-tree dev builds. Refer to the upstream [Codex hooks documentation](https://developers.openai.com/codex/hooks) for the authoritative schema.
 
 ### 3. API key
 

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -49,7 +49,7 @@ If you want to keep hooks alongside the rest of your Codex config:
 
 ```toml
 [features]
-codex_hooks = true   # gate is still required on some Codex versions
+codex_hooks = true   # required: Codex hooks are still experimental and gated behind this feature flag
 
 [[hooks.PermissionRequest]]
 matcher = ""

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -150,7 +150,45 @@ defaults は Claude Code と同じ思想 (allow + deny + environment)。Codex ho
 
 ### 2. Codex hook として登録
 
-[Codex hooks ドキュメント](https://developers.openai.com/codex/hooks) を参照して `PermissionRequest` hook の `command` に ccgate を指定してください。Codex のバージョンによっては `~/.codex/config.toml` で hooks の feature flag を有効化する必要があります。
+Codex は `~/.codex/hooks.json` と `~/.codex/config.toml` から hook を読み込みます (project が trusted なら `<repo>/.codex/{hooks.json,config.toml}` も overlay)。好きな方で登録してください。
+
+`~/.codex/hooks.json`:
+
+```json
+{
+  "hooks": {
+    "PermissionRequest": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ccgate codex",
+            "statusMessage": "ccgate evaluating request"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`~/.codex/config.toml`:
+
+```toml
+[features]
+codex_hooks = true   # hooks を feature flag で gate している Codex バージョンでは必須
+
+[[hooks.PermissionRequest]]
+matcher = ""
+
+[[hooks.PermissionRequest.hooks]]
+type    = "command"
+command = "ccgate codex"
+statusMessage = "ccgate evaluating request"
+```
+
+lookup 順序、project-local overlay、in-tree dev build 用の `go run` レシピは [docs/codex.md](../codex.md) を参照。upstream の [Codex hooks ドキュメント](https://developers.openai.com/codex/hooks) が schema の正本です。
 
 ### 3. API キー
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -177,7 +177,7 @@ Codex は `~/.codex/hooks.json` と `~/.codex/config.toml` から hook を読み
 
 ```toml
 [features]
-codex_hooks = true   # hooks を feature flag で gate している Codex バージョンでは必須
+codex_hooks = true   # 必須: Codex hooks は experimental で、この feature flag で gate されている
 
 [[hooks.PermissionRequest]]
 matcher = ""

--- a/docs/ja/codex.md
+++ b/docs/ja/codex.md
@@ -49,7 +49,7 @@ Codex 設定全体を 1 ファイルにまとめたい場合:
 
 ```toml
 [features]
-codex_hooks = true   # Codex のバージョンによっては feature flag が必要
+codex_hooks = true   # 必須: Codex hooks は experimental で、この feature flag で gate されている
 
 [[hooks.PermissionRequest]]
 matcher = ""


### PR DESCRIPTION
## Why

The Codex CLI setup section in the README still tells users "refer to the Codex hooks docs" without showing what to actually paste into `~/.codex/{hooks.json,config.toml}`. `docs/codex.md` already has both forms; pulling them up to the README so the quick-start is self-contained.

## What

- Replace the bare external pointer in `README.md` Setup §2 with copy-pasteable `hooks.json` and `config.toml` blocks, plus a one-line link to `docs/codex.md` for project-local overlays / `go run` dev recipes.
- Mirror the same change in `docs/ja/README.md`.