### PR TITLE
feat: load main worktree's ccgate.local.jsonnet from linked worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ So `~/.<target>/ccgate.jsonnet` that wants to bump just the model still has to r
 
 Project-local configs are loaded only when **not tracked by Git**.
 
+In a linked git worktree (`git worktree add ...`), ccgate also reads the **main worktree's** untracked `ccgate.local.jsonnet` before the current worktree's, so the personal rules in your main checkout stay active. Set `disable_load_main_worktree_local_config: true` in defaults or global config to opt out. Full details in [docs/configuration.md#linked-git-worktrees](docs/configuration.md#linked-git-worktrees).
+
 
 ### Config fields
 
@@ -269,6 +271,7 @@ Project-local configs are loaded only when **not tracked by Git**.
 | `metrics_disabled`       | bool                              | `false`                                                                       | Disable metrics collection entirely                                                                    |
 | `metrics_max_size`       | int                               | `2097152`                                                                     | Max metrics file size in bytes before rotation (default 2MB). `0` = no rotation.                       |
 | `fallthrough_strategy`   | `"ask"` / `"allow"` / `"deny"`    | `"ask"`                                                                       | How to resolve LLM uncertainty (`fallthrough`). See [Unattended automation](#unattended-automation-fallthrough_strategy). |
+| `disable_load_main_worktree_local_config` | bool | `false`                                                                       | When ccgate runs in a linked git worktree, default behaviour reads the main worktree's untracked `ccgate.local.jsonnet` before the current worktree's. Set `true` to skip the main worktree. See [docs/configuration.md#linked-git-worktrees](docs/configuration.md#linked-git-worktrees). |
 | `allow`                  | string[]                          | `[]`                                                                          | Allow guidance rules. **Replaces** the value carried over from earlier layers when set.                |
 | `deny`                   | string[]                          | `[]`                                                                          | Deny guidance rules (mandatory). Supports inline `deny_message:` hints. Same replace semantics as `allow`. |
 | `environment`            | string[]                          | `[]`                                                                          | Context strings passed to the LLM (trust level, policies, etc.). Same replace semantics as `allow`.    |

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ So `~/.<target>/ccgate.jsonnet` that wants to bump just the model still has to r
 
 Project-local configs are loaded only when **not tracked by Git**.
 
-In a linked git worktree (`git worktree add ...`), ccgate also reads the **main worktree's** untracked `ccgate.local.jsonnet` before the current worktree's, so the personal rules in your main checkout stay active. Set `disable_load_main_worktree_local_config: true` in defaults or global config to opt out. Full details in [docs/configuration.md#linked-git-worktrees](docs/configuration.md#linked-git-worktrees).
+In a linked git worktree, the main worktree's `ccgate.local.jsonnet` is also read, layered before the current worktree's. Disable with `disable_load_main_worktree_local_config: true`. See [docs/configuration.md](docs/configuration.md#linked-git-worktrees).
 
 
 ### Config fields
@@ -271,7 +271,7 @@ In a linked git worktree (`git worktree add ...`), ccgate also reads the **main 
 | `metrics_disabled`       | bool                              | `false`                                                                       | Disable metrics collection entirely                                                                    |
 | `metrics_max_size`       | int                               | `2097152`                                                                     | Max metrics file size in bytes before rotation (default 2MB). `0` = no rotation.                       |
 | `fallthrough_strategy`   | `"ask"` / `"allow"` / `"deny"`    | `"ask"`                                                                       | How to resolve LLM uncertainty (`fallthrough`). See [Unattended automation](#unattended-automation-fallthrough_strategy). |
-| `disable_load_main_worktree_local_config` | bool | `false`                                                                       | When ccgate runs in a linked git worktree, default behaviour reads the main worktree's untracked `ccgate.local.jsonnet` before the current worktree's. Set `true` to skip the main worktree. See [docs/configuration.md#linked-git-worktrees](docs/configuration.md#linked-git-worktrees). |
+| `disable_load_main_worktree_local_config` | bool | `false`                                                                       | In a linked git worktree, skip the main worktree's `ccgate.local.jsonnet`. See [docs/configuration.md](docs/configuration.md#linked-git-worktrees). |
 | `allow`                  | string[]                          | `[]`                                                                          | Allow guidance rules. **Replaces** the value carried over from earlier layers when set.                |
 | `deny`                   | string[]                          | `[]`                                                                          | Deny guidance rules (mandatory). Supports inline `deny_message:` hints. Same replace semantics as `allow`. |
 | `environment`            | string[]                          | `[]`                                                                          | Context strings passed to the LLM (trust level, policies, etc.). Same replace semantics as `allow`.    |

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ So `~/.<target>/ccgate.jsonnet` that wants to bump just the model still has to r
 
 Project-local configs are loaded only when **not tracked by Git**.
 
-In a linked git worktree, the main worktree's `ccgate.local.jsonnet` is also read, layered before the current worktree's. Disable with `disable_load_main_worktree_local_config: true`. See [docs/configuration.md](docs/configuration.md#linked-git-worktrees).
+In a linked git worktree, the main worktree's `ccgate.local.jsonnet` is also read, layered before the current worktree's. Disable with `disable_load_main_worktree_local_config: true`. See [docs/configuration.md](docs/configuration.md#where-ccgate-looks-for-config).
 
 
 ### Config fields
@@ -271,7 +271,7 @@ In a linked git worktree, the main worktree's `ccgate.local.jsonnet` is also rea
 | `metrics_disabled`       | bool                              | `false`                                                                       | Disable metrics collection entirely                                                                    |
 | `metrics_max_size`       | int                               | `2097152`                                                                     | Max metrics file size in bytes before rotation (default 2MB). `0` = no rotation.                       |
 | `fallthrough_strategy`   | `"ask"` / `"allow"` / `"deny"`    | `"ask"`                                                                       | How to resolve LLM uncertainty (`fallthrough`). See [Unattended automation](#unattended-automation-fallthrough_strategy). |
-| `disable_load_main_worktree_local_config` | bool | `false`                                                                       | In a linked git worktree, skip the main worktree's `ccgate.local.jsonnet`. See [docs/configuration.md](docs/configuration.md#linked-git-worktrees). |
+| `disable_load_main_worktree_local_config` | bool | `false`                                                                       | In a linked git worktree, skip the main worktree's `ccgate.local.jsonnet`. See [docs/configuration.md](docs/configuration.md#where-ccgate-looks-for-config). |
 | `allow`                  | string[]                          | `[]`                                                                          | Allow guidance rules. **Replaces** the value carried over from earlier layers when set.                |
 | `deny`                   | string[]                          | `[]`                                                                          | Deny guidance rules (mandatory). Supports inline `deny_message:` hints. Same replace semantics as `allow`. |
 | `environment`            | string[]                          | `[]`                                                                          | Context strings passed to the LLM (trust level, policies, etc.). Same replace semantics as `allow`.    |

--- a/README.md
+++ b/README.md
@@ -240,9 +240,10 @@ Same env vars as Claude Code — see the [provider table](#3-api-key).
 |------:|-------------|-----------|
 | 1     | Embedded defaults (always applied as the base) | Embedded defaults (same) |
 | 2     | `~/.claude/ccgate.jsonnet` — global (layered on top) | `~/.codex/ccgate.jsonnet` — global (same) |
-| 3     | `{repo_root}/.claude/ccgate.local.jsonnet` — project-local (untracked only, layered on top) | `{repo_root}/.codex/ccgate.local.jsonnet` — project-local (same) |
+| 3     | `{main_worktree}/.claude/ccgate.local.jsonnet` — main-worktree project-local (untracked only; only when running in a linked git worktree) | `{main_worktree}/.codex/ccgate.local.jsonnet` (same) |
+| 4     | `{repo_root}/.claude/ccgate.local.jsonnet` — current-worktree project-local (untracked only) | `{repo_root}/.codex/ccgate.local.jsonnet` (same) |
 
-All three layers compose with the same rules:
+All layers compose with the same rules:
 
 - **Lists** — `allow` / `deny` / `environment` **replace** the value carried over from earlier layers when the layer sets them (even to `[]`). The `append_*` siblings (`append_allow`, `append_deny`, `append_environment`) **add** entries on top of whatever the earlier layers produced.
 - **Scalars** — `log_*`, `metrics_*`, `fallthrough_strategy` are overwritten per-field when the layer sets them, otherwise the earlier value survives.
@@ -252,7 +253,7 @@ So `~/.<target>/ccgate.jsonnet` that wants to bump just the model still has to r
 
 Project-local configs are loaded only when **not tracked by Git**.
 
-In a linked git worktree, the main worktree's `ccgate.local.jsonnet` is also read, layered before the current worktree's. Disable with `disable_load_main_worktree_local_config: true`. See [docs/configuration.md](docs/configuration.md#where-ccgate-looks-for-config).
+Set `disable_load_main_worktree_local_config: true` in layer (1) or (2) to skip layer (3). The flag is honoured only at those two layers — written into (3) or (4) it is ignored. See [docs/configuration.md](docs/configuration.md#where-ccgate-looks-for-config).
 
 
 ### Config fields

--- a/ccgate.schema.json
+++ b/ccgate.schema.json
@@ -151,6 +151,10 @@
       "enum": ["ask", "allow", "deny"],
       "description": "How to resolve LLM-driven fallthrough decisions. 'ask' (default): defer to Claude Code's prompt. 'deny': auto-deny uncertain requests; the hook message tells Claude that the decision was forced for safety and that it must not ask the user or bypass the restriction. 'allow': auto-approve uncertain requests; note that Claude Code's hook spec only delivers decision.message on deny, so Claude will NOT see any warning that an uncertain request was auto-approved — choose this only when you are comfortable with that. Only LLM fallthrough is affected (bypassPermissions, dontAsk, missing API key, non-Anthropic provider, and ExitPlanMode/AskUserQuestion still defer to Claude Code regardless)."
     },
+    "disable_load_main_worktree_local_config": {
+      "type": "boolean",
+      "description": "Kill switch for the linked-worktree convenience that reads the main worktree's untracked project-local config (e.g. <main_worktree>/.claude/ccgate.local.jsonnet, or .codex/...) before the current worktree's local config. Default: false (the main worktree is read). Set to true to skip the main worktree entirely and use only the current worktree's local config. Only evaluated at the embed/global layer — values written into project-local config are ignored to avoid a chicken-and-egg loop."
+    },
     "environment": {
       "type": "array",
       "items": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,19 +6,24 @@ Cross-target configuration reference. The [root README](../README.md) lists the 
 
 ## Where ccgate looks for config
 
-ccgate evaluates three layers, in order, per target. Every layer composes with the same merge semantics (see "How layers compose" below):
+ccgate evaluates these layers, in order, per target. Every layer composes with the same merge semantics (see "How layers compose" below):
 
 1. **Embedded defaults.** Compiled into the binary. Always applied as the base. Inspect with `ccgate <target> init`.
 2. **Global config**, layered on top of the embedded defaults if present:
    - Claude Code: `~/.claude/ccgate.jsonnet`
    - Codex CLI:   `~/.codex/ccgate.jsonnet`
-3. **Project-local overrides**, layered on top of (1)+(2). Tracked files are ignored (see "Why tracked files are skipped" below):
+3. **Main-worktree project-local**, only when ccgate runs in a linked git worktree (`git worktree add ...`). Tracked files are ignored (see "Why tracked files are skipped" below):
+   - Claude Code: `{main_worktree}/.claude/ccgate.local.jsonnet`
+   - Codex CLI:   `{main_worktree}/.codex/ccgate.local.jsonnet`
+4. **Current-worktree project-local.** Tracked files are ignored:
    - Claude Code: `{repo_root}/.claude/ccgate.local.jsonnet`
    - Codex CLI:   `{repo_root}/.codex/ccgate.local.jsonnet`
 
-   In a linked git worktree (`git worktree add ...`), the main worktree's `ccgate.local.jsonnet` (or `.codex/...`) is read first, then the current worktree's. Set `disable_load_main_worktree_local_config: true` in defaults or global to skip the main-worktree side. Relative paths (`log_path`, `metrics_path`, `auth.path`, …) resolve against the current cwd, not against the config file's directory.
+`{repo_root}` is the git repo root, resolved via `git rev-parse --show-toplevel` from the hook's `cwd`. `{main_worktree}` is the same repo's main worktree root, derived from `git rev-parse --git-common-dir`. Outside a git repo the `cwd` itself is used.
 
-`{repo_root}` is the git repo root, resolved via `git rev-parse --show-toplevel` from the hook's `cwd`. Outside a git repo the `cwd` itself is used.
+Set `disable_load_main_worktree_local_config: true` in layer (1) or (2) to skip layer (3). The flag is honoured **only** at those two layers — written into (3) or (4) it is ignored.
+
+Relative paths in any layer (`log_path`, `metrics_path`, `auth.path`, …) resolve against the current cwd, not against the config file's directory.
 
 
 ### How layers compose

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,33 +20,11 @@ ccgate evaluates three layers, in order, per target. Every layer composes with t
 
 ### Linked git worktrees
 
-When ccgate runs inside a linked git worktree (`git worktree add ...`), step (3) gains an extra sub-layer: the **main worktree's** untracked `ccgate.local.jsonnet` is read *before* the current worktree's. The intent is to keep the personal rules from your main checkout active in temporary worktrees (PR reviews, parallel branches) without copying or symlinking the file.
+When ccgate runs inside a linked git worktree (`git worktree add ...`), step (3) also reads the main worktree's untracked `ccgate.local.jsonnet` (or `.codex/...`), layered *before* the current worktree's.
 
-| Sub-layer (in merge order, within step 3) | Behavior |
-|---|---|
-| 3a. Main-worktree project-local: `{main_worktree}/.claude/ccgate.local.jsonnet` (or `.codex/...`) | **New.** Read only when ccgate is inside a linked worktree and the file is untracked. |
-| 3b. Current-worktree project-local | Same as before. |
+Set `disable_load_main_worktree_local_config: true` in defaults or global to skip the main worktree.
 
-This is a ccgate-specific convenience — Claude Code and Codex CLI themselves do not inherit their own project-local config files from the main worktree.
-
-**Turning the inherit off.** Set `disable_load_main_worktree_local_config: true` in the embedded defaults or in your global config. The flag is evaluated at the embed+global layer only; writing it into either project-local layer is **ignored** (ccgate would have to read the main config to decide whether to read the main config). A debug dump can therefore show `disable_load_main_worktree_local_config: true` while the runtime keeps reading the main layer, if the `true` was set in project-local.
-
-**`append_*` carries across both sub-layers.** Entries appended in main-worktree local stack onto the current worktree's appends as you'd expect. Removing a single appended rule from the current worktree alone is not possible; this is the same constraint that applies between any two layers (see "Known limitations").
-
-**Relative paths use the current cwd.** `log_path` / `metrics_path` / `auth.path` and other path fields are handed to the OS verbatim once `~/` has been expanded — there is no rewriting of relative paths against the file's directory. A `log_path: 'logs/ccgate.log'` written in the main-worktree config will resolve under the current worktree's cwd, not the main worktree's. Use absolute or `~/`-prefixed paths if you want a single, worktree-independent location.
-
-**Per-worktree env switch (optional).** ccgate does not reserve any env var for this option, but the global config can read your own env vars through `std.native('env')`:
-
-```jsonnet
-// ~/.claude/ccgate.jsonnet
-// Env var name is YOUR choice — ccgate doesn't read a specific one.
-{
-  disable_load_main_worktree_local_config:
-    std.native('env')('SKIP_MAIN_WORKTREE_CCGATE') == 'true',
-}
-```
-
-With direnv, put `export SKIP_MAIN_WORKTREE_CCGATE=true` in `<worktree>/.envrc` to disable inheriting only for that worktree.
+Relative paths (`log_path`, `metrics_path`, `auth.path`, …) resolve against the current cwd, not against the file's directory — use absolute or `~/`-prefixed paths if you need a worktree-independent location.
 
 
 ### How layers compose

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,36 @@ ccgate evaluates three layers, in order, per target. Every layer composes with t
 
 `{repo_root}` is the git repo root, resolved via `git rev-parse --show-toplevel` from the hook's `cwd`. Outside a git repo the `cwd` itself is used.
 
+### Linked git worktrees
+
+When ccgate runs inside a linked git worktree (`git worktree add ...`), step (3) gains an extra sub-layer: the **main worktree's** untracked `ccgate.local.jsonnet` is read *before* the current worktree's. The intent is to keep the personal rules from your main checkout active in temporary worktrees (PR reviews, parallel branches) without copying or symlinking the file.
+
+| Sub-layer (in merge order, within step 3) | Behavior |
+|---|---|
+| 3a. Main-worktree project-local: `{main_worktree}/.claude/ccgate.local.jsonnet` (or `.codex/...`) | **New.** Read only when ccgate is inside a linked worktree and the file is untracked. |
+| 3b. Current-worktree project-local | Same as before. |
+
+This is a ccgate-specific convenience — Claude Code and Codex CLI themselves do not inherit their own project-local config files from the main worktree.
+
+**Turning the inherit off.** Set `disable_load_main_worktree_local_config: true` in the embedded defaults or in your global config. The flag is evaluated at the embed+global layer only; writing it into either project-local layer is **ignored** (ccgate would have to read the main config to decide whether to read the main config). A debug dump can therefore show `disable_load_main_worktree_local_config: true` while the runtime keeps reading the main layer, if the `true` was set in project-local.
+
+**`append_*` carries across both sub-layers.** Entries appended in main-worktree local stack onto the current worktree's appends as you'd expect. Removing a single appended rule from the current worktree alone is not possible; this is the same constraint that applies between any two layers (see "Known limitations").
+
+**Relative paths use the current cwd.** `log_path` / `metrics_path` / `auth.path` and other path fields are handed to the OS verbatim once `~/` has been expanded — there is no rewriting of relative paths against the file's directory. A `log_path: 'logs/ccgate.log'` written in the main-worktree config will resolve under the current worktree's cwd, not the main worktree's. Use absolute or `~/`-prefixed paths if you want a single, worktree-independent location.
+
+**Per-worktree env switch (optional).** ccgate does not reserve any env var for this option, but the global config can read your own env vars through `std.native('env')`:
+
+```jsonnet
+// ~/.claude/ccgate.jsonnet
+// Env var name is YOUR choice — ccgate doesn't read a specific one.
+{
+  disable_load_main_worktree_local_config:
+    std.native('env')('SKIP_MAIN_WORKTREE_CCGATE') == 'true',
+}
+```
+
+With direnv, put `export SKIP_MAIN_WORKTREE_CCGATE=true` in `<worktree>/.envrc` to disable inheriting only for that worktree.
+
 
 ### How layers compose
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,15 +16,9 @@ ccgate evaluates three layers, in order, per target. Every layer composes with t
    - Claude Code: `{repo_root}/.claude/ccgate.local.jsonnet`
    - Codex CLI:   `{repo_root}/.codex/ccgate.local.jsonnet`
 
+   In a linked git worktree (`git worktree add ...`), the main worktree's `ccgate.local.jsonnet` (or `.codex/...`) is read first, then the current worktree's. Set `disable_load_main_worktree_local_config: true` in defaults or global to skip the main-worktree side. Relative paths (`log_path`, `metrics_path`, `auth.path`, …) resolve against the current cwd, not against the config file's directory.
+
 `{repo_root}` is the git repo root, resolved via `git rev-parse --show-toplevel` from the hook's `cwd`. Outside a git repo the `cwd` itself is used.
-
-### Linked git worktrees
-
-When ccgate runs inside a linked git worktree (`git worktree add ...`), step (3) also reads the main worktree's untracked `ccgate.local.jsonnet` (or `.codex/...`), layered *before* the current worktree's.
-
-Set `disable_load_main_worktree_local_config: true` in defaults or global to skip the main worktree.
-
-Relative paths (`log_path`, `metrics_path`, `auth.path`, …) resolve against the current cwd, not against the file's directory — use absolute or `~/`-prefixed paths if you need a worktree-independent location.
 
 
 ### How layers compose

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -242,6 +242,8 @@ Claude Code と同じ環境変数を使います — [provider table](#3-api-キ
 `~/.<target>/ccgate.jsonnet` で model だけ変えたい場合でも `provider: {name: 'anthropic', model: 'claude-sonnet-4-6'}` のように block 全体を書き直す必要があります (embedded の `allow` / `deny` はそのまま残ります)。`allow: [...]` を書けば embedded の allow を完全に差し替え (これは v0.6 以前のグローバル設定がすでに行っていた挙動なので、そのまま冪等)。プロジェクトローカル設定は典型的に `append_deny: [...]` / `append_environment: [...]` で追加制限を載せます。
 プロジェクトローカル設定は **Git に追跡されていないファイルのみ** 読み込まれます。
 
+linked git worktree (`git worktree add ...`) の中で動作する場合、ccgate は current worktree の前に **main worktree** 側の untracked な `ccgate.local.jsonnet` も読みます。main checkout に置いた個人ルールが一時 worktree でもそのまま効くようにするためです。default / global 層に `disable_load_main_worktree_local_config: true` を書けば opt-out 可能。詳細は [docs/configuration.md#linked-git-worktrees](configuration.md#linked-git-worktree-でのふるまい) を参照。
+
 
 ### 設定項目
 
@@ -259,6 +261,7 @@ Claude Code と同じ環境変数を使います — [provider table](#3-api-キ
 | `metrics_disabled`       | bool                              | `false`                                                                         | メトリクス収集を完全に無効化                                                                               |
 | `metrics_max_size`       | int                               | `2097152`                                                                       | ローテーション閾値 (bytes, デフォルト 2MB)。`0` = ローテーションなし                                       |
 | `fallthrough_strategy`   | `"ask"` / `"allow"` / `"deny"`    | `"ask"`                                                                         | LLM が判定に迷った (`fallthrough`) 際の扱い。[完全自動運転モード](#完全自動運転モード-fallthrough_strategy) 参照 |
+| `disable_load_main_worktree_local_config` | bool | `false`                                                                         | linked git worktree で ccgate が動作するとき、default では main worktree 側の untracked な `ccgate.local.jsonnet` を current worktree のものより先に読みます。`true` を書くと main 側を読まなくなります。詳細は [docs/configuration.md#linked-git-worktrees](configuration.md#linked-git-worktree-でのふるまい) |
 | `allow`                  | string[]                          | `[]`                                                                            | 許可ルール。設定すると前の layer から引き継いだ list を **完全置換**                                       |
 | `deny`                   | string[]                          | `[]`                                                                            | 拒否ルール (mandatory)。`deny_message:` ヒント対応。`allow` と同じく置換                                   |
 | `environment`            | string[]                          | `[]`                                                                            | LLM に渡すコンテキスト (信頼レベル、ポリシー等)。`allow` と同じく置換                                       |

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -242,7 +242,7 @@ Claude Code と同じ環境変数を使います — [provider table](#3-api-キ
 `~/.<target>/ccgate.jsonnet` で model だけ変えたい場合でも `provider: {name: 'anthropic', model: 'claude-sonnet-4-6'}` のように block 全体を書き直す必要があります (embedded の `allow` / `deny` はそのまま残ります)。`allow: [...]` を書けば embedded の allow を完全に差し替え (これは v0.6 以前のグローバル設定がすでに行っていた挙動なので、そのまま冪等)。プロジェクトローカル設定は典型的に `append_deny: [...]` / `append_environment: [...]` で追加制限を載せます。
 プロジェクトローカル設定は **Git に追跡されていないファイルのみ** 読み込まれます。
 
-linked git worktree では main worktree 側の `ccgate.local.jsonnet` も読まれます (current worktree より先)。`disable_load_main_worktree_local_config: true` で無効化。詳細は [docs/configuration.md](configuration.md#linked-git-worktree-でのふるまい) を参照。
+linked git worktree では main worktree 側の `ccgate.local.jsonnet` も読まれます (current worktree より先)。`disable_load_main_worktree_local_config: true` で無効化。詳細は [docs/configuration.md](configuration.md#ccgate-が-config-を探す場所) を参照。
 
 
 ### 設定項目
@@ -261,7 +261,7 @@ linked git worktree では main worktree 側の `ccgate.local.jsonnet` も読ま
 | `metrics_disabled`       | bool                              | `false`                                                                         | メトリクス収集を完全に無効化                                                                               |
 | `metrics_max_size`       | int                               | `2097152`                                                                       | ローテーション閾値 (bytes, デフォルト 2MB)。`0` = ローテーションなし                                       |
 | `fallthrough_strategy`   | `"ask"` / `"allow"` / `"deny"`    | `"ask"`                                                                         | LLM が判定に迷った (`fallthrough`) 際の扱い。[完全自動運転モード](#完全自動運転モード-fallthrough_strategy) 参照 |
-| `disable_load_main_worktree_local_config` | bool | `false`                                                                         | linked git worktree で ccgate が動作するとき、default では main worktree 側の untracked な `ccgate.local.jsonnet` を current worktree のものより先に読みます。`true` を書くと main 側を読まなくなります。詳細は [docs/configuration.md#linked-git-worktrees](configuration.md#linked-git-worktree-でのふるまい) |
+| `disable_load_main_worktree_local_config` | bool | `false`                                                                         | linked git worktree で main worktree 側の `ccgate.local.jsonnet` を読むのをスキップ。詳細は [docs/configuration.md](configuration.md#ccgate-が-config-を探す場所) |
 | `allow`                  | string[]                          | `[]`                                                                            | 許可ルール。設定すると前の layer から引き継いだ list を **完全置換**                                       |
 | `deny`                   | string[]                          | `[]`                                                                            | 拒否ルール (mandatory)。`deny_message:` ヒント対応。`allow` と同じく置換                                   |
 | `environment`            | string[]                          | `[]`                                                                            | LLM に渡すコンテキスト (信頼レベル、ポリシー等)。`allow` と同じく置換                                       |

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -242,7 +242,7 @@ Claude Code と同じ環境変数を使います — [provider table](#3-api-キ
 `~/.<target>/ccgate.jsonnet` で model だけ変えたい場合でも `provider: {name: 'anthropic', model: 'claude-sonnet-4-6'}` のように block 全体を書き直す必要があります (embedded の `allow` / `deny` はそのまま残ります)。`allow: [...]` を書けば embedded の allow を完全に差し替え (これは v0.6 以前のグローバル設定がすでに行っていた挙動なので、そのまま冪等)。プロジェクトローカル設定は典型的に `append_deny: [...]` / `append_environment: [...]` で追加制限を載せます。
 プロジェクトローカル設定は **Git に追跡されていないファイルのみ** 読み込まれます。
 
-linked git worktree (`git worktree add ...`) の中で動作する場合、ccgate は current worktree の前に **main worktree** 側の untracked な `ccgate.local.jsonnet` も読みます。main checkout に置いた個人ルールが一時 worktree でもそのまま効くようにするためです。default / global 層に `disable_load_main_worktree_local_config: true` を書けば opt-out 可能。詳細は [docs/configuration.md#linked-git-worktrees](configuration.md#linked-git-worktree-でのふるまい) を参照。
+linked git worktree では main worktree 側の `ccgate.local.jsonnet` も読まれます (current worktree より先)。`disable_load_main_worktree_local_config: true` で無効化。詳細は [docs/configuration.md](configuration.md#linked-git-worktree-でのふるまい) を参照。
 
 
 ### 設定項目

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -231,9 +231,10 @@ Claude Code と同じ環境変数を使います — [provider table](#3-api-キ
 |----:|-------------|-----------|
 | 1 | 組み込みデフォルト (常にベースとして適用) | 同じ |
 | 2 | `~/.claude/ccgate.jsonnet` — グローバル (上に重ねる) | `~/.codex/ccgate.jsonnet` — グローバル (同じ) |
-| 3 | `{repo_root}/.claude/ccgate.local.jsonnet` — プロジェクトローカル (Git 未追跡のみ、上に重ねる) | `{repo_root}/.codex/ccgate.local.jsonnet` — プロジェクトローカル (同じ) |
+| 3 | `{main_worktree}/.claude/ccgate.local.jsonnet` — main worktree プロジェクトローカル (Git 未追跡のみ、linked git worktree のときのみ) | `{main_worktree}/.codex/ccgate.local.jsonnet` (同じ) |
+| 4 | `{repo_root}/.claude/ccgate.local.jsonnet` — current worktree プロジェクトローカル (Git 未追跡のみ) | `{repo_root}/.codex/ccgate.local.jsonnet` (同じ) |
 
-3 つの layer はすべて同じ merge ルールで合成されます:
+各 layer はすべて同じ merge ルールで合成されます:
 
 - **list**: `allow` / `deny` / `environment` は値を設定した layer が前の layer から引き継いだ list を **置き換える** (`[]` を書けば空 list に置き換え)。`append_*` 系 (`append_allow` / `append_deny` / `append_environment`) は前の layer の累積 list の **末尾に追加** する。
 - **スカラー**: `log_*` / `metrics_*` / `fallthrough_strategy` はその layer がフィールドを設定していれば per-field で上書き、設定していなければ前の値を保持。
@@ -242,7 +243,7 @@ Claude Code と同じ環境変数を使います — [provider table](#3-api-キ
 `~/.<target>/ccgate.jsonnet` で model だけ変えたい場合でも `provider: {name: 'anthropic', model: 'claude-sonnet-4-6'}` のように block 全体を書き直す必要があります (embedded の `allow` / `deny` はそのまま残ります)。`allow: [...]` を書けば embedded の allow を完全に差し替え (これは v0.6 以前のグローバル設定がすでに行っていた挙動なので、そのまま冪等)。プロジェクトローカル設定は典型的に `append_deny: [...]` / `append_environment: [...]` で追加制限を載せます。
 プロジェクトローカル設定は **Git に追跡されていないファイルのみ** 読み込まれます。
 
-linked git worktree では main worktree 側の `ccgate.local.jsonnet` も読まれます (current worktree より先)。`disable_load_main_worktree_local_config: true` で無効化。詳細は [docs/configuration.md](configuration.md#ccgate-が-config-を探す場所) を参照。
+`disable_load_main_worktree_local_config: true` を (1) または (2) に書けば (3) をスキップします。この flag は (1) / (2) でのみ有効で、(3) / (4) に書いても無視されます。詳細は [docs/configuration.md](configuration.md#ccgate-が-config-を探す場所) を参照。
 
 
 ### 設定項目

--- a/docs/ja/configuration.md
+++ b/docs/ja/configuration.md
@@ -16,15 +16,9 @@ ccgate は target ごとに 3 つの設定層を順に読み込みます。各�
    - Claude Code: `{repo_root}/.claude/ccgate.local.jsonnet`
    - Codex CLI:   `{repo_root}/.codex/ccgate.local.jsonnet`
 
+   linked git worktree (`git worktree add ...`) の中では、main worktree 側の `ccgate.local.jsonnet` (or `.codex/...`) が先に読まれ、続いて current worktree 側が読まれます。`disable_load_main_worktree_local_config: true` を defaults / global に書けば main 側をスキップします。相対パス (`log_path` / `metrics_path` / `auth.path` 等) は config file の置き場所ではなく **current cwd** 基準で解決されます。
+
 `{repo_root}` は git repo root で、hook の `cwd` から `git rev-parse --show-toplevel` で解決します。git repo 外では `cwd` 自体が使われます。
-
-### linked git worktree でのふるまい
-
-ccgate が linked git worktree (`git worktree add ...`) の中で動作するとき、上記 (3) は main worktree 側の untracked な `ccgate.local.jsonnet` (or `.codex/...`) も読みます。順序は main 側 → current worktree 側。
-
-`disable_load_main_worktree_local_config: true` を defaults / global に書けば main 側をスキップします。
-
-相対パス (`log_path` / `metrics_path` / `auth.path` 等) は file の置き場所ではなく **current cwd** 基準で解決されます。worktree に依存しない単一の場所を指したいときは絶対パスか `~/` を使ってください。
 
 
 ### layer の合成ルール

--- a/docs/ja/configuration.md
+++ b/docs/ja/configuration.md
@@ -18,6 +18,36 @@ ccgate は target ごとに 3 つの設定層を順に読み込みます。各�
 
 `{repo_root}` は git repo root で、hook の `cwd` から `git rev-parse --show-toplevel` で解決します。git repo 外では `cwd` 自体が使われます。
 
+### linked git worktree でのふるまい
+
+ccgate が linked git worktree (`git worktree add ...`) の中で動作するとき、上記 (3) には sub-layer が追加されます: **main worktree** 側の untracked な `ccgate.local.jsonnet` を、current worktree のものより *先に* 読みます。PR レビュー用や並行作業用の一時 worktree でも、main checkout に置いた個人ルールをそのまま使い続けたい、というニーズに応えるためのものです。
+
+| sub-layer (merge 順、step 3 内) | 動作 |
+|---|---|
+| 3a. main-worktree project-local: `{main_worktree}/.claude/ccgate.local.jsonnet` (or `.codex/...`) | **新規**。ccgate が linked worktree 内で動作し、かつ当該 file が untracked のときのみ読み込む |
+| 3b. current-worktree project-local | 従来どおり |
+
+これは ccgate 独自の便宜であり、Claude Code 本体 / Codex CLI 本体は main worktree から自分達の project-local 設定を継承するわけではありません。ccgate が自前の untracked な `ccgate.local.jsonnet` だけにこの層を足しています。
+
+**継承を無効化する**: `disable_load_main_worktree_local_config: true` を embedded defaults もしくは global config に書く。flag は embed + global の 2 層までで確定し、project-local (main / current いずれ) に書いても **無視** されます (main の config を読むかどうかを決めるのに main の config を読まないといけない、という鶏卵問題を避けるため)。そのため debug dump で `disable_load_main_worktree_local_config: true` が見えていても、その `true` を project-local に書いた場合は実挙動では main 側が読まれ続けます。
+
+**`append_*` は両 sub-layer をまたいで累積**: main-worktree local で append したものは current-worktree local の append にそのまま積まれます。current worktree 側で「main から来た特定 1 行だけを取り消す」操作はマージ規則上できません — これは layer 間共通の制約です (「既知の制約」参照)。
+
+**相対パスは current worktree の cwd 基準**: `log_path` / `metrics_path` / `auth.path` 等の path 系 field は、`~/` の展開だけ ccgate が行い、それ以外の相対パスは OS にそのまま渡されます。main worktree の config に `log_path: 'logs/ccgate.log'` と書いても、それは main worktree ではなく **current worktree** の cwd 基準で解決されます。worktree に依存しない単一の場所を指したいときは絶対パスか `~/` を使ってください。
+
+**per-worktree で env から切り替える (任意)**: ccgate は本機能用の env var を予約していませんが、global config から `std.native('env')` を使えば任意の env var を読めます:
+
+```jsonnet
+// ~/.claude/ccgate.jsonnet
+// env var の名前は user 側で自由に決める — ccgate は特定 env を予約しない
+{
+  disable_load_main_worktree_local_config:
+    std.native('env')('SKIP_MAIN_WORKTREE_CCGATE') == 'true',
+}
+```
+
+direnv なら `<worktree>/.envrc` に `export SKIP_MAIN_WORKTREE_CCGATE=true` を入れることで、その worktree でだけ継承を切れます。
+
 
 ### layer の合成ルール
 

--- a/docs/ja/configuration.md
+++ b/docs/ja/configuration.md
@@ -20,33 +20,11 @@ ccgate は target ごとに 3 つの設定層を順に読み込みます。各�
 
 ### linked git worktree でのふるまい
 
-ccgate が linked git worktree (`git worktree add ...`) の中で動作するとき、上記 (3) には sub-layer が追加されます: **main worktree** 側の untracked な `ccgate.local.jsonnet` を、current worktree のものより *先に* 読みます。PR レビュー用や並行作業用の一時 worktree でも、main checkout に置いた個人ルールをそのまま使い続けたい、というニーズに応えるためのものです。
+ccgate が linked git worktree (`git worktree add ...`) の中で動作するとき、上記 (3) は main worktree 側の untracked な `ccgate.local.jsonnet` (or `.codex/...`) も読みます。順序は main 側 → current worktree 側。
 
-| sub-layer (merge 順、step 3 内) | 動作 |
-|---|---|
-| 3a. main-worktree project-local: `{main_worktree}/.claude/ccgate.local.jsonnet` (or `.codex/...`) | **新規**。ccgate が linked worktree 内で動作し、かつ当該 file が untracked のときのみ読み込む |
-| 3b. current-worktree project-local | 従来どおり |
+`disable_load_main_worktree_local_config: true` を defaults / global に書けば main 側をスキップします。
 
-これは ccgate 独自の便宜であり、Claude Code 本体 / Codex CLI 本体は main worktree から自分達の project-local 設定を継承するわけではありません。ccgate が自前の untracked な `ccgate.local.jsonnet` だけにこの層を足しています。
-
-**継承を無効化する**: `disable_load_main_worktree_local_config: true` を embedded defaults もしくは global config に書く。flag は embed + global の 2 層までで確定し、project-local (main / current いずれ) に書いても **無視** されます (main の config を読むかどうかを決めるのに main の config を読まないといけない、という鶏卵問題を避けるため)。そのため debug dump で `disable_load_main_worktree_local_config: true` が見えていても、その `true` を project-local に書いた場合は実挙動では main 側が読まれ続けます。
-
-**`append_*` は両 sub-layer をまたいで累積**: main-worktree local で append したものは current-worktree local の append にそのまま積まれます。current worktree 側で「main から来た特定 1 行だけを取り消す」操作はマージ規則上できません — これは layer 間共通の制約です (「既知の制約」参照)。
-
-**相対パスは current worktree の cwd 基準**: `log_path` / `metrics_path` / `auth.path` 等の path 系 field は、`~/` の展開だけ ccgate が行い、それ以外の相対パスは OS にそのまま渡されます。main worktree の config に `log_path: 'logs/ccgate.log'` と書いても、それは main worktree ではなく **current worktree** の cwd 基準で解決されます。worktree に依存しない単一の場所を指したいときは絶対パスか `~/` を使ってください。
-
-**per-worktree で env から切り替える (任意)**: ccgate は本機能用の env var を予約していませんが、global config から `std.native('env')` を使えば任意の env var を読めます:
-
-```jsonnet
-// ~/.claude/ccgate.jsonnet
-// env var の名前は user 側で自由に決める — ccgate は特定 env を予約しない
-{
-  disable_load_main_worktree_local_config:
-    std.native('env')('SKIP_MAIN_WORKTREE_CCGATE') == 'true',
-}
-```
-
-direnv なら `<worktree>/.envrc` に `export SKIP_MAIN_WORKTREE_CCGATE=true` を入れることで、その worktree でだけ継承を切れます。
+相対パス (`log_path` / `metrics_path` / `auth.path` 等) は file の置き場所ではなく **current cwd** 基準で解決されます。worktree に依存しない単一の場所を指したいときは絶対パスか `~/` を使ってください。
 
 
 ### layer の合成ルール

--- a/docs/ja/configuration.md
+++ b/docs/ja/configuration.md
@@ -6,19 +6,24 @@
 
 ## ccgate が config を探す場所
 
-ccgate は target ごとに 3 つの設定層を順に読み込みます。各層は同じルールで合成されます (詳細は後述の「layer の合成ルール」):
+ccgate は target ごとに以下の層を順に読み込みます。各層は同じルールで合成されます (詳細は後述の「layer の合成ルール」):
 
 1. **埋込デフォルト**: バイナリに同梱。常にベースとして適用。`ccgate <target> init` で確認可能
 2. **グローバル設定**: 存在すれば埋込デフォルトの上に重ねる:
    - Claude Code: `~/.claude/ccgate.jsonnet`
    - Codex CLI:   `~/.codex/ccgate.jsonnet`
-3. **プロジェクトローカル**: (1)+(2) の上に重ねる。tracked file は無視される (後述「tracked file が無視される理由」):
+3. **main worktree のプロジェクトローカル**: ccgate が linked git worktree (`git worktree add ...`) の中で動作するときのみ。tracked file は無視される (後述「tracked file が無視される理由」):
+   - Claude Code: `{main_worktree}/.claude/ccgate.local.jsonnet`
+   - Codex CLI:   `{main_worktree}/.codex/ccgate.local.jsonnet`
+4. **current worktree のプロジェクトローカル**: tracked file は無視される:
    - Claude Code: `{repo_root}/.claude/ccgate.local.jsonnet`
    - Codex CLI:   `{repo_root}/.codex/ccgate.local.jsonnet`
 
-   linked git worktree (`git worktree add ...`) の中では、main worktree 側の `ccgate.local.jsonnet` (or `.codex/...`) が先に読まれ、続いて current worktree 側が読まれます。`disable_load_main_worktree_local_config: true` を defaults / global に書けば main 側をスキップします。相対パス (`log_path` / `metrics_path` / `auth.path` 等) は config file の置き場所ではなく **current cwd** 基準で解決されます。
+`{repo_root}` は git repo root で、hook の `cwd` から `git rev-parse --show-toplevel` で解決します。`{main_worktree}` は同じ repo の main worktree の root で、`git rev-parse --git-common-dir` から求めます。git repo 外では `cwd` 自体が使われます。
 
-`{repo_root}` は git repo root で、hook の `cwd` から `git rev-parse --show-toplevel` で解決します。git repo 外では `cwd` 自体が使われます。
+`disable_load_main_worktree_local_config: true` を (1) 埋込デフォルト もしくは (2) グローバル設定 に書けば (3) をスキップします。この flag は (1) / (2) でのみ有効で、(3) / (4) に書いても **無視** されます。
+
+相対パス (`log_path` / `metrics_path` / `auth.path` 等) は config file の置き場所ではなく **current cwd** 基準で解決されます。
 
 
 ### layer の合成ルール

--- a/internal/cmd/claude/defaults.jsonnet
+++ b/internal/cmd/claude/defaults.jsonnet
@@ -41,13 +41,10 @@
   // disable_load_main_worktree_local_config: true,
   // When ccgate runs inside a linked git worktree (`git worktree add`),
   // it reads <main_worktree>/.claude/ccgate.local.jsonnet (untracked
-  // only) before the current worktree's local config, so the
-  // personal rules in your main checkout still apply in PR-review
-  // worktrees. Set this to true to skip the main worktree and read
-  // only the current worktree's local config. Evaluated at the
-  // embed/global layer; written into project-local config it is
-  // ignored (we'd need to read the main config to decide whether
-  // to read the main config).
+  // only) before the current worktree's local config. Set this to
+  // true to skip the main worktree and read only the current
+  // worktree's local config. Evaluated before project-local configs;
+  // values written in project-local config are ignored.
 
   allow: [
     'Read-Only Operations: Read, Glob, Grep, and other read-only tools that do not modify state.',

--- a/internal/cmd/claude/defaults.jsonnet
+++ b/internal/cmd/claude/defaults.jsonnet
@@ -38,6 +38,17 @@
   // Only LLM uncertainty is affected; bypassPermissions / dontAsk / missing API key still defer.
   // fallthrough_strategy: 'ask',
 
+  // disable_load_main_worktree_local_config: true,
+  // When ccgate runs inside a linked git worktree (`git worktree add`),
+  // it reads <main_worktree>/.claude/ccgate.local.jsonnet (untracked
+  // only) before the current worktree's local config, so the
+  // personal rules in your main checkout still apply in PR-review
+  // worktrees. Set this to true to skip the main worktree and read
+  // only the current worktree's local config. Evaluated at the
+  // embed/global layer; written into project-local config it is
+  // ignored (we'd need to read the main config to decide whether
+  // to read the main config).
+
   allow: [
     'Read-Only Operations: Read, Glob, Grep, and other read-only tools that do not modify state.',
     'Local Development: Build, test, lint, format commands in the current repository.',

--- a/internal/cmd/codex/defaults.jsonnet
+++ b/internal/cmd/codex/defaults.jsonnet
@@ -50,6 +50,17 @@
   // Only LLM uncertainty is affected; runtime-mode fallthroughs (no API key, etc.) still defer.
   // fallthrough_strategy: 'ask',
 
+  // disable_load_main_worktree_local_config: true,
+  // When ccgate runs inside a linked git worktree (`git worktree add`),
+  // it reads <main_worktree>/.codex/ccgate.local.jsonnet (untracked
+  // only) before the current worktree's local config, so the
+  // personal rules in your main checkout still apply in PR-review
+  // worktrees. Set this to true to skip the main worktree and read
+  // only the current worktree's local config. Evaluated at the
+  // embed/global layer; written into project-local config it is
+  // ignored (we'd need to read the main config to decide whether
+  // to read the main config).
+
   allow: [
     'Read-only operations: Bash inspection commands (ls, cat, head, tail, less, file, stat, find/grep without -exec/--delete, git status/log/diff/show/branch/remote -v), or any tool whose tool_input shape implies pure read (no writes, no network calls with side effects).',
     'Local writes inside the workspace: apply_patch hunks whose target paths are all under cwd / repo_root, edits to project files for editing/refactoring/scaffolding the AI is currently doing. Same bar as Claude Code Edit/Write through ccgate.',

--- a/internal/cmd/codex/defaults.jsonnet
+++ b/internal/cmd/codex/defaults.jsonnet
@@ -53,13 +53,10 @@
   // disable_load_main_worktree_local_config: true,
   // When ccgate runs inside a linked git worktree (`git worktree add`),
   // it reads <main_worktree>/.codex/ccgate.local.jsonnet (untracked
-  // only) before the current worktree's local config, so the
-  // personal rules in your main checkout still apply in PR-review
-  // worktrees. Set this to true to skip the main worktree and read
-  // only the current worktree's local config. Evaluated at the
-  // embed/global layer; written into project-local config it is
-  // ignored (we'd need to read the main config to decide whether
-  // to read the main config).
+  // only) before the current worktree's local config. Set this to
+  // true to skip the main worktree and read only the current
+  // worktree's local config. Evaluated before project-local configs;
+  // values written in project-local config are ignored.
 
   allow: [
     'Read-only operations: Bash inspection commands (ls, cat, head, tail, less, file, stat, find/grep without -exec/--delete, git status/log/diff/show/branch/remote -v), or any tool whose tool_input shape implies pure read (no writes, no network calls with side effects).',

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,6 +82,15 @@ type Config struct {
 	MetricsDisabled     *bool          `json:"metrics_disabled,omitempty"`
 	MetricsMaxSize      *int64         `json:"metrics_max_size,omitempty"`
 	FallthroughStrategy *string        `json:"fallthrough_strategy,omitempty"`
+	// DisableLoadMainWorktreeLocalConfig is a kill switch for the
+	// linked-worktree convenience that reads
+	// `<main_worktree>/.claude/ccgate.local.jsonnet` (or `.codex/...`)
+	// before the current worktree's local config. Defaults to false
+	// (= the main worktree is read). Set to true to skip it and read
+	// only the current worktree's local config. Evaluated at the
+	// embed+global layer; values written into project-local config
+	// are ignored — see `Load` for the rationale.
+	DisableLoadMainWorktreeLocalConfig *bool `json:"disable_load_main_worktree_local_config,omitempty"`
 	// Allow / Deny / Environment replace the value carried over from
 	// previous layers when the layer sets them (even to []). Embedded
 	// defaults are always layer 0, so writing `allow: [...]` in your
@@ -107,6 +116,15 @@ func (c Config) GetFallthroughStrategy() string {
 		return FallthroughStrategyAsk
 	}
 	return *c.FallthroughStrategy
+}
+
+// ShouldLoadMainWorktreeLocalConfig reports whether ccgate should
+// read the main worktree's untracked project-local config when run
+// inside a linked git worktree. Default true; set
+// `disable_load_main_worktree_local_config: true` in the embedded
+// defaults or your global config to skip the main worktree entirely.
+func (c Config) ShouldLoadMainWorktreeLocalConfig() bool {
+	return c.DisableLoadMainWorktreeLocalConfig == nil || !*c.DisableLoadMainWorktreeLocalConfig
 }
 
 type ProviderConfig struct {
@@ -461,6 +479,21 @@ func Load(opts LoadOptions, cwd string) (LoadResult, error) {
 		source = SourceGlobalConfig
 	}
 
+	// In a linked git worktree, layer the main worktree's untracked
+	// project-local config before the current worktree's. The flag is
+	// evaluated at this point so it can only be set by embedded
+	// defaults or the global config; writing it into project-local
+	// config would create a chicken-and-egg loop (we'd need to read
+	// the main worktree's config to decide whether to read the main
+	// worktree's config) and is intentionally ignored.
+	if cfg.ShouldLoadMainWorktreeLocalConfig() {
+		for _, path := range safeMainWorktreeLocalConfigPaths(cwd, opts.ProjectLocalRelativePaths) {
+			if err := mergeConfigFile(path, &cfg); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return LoadResult{Config: cfg}, fmt.Errorf("main-worktree local config %s: %w", path, err)
+			}
+		}
+	}
+
 	for _, path := range safeProjectLocalConfigPaths(cwd, opts.ProjectLocalRelativePaths) {
 		if err := mergeConfigFile(path, &cfg); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return LoadResult{Config: cfg}, fmt.Errorf("local config %s: %w", path, err)
@@ -509,8 +542,43 @@ func safeProjectLocalConfigPaths(cwd string, relativePaths []string) []string {
 		root = repoRoot
 	}
 
+	return safeUntrackedPaths(root, projectLocalConfigPaths(cwd, relativePaths))
+}
+
+// safeMainWorktreeLocalConfigPaths returns the equivalents of
+// safeProjectLocalConfigPaths anchored at the *main* worktree root
+// rather than the current cwd's repo root, used when ccgate runs
+// inside a linked git worktree. Returns nil when not in a linked
+// worktree, when the main worktree root coincides with the current
+// repo root (no-op, avoids reading the same file twice), or when
+// no relative paths are supplied.
+func safeMainWorktreeLocalConfigPaths(cwd string, relativePaths []string) []string {
+	if len(relativePaths) == 0 {
+		return nil
+	}
+	mainRoot := gitutil.MainWorktreeRoot(cwd)
+	if mainRoot == "" {
+		return nil
+	}
+	repoRoot, err := gitutil.RepoRoot(cwd)
+	if err == nil && repoRoot == mainRoot {
+		return nil
+	}
+
+	candidates := make([]string, 0, len(relativePaths))
+	for _, rel := range relativePaths {
+		candidates = append(candidates, filepath.Join(mainRoot, rel))
+	}
+	return safeUntrackedPaths(mainRoot, candidates)
+}
+
+// safeUntrackedPaths filters candidate paths anchored at root,
+// returning the existing files that git does not track. Tracked
+// files are skipped on purpose — ccgate's project-local layer is for
+// per-user, gitignored config, never something checked in.
+func safeUntrackedPaths(root string, candidates []string) []string {
 	var safe []string
-	for _, path := range projectLocalConfigPaths(cwd, relativePaths) {
+	for _, path := range candidates {
 		if _, err := os.Stat(path); err != nil {
 			continue
 		}
@@ -649,6 +717,9 @@ func mergeConfigJSON(data string, cfg *Config) error {
 	}
 	if override.FallthroughStrategy != nil {
 		cfg.FallthroughStrategy = override.FallthroughStrategy
+	}
+	if override.DisableLoadMainWorktreeLocalConfig != nil {
+		cfg.DisableLoadMainWorktreeLocalConfig = override.DisableLoadMainWorktreeLocalConfig
 	}
 
 	// Lists: `allow` / `deny` / `environment` REPLACE the value

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -479,13 +479,15 @@ func Load(opts LoadOptions, cwd string) (LoadResult, error) {
 		source = SourceGlobalConfig
 	}
 
-	// In a linked git worktree, layer the main worktree's untracked
-	// project-local config before the current worktree's. The flag is
-	// evaluated at this point so it can only be set by embedded
-	// defaults or the global config; writing it into project-local
-	// config would create a chicken-and-egg loop (we'd need to read
-	// the main worktree's config to decide whether to read the main
-	// worktree's config) and is intentionally ignored.
+	// Freeze the main-worktree kill switch before project-local
+	// merges start. Reading the main worktree's config to decide
+	// whether to read the main worktree's config would loop, so only
+	// the embed and global layers can flip this field. The frozen
+	// value is restored after the project-local merges so the field
+	// surfaced through the returned Config also reflects the
+	// authoritative decision and doesn't track a stray override from
+	// (3) or (4).
+	frozenDisableLoadMain := cfg.DisableLoadMainWorktreeLocalConfig
 	if cfg.ShouldLoadMainWorktreeLocalConfig() {
 		for _, path := range safeMainWorktreeLocalConfigPaths(cwd, opts.ProjectLocalRelativePaths) {
 			if err := mergeConfigFile(path, &cfg); err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -499,6 +501,7 @@ func Load(opts LoadOptions, cwd string) (LoadResult, error) {
 			return LoadResult{Config: cfg}, fmt.Errorf("local config %s: %w", path, err)
 		}
 	}
+	cfg.DisableLoadMainWorktreeLocalConfig = frozenDisableLoadMain
 
 	// Apply target-specific log/metrics defaults only when the user
 	// did not set explicit paths in any of the merged configs. This

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -713,7 +713,8 @@ func TestLoadInheritsMainWorktreeLocalConfig(t *testing.T) {
 	// worktree, then runs Load from the worktree (or main itself for
 	// the no-worktree case) and checks the merged Deny list.
 	type want struct {
-		deny []string
+		deny           []string
+		shouldLoadMain bool // expected lr.Config.ShouldLoadMainWorktreeLocalConfig()
 	}
 	cases := map[string]struct {
 		mainLocal   string // jsonnet for <main>/.fake/ccgate.local.jsonnet
@@ -727,33 +728,36 @@ func TestLoadInheritsMainWorktreeLocalConfig(t *testing.T) {
 		"main + wt append_deny stack in order": {
 			mainLocal: `{ append_deny: ['from-main'] }`,
 			wtLocal:   `{ append_deny: ['from-wt'] }`,
-			want:      want{deny: []string{"default-deny", "from-main", "from-wt"}},
+			want:      want{deny: []string{"default-deny", "from-main", "from-wt"}, shouldLoadMain: true},
 		},
 		"main-only local is read": {
 			mainLocal: `{ append_deny: ['from-main'] }`,
-			want:      want{deny: []string{"default-deny", "from-main"}},
+			want:      want{deny: []string{"default-deny", "from-main"}, shouldLoadMain: true},
 		},
 		"global disable=true skips the main worktree": {
 			globalCfg: `{ disable_load_main_worktree_local_config: true }`,
 			mainLocal: `{ append_deny: ['from-main'] }`,
 			wtLocal:   `{ append_deny: ['from-wt'] }`,
-			want:      want{deny: []string{"default-deny", "from-wt"}},
+			want:      want{deny: []string{"default-deny", "from-wt"}, shouldLoadMain: false},
 		},
 		"disable=true written into project-local layers is ignored": {
 			mainLocal: `{ disable_load_main_worktree_local_config: true, append_deny: ['from-main'] }`,
 			wtLocal:   `{ disable_load_main_worktree_local_config: true, append_deny: ['from-wt'] }`,
-			want:      want{deny: []string{"default-deny", "from-main", "from-wt"}},
+			// The field is restored to its global-layer value after
+			// project-local merges, so a caller inspecting cfg can't
+			// be misled into thinking the main worktree was skipped.
+			want: want{deny: []string{"default-deny", "from-main", "from-wt"}, shouldLoadMain: true},
 		},
 		"tracked main-local is skipped (untracked-only policy)": {
 			mainLocal:   `{ append_deny: ['from-main'] }`,
 			wtLocal:     `{ append_deny: ['from-wt'] }`,
 			mainTracked: true,
-			want:        want{deny: []string{"default-deny", "from-wt"}},
+			want:        want{deny: []string{"default-deny", "from-wt"}, shouldLoadMain: true},
 		},
 		"non-worktree run: main path is a no-op": {
 			mainLocal:   `{ append_deny: ['from-main'] }`,
 			nonWorktree: true,
-			want:        want{deny: []string{"default-deny", "from-main"}},
+			want:        want{deny: []string{"default-deny", "from-main"}, shouldLoadMain: true},
 		},
 		"syntax error in main-local surfaces": {
 			mainLocal: `{ invalid jsonnet`,
@@ -814,6 +818,9 @@ func TestLoadInheritsMainWorktreeLocalConfig(t *testing.T) {
 			}
 			if !reflect.DeepEqual(lr.Config.Deny, tc.want.deny) {
 				t.Errorf("deny = %v, want %v", lr.Config.Deny, tc.want.deny)
+			}
+			if got := lr.Config.ShouldLoadMainWorktreeLocalConfig(); got != tc.want.shouldLoadMain {
+				t.Errorf("ShouldLoadMainWorktreeLocalConfig() = %v, want %v", got, tc.want.shouldLoadMain)
 			}
 		})
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -706,6 +706,130 @@ func TestLoadLayerSemantics(t *testing.T) {
 	}
 }
 
+func TestLoadInheritsMainWorktreeLocalConfig(t *testing.T) {
+	// fakeLoadOptions seeds embed defaults with deny=["default-deny"]
+	// and points ProjectLocalRelativePaths at ".fake/ccgate.local.jsonnet".
+	// Each case sets up a main repo (always) and optionally a linked
+	// worktree, then runs Load from the worktree (or main itself for
+	// the no-worktree case) and checks the merged Deny list.
+	type want struct {
+		deny []string
+	}
+	cases := map[string]struct {
+		mainLocal   string // jsonnet for <main>/.fake/ccgate.local.jsonnet
+		wtLocal     string // jsonnet for <wt>/.fake/ccgate.local.jsonnet
+		globalCfg   string // jsonnet for <home>/.fake/ccgate.jsonnet
+		mainTracked bool   // git add the main local before loading
+		nonWorktree bool   // skip the worktree add and load from main itself
+		expectErr   bool
+		want        want
+	}{
+		"main + wt append_deny stack in order": {
+			mainLocal: `{ append_deny: ['from-main'] }`,
+			wtLocal:   `{ append_deny: ['from-wt'] }`,
+			want:      want{deny: []string{"default-deny", "from-main", "from-wt"}},
+		},
+		"main-only local is read": {
+			mainLocal: `{ append_deny: ['from-main'] }`,
+			want:      want{deny: []string{"default-deny", "from-main"}},
+		},
+		"global disable=true skips the main worktree": {
+			globalCfg: `{ disable_load_main_worktree_local_config: true }`,
+			mainLocal: `{ append_deny: ['from-main'] }`,
+			wtLocal:   `{ append_deny: ['from-wt'] }`,
+			want:      want{deny: []string{"default-deny", "from-wt"}},
+		},
+		"disable=true written into project-local layers is ignored": {
+			mainLocal: `{ disable_load_main_worktree_local_config: true, append_deny: ['from-main'] }`,
+			wtLocal:   `{ disable_load_main_worktree_local_config: true, append_deny: ['from-wt'] }`,
+			want:      want{deny: []string{"default-deny", "from-main", "from-wt"}},
+		},
+		"tracked main-local is skipped (untracked-only policy)": {
+			mainLocal:   `{ append_deny: ['from-main'] }`,
+			wtLocal:     `{ append_deny: ['from-wt'] }`,
+			mainTracked: true,
+			want:        want{deny: []string{"default-deny", "from-wt"}},
+		},
+		"non-worktree run: main path is a no-op": {
+			mainLocal:   `{ append_deny: ['from-main'] }`,
+			nonWorktree: true,
+			want:        want{deny: []string{"default-deny", "from-main"}},
+		},
+		"syntax error in main-local surfaces": {
+			mainLocal: `{ invalid jsonnet`,
+			expectErr: true,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// t.Setenv is incompatible with t.Parallel.
+			home := t.TempDir()
+			setHomeEnv(t, home)
+
+			main := filepath.Join(t.TempDir(), "main")
+			if err := os.MkdirAll(main, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			gitRun(t, main, "init")
+			gitRun(t, main, "config", "user.email", "test@test.com")
+			gitRun(t, main, "config", "user.name", "test")
+			gitRun(t, main, "commit", "--allow-empty", "-m", "init")
+
+			if tc.mainLocal != "" {
+				writeProjectLocal(t, main, tc.mainLocal)
+				if tc.mainTracked {
+					gitRun(t, main, "add", "-f", filepath.Join(".fake", LocalConfigName))
+				}
+			}
+
+			if tc.globalCfg != "" {
+				globalFake := filepath.Join(home, ".fake")
+				if err := os.MkdirAll(globalFake, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(globalFake, BaseConfigName), []byte(tc.globalCfg), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			target := main
+			if !tc.nonWorktree {
+				wt := filepath.Join(t.TempDir(), "wt")
+				gitRun(t, main, "worktree", "add", "--detach", wt)
+				if tc.wtLocal != "" {
+					writeProjectLocal(t, wt, tc.wtLocal)
+				}
+				target = wt
+			}
+
+			lr, err := Load(fakeLoadOptions(home), target)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(lr.Config.Deny, tc.want.deny) {
+				t.Errorf("deny = %v, want %v", lr.Config.Deny, tc.want.deny)
+			}
+		})
+	}
+}
+
+func writeProjectLocal(t *testing.T, root, body string) {
+	t.Helper()
+	dir := filepath.Join(root, ".fake")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, LocalConfigName), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func gitRun(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)

--- a/internal/gitutil/gitutil.go
+++ b/internal/gitutil/gitutil.go
@@ -33,10 +33,26 @@ func RepoRoot(dir string) (string, error) {
 // ambiguous. Never errors.
 func MainWorktreeRoot(dir string) string {
 	ctx := BuildContext(dir)
-	if ctx.IsWorktree && ctx.PrimaryCheckoutRoot != "" {
-		return ctx.PrimaryCheckoutRoot
+	if !ctx.IsWorktree || ctx.PrimaryCheckoutRoot == "" {
+		return ""
 	}
-	return ""
+	// `worktree list --porcelain` emits the main worktree as the
+	// first record; if that record carries a `bare` line, the main
+	// has no real working tree and PrimaryCheckoutRoot is just the
+	// bare repo's parent directory — not somewhere we should read
+	// a `ccgate.local.jsonnet` from. Surface the bare case as the
+	// "" no-op contract the project promises.
+	if out, err := Output(dir, "worktree", "list", "--porcelain"); err == nil {
+		for line := range strings.SplitSeq(out, "\n") {
+			if line == "" {
+				break
+			}
+			if line == "bare" {
+				return ""
+			}
+		}
+	}
+	return ctx.PrimaryCheckoutRoot
 }
 
 // IsTracked reports whether the file at path is tracked by git in the given repo root.

--- a/internal/gitutil/gitutil.go
+++ b/internal/gitutil/gitutil.go
@@ -27,6 +27,18 @@ func RepoRoot(dir string) (string, error) {
 	return Output(dir, "rev-parse", "--show-toplevel")
 }
 
+// MainWorktreeRoot returns the root of the main worktree when dir is
+// inside a linked git worktree. Returns "" otherwise — main worktree
+// itself, non-git directory, bare repo, or anywhere the detection is
+// ambiguous. Never errors.
+func MainWorktreeRoot(dir string) string {
+	ctx := BuildContext(dir)
+	if ctx.IsWorktree && ctx.PrimaryCheckoutRoot != "" {
+		return ctx.PrimaryCheckoutRoot
+	}
+	return ""
+}
+
 // IsTracked reports whether the file at path is tracked by git in the given repo root.
 // Returns (false, nil) if the file does not exist.
 // Returns (false, error) on git errors (fail-closed).

--- a/internal/gitutil/gitutil_test.go
+++ b/internal/gitutil/gitutil_test.go
@@ -170,6 +170,31 @@ func TestMainWorktreeRoot(t *testing.T) {
 	}
 }
 
+func TestMainWorktreeRootBareRepo(t *testing.T) {
+	t.Parallel()
+
+	// A bare repo plus a linked worktree must surface as no-op
+	// (empty string), matching the project's "bare repo / submodule /
+	// custom $GIT_DIR -> empty" invariant.
+	parent := t.TempDir()
+	bare := filepath.Join(parent, "repo.git")
+	gitRun(t, parent, "init", "--bare", "repo.git")
+
+	seed := filepath.Join(parent, "seed")
+	gitRun(t, parent, "clone", bare, "seed")
+	gitRun(t, seed, "config", "user.email", "test@test.com")
+	gitRun(t, seed, "config", "user.name", "test")
+	gitRun(t, seed, "commit", "--allow-empty", "-m", "init")
+	gitRun(t, seed, "push", "origin", "HEAD:refs/heads/main")
+
+	wt := filepath.Join(parent, "wt")
+	gitRun(t, bare, "worktree", "add", wt, "main")
+
+	if got := MainWorktreeRoot(wt); got != "" {
+		t.Fatalf("bare repo linked worktree: got %q, want empty", got)
+	}
+}
+
 func initGit(t *testing.T, dir string) {
 	t.Helper()
 	gitRun(t, dir, "init")

--- a/internal/gitutil/gitutil_test.go
+++ b/internal/gitutil/gitutil_test.go
@@ -118,6 +118,58 @@ func TestIsTrackedEmptyRoot(t *testing.T) {
 	}
 }
 
+func TestMainWorktreeRoot(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		isGit        bool
+		makeWorktree bool
+	}{
+		"main repo":       {isGit: true, makeWorktree: false},
+		"linked worktree": {isGit: true, makeWorktree: true},
+		"non-git dir":     {isGit: false, makeWorktree: false},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			main := t.TempDir()
+			if tc.isGit {
+				initGit(t, main)
+			}
+
+			target := main
+			var wantMain string
+			if tc.makeWorktree {
+				gitRun(t, main, "commit", "--allow-empty", "-m", "init")
+				wt := filepath.Join(filepath.Dir(main), filepath.Base(main)+"-wt")
+				t.Cleanup(func() { _ = os.RemoveAll(wt) })
+				gitRun(t, main, "worktree", "add", "--detach", wt)
+				target = wt
+				wantMain, _ = filepath.EvalSymlinks(main)
+			}
+
+			got := MainWorktreeRoot(target)
+
+			if wantMain == "" {
+				if got != "" {
+					t.Fatalf("got %q, want empty", got)
+				}
+				return
+			}
+
+			gotResolved, err := filepath.EvalSymlinks(got)
+			if err != nil {
+				t.Fatalf("EvalSymlinks(%q): %v", got, err)
+			}
+			if gotResolved != wantMain {
+				t.Fatalf("got %q, want %q", gotResolved, wantMain)
+			}
+		})
+	}
+}
+
 func initGit(t *testing.T, dir string) {
 	t.Helper()
 	gitRun(t, dir, "init")

--- a/internal/gitutil/gitutil_test.go
+++ b/internal/gitutil/gitutil_test.go
@@ -175,23 +175,44 @@ func TestMainWorktreeRootBareRepo(t *testing.T) {
 
 	// A bare repo plus a linked worktree must surface as no-op
 	// (empty string), matching the project's "bare repo / submodule /
-	// custom $GIT_DIR -> empty" invariant.
-	parent := t.TempDir()
-	bare := filepath.Join(parent, "repo.git")
-	gitRun(t, parent, "init", "--bare", "repo.git")
+	// custom $GIT_DIR -> empty" invariant. Two naming shapes:
+	//   - `repo.git`     : the conventional bare-repo name
+	//   - `holder/.git`  : a hostile shape whose suffix happens to
+	//                      match the non-bare `.git` heuristic
+	cases := map[string]struct {
+		bareName string // path of the bare repo relative to parent
+	}{
+		"conventional <name>.git": {bareName: "repo.git"},
+		"hostile <dir>/.git":      {bareName: "holder/.git"},
+	}
 
-	seed := filepath.Join(parent, "seed")
-	gitRun(t, parent, "clone", bare, "seed")
-	gitRun(t, seed, "config", "user.email", "test@test.com")
-	gitRun(t, seed, "config", "user.name", "test")
-	gitRun(t, seed, "commit", "--allow-empty", "-m", "init")
-	gitRun(t, seed, "push", "origin", "HEAD:refs/heads/main")
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	wt := filepath.Join(parent, "wt")
-	gitRun(t, bare, "worktree", "add", wt, "main")
+			parent := t.TempDir()
+			bare := filepath.Join(parent, tc.bareName)
+			if dir := filepath.Dir(bare); dir != parent {
+				if err := os.MkdirAll(dir, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			gitRun(t, parent, "init", "--bare", tc.bareName)
 
-	if got := MainWorktreeRoot(wt); got != "" {
-		t.Fatalf("bare repo linked worktree: got %q, want empty", got)
+			seed := filepath.Join(parent, "seed")
+			gitRun(t, parent, "clone", bare, "seed")
+			gitRun(t, seed, "config", "user.email", "test@test.com")
+			gitRun(t, seed, "config", "user.name", "test")
+			gitRun(t, seed, "commit", "--allow-empty", "-m", "init")
+			gitRun(t, seed, "push", "origin", "HEAD:refs/heads/main")
+
+			wt := filepath.Join(parent, "wt")
+			gitRun(t, bare, "worktree", "add", wt, "main")
+
+			if got := MainWorktreeRoot(wt); got != "" {
+				t.Fatalf("bare repo linked worktree (%s): got %q, want empty", tc.bareName, got)
+			}
+		})
 	}
 }
 

--- a/schemas/claude.schema.json
+++ b/schemas/claude.schema.json
@@ -141,6 +141,9 @@
     "fallthrough_strategy": {
       "type": "string"
     },
+    "disable_load_main_worktree_local_config": {
+      "type": "boolean"
+    },
     "allow": {
       "items": {
         "type": "string"

--- a/schemas/codex.schema.json
+++ b/schemas/codex.schema.json
@@ -141,6 +141,9 @@
     "fallthrough_strategy": {
       "type": "string"
     },
+    "disable_load_main_worktree_local_config": {
+      "type": "boolean"
+    },
     "allow": {
       "items": {
         "type": "string"


### PR DESCRIPTION
## Why

When you `git worktree add` a temporary checkout (e.g. for PR review), you usually want to keep using the personal ccgate rules from your main checkout. Today ccgate's project-local layer is anchored at `git rev-parse --show-toplevel`, which inside a linked worktree returns the worktree's own root — the main worktree's untracked `ccgate.local.jsonnet` is silently dropped. Claude Code and Codex CLI themselves don't inherit settings across worktrees either, so closing this gap is a ccgate-specific convenience for users who keep their personal rules in the main checkout.

## What

Layers the main worktree's untracked project-local config (`.claude/ccgate.local.jsonnet` or `.codex/ccgate.local.jsonnet`) before the current worktree's local config when ccgate runs inside a linked worktree. Existing append/replace semantics carry over — `append_deny` etc. accumulate across `main → current`, `deny` in either layer still replaces wholesale.

Default ON; the kill switch is the new `disable_load_main_worktree_local_config: true` field (evaluated at the embed+global layer, ignored if written into project-local to avoid a chicken-and-egg loop). No new env var — users who want per-worktree toggling can wire `std.native('env')(...)` themselves; an example is in `docs/configuration.md`.

### Scope

- `internal/gitutil.MainWorktreeRoot` — derives the main worktree root from `git rev-parse --git-common-dir`. Returns `""` for the main worktree itself, bare repos, submodules, and any setup where the detection is ambiguous, so the rest of the pipeline can stay a single no-op branch.
- `internal/config`: new `*bool` field `DisableLoadMainWorktreeLocalConfig`, accessor `ShouldLoadMainWorktreeLocalConfig`, scalar merge entry, and a new `safeMainWorktreeLocalConfigPaths` helper. The existing `safeProjectLocalConfigPaths` and the new one share the untracked-only filter via a small private helper.
- `Load`: inserts the main-worktree pass between the global config and the current worktree's local config. The `Source` enum stays at 2 values (`embedded_defaults` / `global_config`) — main-worktree config does not introduce a new source.
- Schemas: `ccgate.schema.json` (hand-written, drift-checked by `TestRootSchemaTopLevelDrift`) and `schemas/{claude,codex}.schema.json` (generator-driven via `mise run schema`).
- `defaults.jsonnet` (both targets) ships the option as a commented-out kill-switch example next to `fallthrough_strategy`.
- Docs: new "Linked git worktrees" subsection in `docs/configuration.md` (+ ja mirror), one-line pointer + field-table row in README (+ ja README). The subsection covers the use case, how to disable, the chicken-and-egg ignore rule, the cwd-relative path gotcha for `log_path` / `metrics_path` / `auth.path`, and the env-recipe via `std.native('env')`.
- Tests: `TestMainWorktreeRoot` (gitutil, table-driven, real `git worktree add`) and `TestLoadInheritsMainWorktreeLocalConfig` (config, 7 cases — stacked appends, main-only, global kill switch, project-local ignore, tracked skip, non-worktree no-op, syntax-error propagation).