### PR TITLE
feat: publish Homebrew formula via tak848/homebrew-tap

### DIFF
--- a/.github/workflows/release-dryrun.yml
+++ b/.github/workflows/release-dryrun.yml
@@ -1,0 +1,31 @@
+name: release dry-run
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  goreleaser-dryrun:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7.1.0
+        with:
+          version: "~> v2"
+          args: release --snapshot --clean --skip=publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+          retention-days: 7
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         id: tap-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.HOMEBREW_TAP_APP_ID }}
+          client-id: ${{ vars.HOMEBREW_TAP_APP_CLIENT_ID }}
           private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
           owner: tak848
           repositories: homebrew-tap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,18 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - name: Generate Homebrew tap App token
+        id: tap-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.HOMEBREW_TAP_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          owner: tak848
+          repositories: homebrew-tap
       - uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7.1.0
         with:
           version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.tap-token.outputs.token }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -69,6 +69,7 @@ brews:
     repository:
       owner: tak848
       name: homebrew-tap
+      branch: "ccgate-{{ .Version }}"
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
       pull_request:
         enabled: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -64,3 +64,21 @@ changelog:
       # land on docs / chore commits, and dropping them silently from
       # release notes hides them from users. Maintainers should still
       # cross-check release notes against CHANGELOG.md before tagging.
+brews:
+  - name: ccgate
+    repository:
+      owner: tak848
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+      pull_request:
+        enabled: true
+        base:
+          owner: tak848
+          name: homebrew-tap
+          branch: main
+    directory: Formula
+    homepage: "https://github.com/tak848/ccgate"
+    description: "LLM-powered PermissionRequest hook for coding agents (e.g. Claude Code)"
+    license: "MIT"
+    test: |
+      assert_match version.to_s, shell_output("#{bin}/ccgate --version")


### PR DESCRIPTION
## Why

Add Homebrew as a supported install path alongside mise / aqua / `go install` / GitHub Releases. `homebrew-core` is not an option for this project at its current popularity (self-submitted formulae need ≥225 stars / ≥90 forks / ≥90 watchers per [Acceptable Formulae](https://docs.brew.sh/Acceptable-Formulae)), so distribution goes through a personal tap at [`tak848/homebrew-tap`](https://github.com/tak848/homebrew-tap). End goal: `brew install tak848/tap/ccgate` works on macOS and Linux Homebrew.

## What

- `.goreleaser.yml`: add a `brews` block targeting `tak848/homebrew-tap` in PR mode (`pull_request.enabled: true`). `commit_author` is intentionally omitted so commits are attributed to the GitHub App identity and auto-signed by GitHub.
- `.github/workflows/release.yml`: add an `actions/create-github-app-token` step (pinned to v3.1.1) that mints a short-lived token scoped to `tak848/homebrew-tap` and passes it to GoReleaser via `HOMEBREW_TAP_GITHUB_TOKEN`.

## Out of scope (follow-ups, tracked separately)

- README install section update — held back until an end-to-end release has been verified.
- Tap-side `automerge.yml` workflow + ruleset enforcement toggle, both on `tak848/homebrew-tap`.
- Manual prereqs by the maintainer: create the GitHub App, register `HOMEBREW_TAP_APP_ID` / `HOMEBREW_TAP_APP_PRIVATE_KEY` secrets on this repo.