### PR TITLE
fix(openai): retry without temperature for models that reject it

### DIFF
--- a/internal/llm/openai/client.go
+++ b/internal/llm/openai/client.go
@@ -64,7 +64,7 @@ func (c *Client) Decide(ctx context.Context, p llm.Prompt) (llm.Result, error) {
 		return llm.Result{}, fmt.Errorf("generate output schema: %w", err)
 	}
 
-	message, err := client.Chat.Completions.New(ctx, openaigo.ChatCompletionNewParams{
+	params := openaigo.ChatCompletionNewParams{
 		Model: openaigo.ChatModel(p.Model),
 		Messages: []openaigo.ChatCompletionMessageParamUnion{
 			openaigo.SystemMessage(p.System),
@@ -81,7 +81,16 @@ func (c *Client) Decide(ctx context.Context, p llm.Prompt) (llm.Result, error) {
 		},
 		MaxCompletionTokens: param.NewOpt(int64(maxTokens)),
 		Temperature:         param.NewOpt(float64(0)),
-	})
+	}
+
+	message, err := client.Chat.Completions.New(ctx, params)
+	if isTemperatureUnsupported(err) {
+		// Reasoning-only models (gpt-5, gpt-5-mini, gpt-5-nano, gpt-5-chat,
+		// o-series, etc.) reject temperature != 1. Retry once without it.
+		slog.Info("openai rejected temperature; retrying without it", "model", p.Model)
+		params.Temperature = param.Opt[float64]{}
+		message, err = client.Chat.Completions.New(ctx, params)
+	}
 	if err != nil {
 		return llm.Result{}, fmt.Errorf("openai API: %w", err)
 	}
@@ -119,6 +128,17 @@ func (c *Client) Decide(ctx context.Context, p llm.Prompt) (llm.Result, error) {
 	}
 
 	return llm.Result{Output: output, Usage: usage}, nil
+}
+
+// isTemperatureUnsupported reports whether err is the OpenAI 400 returned by
+// reasoning-only models when a non-default temperature is supplied.
+// The error response is shaped: {code: "unsupported_value", param: "temperature", ...}.
+func isTemperatureUnsupported(err error) bool {
+	var apiErr *openaigo.Error
+	return errors.As(err, &apiErr) &&
+		apiErr.StatusCode == 400 &&
+		apiErr.Code == "unsupported_value" &&
+		apiErr.Param == "temperature"
 }
 
 func outputSchema() (map[string]any, error) {

--- a/internal/llm/openai/client_test.go
+++ b/internal/llm/openai/client_test.go
@@ -1,0 +1,136 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/tak848/ccgate/internal/llm"
+)
+
+// TestDecide_RetriesWithoutTemperatureOnUnsupported verifies that when the
+// upstream returns the documented 400 for `temperature` (reasoning-only
+// models such as gpt-5-nano), Decide retries once with `temperature`
+// stripped and parses the second response normally.
+func TestDecide_RetriesWithoutTemperatureOnUnsupported(t *testing.T) {
+	t.Parallel()
+
+	var (
+		calls    int
+		bodies   []string
+		respText = `{"behavior":"allow","reason":"read-only","deny_message":""}`
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, string(body))
+		calls++
+
+		if calls == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{
+				"error": {
+					"message": "Unsupported value: 'temperature' does not support 0 with this model. Only the default (1) value is supported.",
+					"type": "invalid_request_error",
+					"param": "temperature",
+					"code": "unsupported_value"
+				}
+			}`))
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":      "chatcmpl-test",
+			"object":  "chat.completion",
+			"created": 0,
+			"model":   "gpt-5-nano",
+			"choices": []map[string]any{{
+				"index":         0,
+				"finish_reason": "stop",
+				"message": map[string]any{
+					"role":    "assistant",
+					"content": respText,
+				},
+			}},
+			"usage": map[string]any{"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+		})
+	}))
+	defer srv.Close()
+
+	client := &Client{APIKey: "test-key", BaseURL: srv.URL + "/"}
+	got, err := client.Decide(context.Background(), llm.Prompt{
+		System: "sys",
+		User:   "usr",
+		Model:  "gpt-5-nano",
+	})
+	if err != nil {
+		t.Fatalf("Decide returned error: %v", err)
+	}
+
+	if calls != 2 {
+		t.Fatalf("want 2 upstream calls (1 reject + 1 retry), got %d", calls)
+	}
+	if !strings.Contains(bodies[0], `"temperature"`) {
+		t.Errorf("first request should have included temperature, got: %s", bodies[0])
+	}
+	if strings.Contains(bodies[1], `"temperature"`) {
+		t.Errorf("retry request must omit temperature, got: %s", bodies[1])
+	}
+	if got.Output.Behavior != llm.BehaviorAllow {
+		t.Errorf("behavior = %q, want %q", got.Output.Behavior, llm.BehaviorAllow)
+	}
+	if got.Usage == nil || got.Usage.InputTokens != 10 || got.Usage.OutputTokens != 5 {
+		t.Errorf("usage = %+v, want {10, 5}", got.Usage)
+	}
+}
+
+// TestDecide_PassesThroughOtherErrors verifies that a 400 with a different
+// `param` is not treated as a temperature problem: it must surface as an
+// error and not trigger a retry.
+func TestDecide_PassesThroughOtherErrors(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{
+			"error": {
+				"message": "boom",
+				"type": "invalid_request_error",
+				"param": "model",
+				"code": "model_not_found"
+			}
+		}`))
+	}))
+	defer srv.Close()
+
+	client := &Client{APIKey: "test-key", BaseURL: srv.URL + "/"}
+	_, err := client.Decide(context.Background(), llm.Prompt{Model: "nope"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if calls != 1 {
+		t.Errorf("want 1 upstream call (no retry), got %d", calls)
+	}
+}
+
+// TestIsTemperatureUnsupported_NilAndPlain ensures the predicate does not
+// panic on nil and rejects errors that are not OpenAI API errors.
+func TestIsTemperatureUnsupported_NilAndPlain(t *testing.T) {
+	t.Parallel()
+
+	if isTemperatureUnsupported(nil) {
+		t.Error("nil error should not be treated as temperature-unsupported")
+	}
+	if isTemperatureUnsupported(io.EOF) {
+		t.Error("non-API error should not be treated as temperature-unsupported")
+	}
+}


### PR DESCRIPTION
## Why

`internal/llm/openai/client.go` hardcodes `Temperature: param.NewOpt(float64(0))`, but several OpenAI models only accept the default `temperature=1` and respond with a 400 to anything else:

- `gpt-5`, `gpt-5-mini`, `gpt-5-nano`
- `gpt-5-chat`, `gpt-5-chat-latest`
- `gpt-5.2-chat`, `gpt-5.2-chat-latest` (per [litellm#21911](https://github.com/BerriAI/litellm/issues/21911))
- `o1*`, `o3*`, `o4-mini`

Configuring ccgate with one of these (e.g. `model: 'gpt-5-nano'`) breaks every decision:

```
level=ERROR msg="decide failed" error="openai API: ... 400 Bad Request {
    \"message\": \"Unsupported value: 'temperature' does not support 0 with this model. Only the default (1) value is supported.\",
    \"type\": \"invalid_request_error\",
    \"param\": \"temperature\",
    \"code\": \"unsupported_value\"
}"
```

Every Bash/Edit/Write tool call then falls through to a manual permission prompt — defeating the point of the hook. In my session this surfaced as ~6% error rate in `ccgate clm` after switching from `gpt-5.4-nano` to `gpt-5-nano`.

The set of "no-temperature" models keeps moving (5.1/5.2 default to `reasoning_effort=none` and accept temperature again — see [langchain#35423](https://github.com/langchain-ai/langchain/issues/35423)), so a static "skip for these prefixes" list will need maintenance. The OpenAI error response is already unambiguous (`code=unsupported_value`, `param=temperature`), so the natural fix is: try with temperature, and if the API explicitly says it's unsupported, retry once without it.

## What

- `internal/llm/openai/client.go`:
  - Lift the request params into a variable so we can mutate and re-issue.
  - On a 400 whose `Param == "temperature"` and `Code == "unsupported_value"`, clear `Temperature` and retry once. Other errors propagate unchanged.
  - Add an `isTemperatureUnsupported(err)` predicate that uses `errors.As` against `*openai.Error` (no string matching).
- `internal/llm/openai/client_test.go` (new):
  - `TestDecide_RetriesWithoutTemperatureOnUnsupported` — fake `httptest` server returns the documented 400 first, success second; asserts retry happened, the second body omits `temperature`, and the parsed `Result` is correct.
  - `TestDecide_PassesThroughOtherErrors` — a 400 with `param: "model"` is **not** retried.
  - `TestIsTemperatureUnsupported_NilAndPlain` — predicate handles `nil` and non-API errors without panicking.

No config-surface changes. Existing setups keep their single-call path.

## Trade-off

One wasted round-trip per session for affected models. Acceptable for a per-invocation hook (ccgate is short-lived; one extra call per process is negligible against the ~1.6s typical decision latency). A model-keyed in-process cache could trim it later, but isn't worth it at this scale — happy to add it as a follow-up if usage pattern changes.

## Test plan

- [x] `go test -race -cover ./...` — all packages pass; `internal/llm/openai` coverage 0% → 70.6%.
- [x] `go vet ./...` — clean.
- [ ] Manual smoke against `gpt-5-nano`: error rate in `ccgate clm` should drop to ~0%.
- [ ] Manual smoke against `gpt-4o-mini` / `gpt-4.1-mini`: behavior unchanged (single request, `temperature=0` preserved).