### PR TITLE
docs(readme): mention Homebrew tap install

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ go install github.com/tak848/ccgate@latest
 
 Download a binary from [Releases](https://github.com/tak848/ccgate/releases) and place it on your `PATH`.
 
+### Homebrew
+
+```bash
+brew install tak848/tap/ccgate
+```
+
+macOS and Linux.
+
 ## Setup — Claude Code
 
 ### 1. Create a config file (optional)


### PR DESCRIPTION
## Why

Make the Homebrew install path discoverable for users who already manage their CLIs through `brew`. Listed at the bottom of the install section without "recommended" framing — `mise` / `aqua` remain the canonical paths.

## What

- README: add a `### Homebrew` subsection after `### GitHub Releases` with the `brew install tak848/tap/ccgate` one-liner and a one-line note that it works on macOS and Linux.

## Depends on

- #74 (Homebrew formula publishing pipeline) — must land first and produce a verified release before this snippet is truthful.