### PR TITLE
docs: warn against reasoning models on the OpenAI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ Set `provider.name` (and optionally `provider.model`) in any layer:
 
 Then export the matching API key (`CCGATE_OPENAI_API_KEY` / `CCGATE_GEMINI_API_KEY` — see the [provider table](#3-api-key)). If the key is missing, ccgate falls through to the upstream tool's permission prompt, so flipping providers cannot break the hook.
 
+> **Avoid reasoning models** (`gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-chat`, `o1*`, `o3*`, `o4-mini`): they reject `temperature=0` (every request fails) and add seconds of chain-of-thought that ccgate's classification doesn't need. Use `gpt-4.1-nano`, `gpt-4o-mini`, or `gpt-5.4-nano-2026-03-17`.
+
 ### Routing through a compatible proxy
 
 ccgate calls the same chat-completions API every Anthropic / OpenAI client uses, so it works against any **OpenAI- or Anthropic-compatible** endpoint — including [LiteLLM proxy](https://docs.litellm.ai/docs/proxy/quick_start), Azure OpenAI, on-prem gateways, and regional endpoints. Pick the protocol the proxy speaks and set `provider.base_url`.

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -255,6 +255,8 @@ Claude Code と同じ環境変数を使います — [provider table](#3-api-キ
 
 対応する API キー (`CCGATE_OPENAI_API_KEY` / `CCGATE_GEMINI_API_KEY` — [provider table](#3-api-キー)) を export してください。キーが見つからない場合 ccgate は上流ツールの確認画面に fallthrough するため、provider 切替で hook が壊れることはありません。
 
+> **reasoning model は避ける** (`gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-chat`, `o1*`, `o3*`, `o4-mini`): `temperature=0` を拒否するため全リクエストが失敗し、分類タスクには不要な chain-of-thought に数秒かかります。`gpt-4.1-nano` / `gpt-4o-mini` / `gpt-5.4-nano-2026-03-17` を推奨。
+
 ### 互換 proxy 経由で叩く
 
 ccgate は Anthropic / OpenAI クライアントが使うのと同じ chat completions API を喋るので、**OpenAI 互換 / Anthropic 互換**の任意の endpoint — [LiteLLM proxy](https://docs.litellm.ai/docs/proxy/quick_start), Azure OpenAI, オンプレ gateway, 地域別 endpoint など — に対して動きます。proxy が話すプロトコルに合わせて `provider.base_url` を設定します。


### PR DESCRIPTION
## Why

ccgate calls the LLM on every tool invocation to emit a single `allow` / `deny` / `fallthrough` label — a classification task that doesn't benefit from multi-step reasoning. But nothing in the docs warns users away from picking a reasoning model, and OpenAI's listing puts `gpt-5-nano` next to `gpt-5.4-nano` with a lower per-token price, so it's an easy honest mistake.

In practice, picking one breaks ccgate two ways:

1. **`temperature=0` is rejected.** Reasoning models (`gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-chat`, `o1*`, `o3*`, `o4-mini`) only accept `temperature=1`, so every `Decide` call returns 400 and the host falls through to a manual prompt. A user running on `gpt-5-nano` saw ~6% error rate on `ccgate clm` until reverting.
2. **Chain-of-thought adds 5–15 s per decision.** Even when the request succeeds (e.g. via a wrapper that strips temperature), the model spends seconds on internal reasoning before emitting its three-token verdict, and bills those tokens as output. Measured locally: `gpt-5-nano` ~14–20 s/decision vs `gpt-5.4-nano` ~1.7 s for the same prompt.

Both failure modes vanish if users pick a non-reasoning model the first time. Cheaper to fix in docs than in code.

## What

A one-line callout under "Switching to OpenAI / Gemini" in `README.md` and `docs/ja/README.md`, naming the affected model families and the recommended alternatives that the surrounding text already uses (`gpt-4.1-nano`, `gpt-4o-mini`, `gpt-5.4-nano-2026-03-17`).

## Note

I sent #64 first proposing a code-side workaround (auto-retry without `temperature` + lower `reasoning_effort`). On reflection, the right answer is "don't pick a reasoning model for a per-call classifier" — the workaround papers over a config mistake without fixing the latency, and reasoning models have no upside for this task. Closing #64 in favor of this.