### PR TITLE
ci(renovate): run go mod tidy on gomod updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,7 @@
     ":prHourlyLimitNone",
   ],
   rangeStrategy: "bump",
+  postUpdateOptions: ["gomodTidy"],
   labels: ["renovate"],
   prConcurrentLimit: 0,
   prHourlyLimit: 0,


### PR DESCRIPTION
## Why

Renovate's gomod manager only refreshes the `go.sum` entries it touches by default. It does not run `go mod tidy` unless `postUpdateOptions` includes `gomodTidy` (or it is a major update with `gomodUpdateImportPaths` enabled, which we don't use).

That meant our Go-update PRs could leave `go.mod` / `go.sum` in a non-tidy state — extra or missing indirect entries that a local `go mod tidy` would have cleaned up.

Ref: https://docs.renovatebot.com/configuration-options/#postupdateoptions

## What

- Add `postUpdateOptions: ["gomodTidy"]` to `.github/renovate.json5` so every Go module bump runs `go mod tidy` before the PR is opened.
