### PR TITLE
docs: restructure manuals for scannability and retrieval safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,13 +156,15 @@ Evaluation flow:
 flowchart TD
   A["Claude Code / Codex CLI"] --> B{"Resolved by the upstream tool's static rules?"}
   B -->|Yes| C["Run / refuse upstream"]
-  B -->|No| D["PermissionRequest hook"]
+  B -->|No| D["PermissionRequest hook<br/>(stdin: HookInput JSON)"]
   D --> E["ccgate"]
-  E --> F["tool_input / git context / jsonnet rules"]
-  F --> G{"LLM (default: Haiku) judges"}
+  E --> F1["Load jsonnet config<br/>embedded defaults + global + project-local"]
+  E --> F2["Build context<br/>git context, referenced_paths,<br/>recent_transcript (Claude only)"]
+  F1 --> G{"LLM (default: Haiku) judges<br/>via structured output"}
+  F2 --> G
   G -->|allow| H["Run"]
-  G -->|deny| I["Refuse with reason"]
-  G -->|fallthrough| J["Back to user confirmation"]
+  G -->|deny| I["Refuse with deny_message"]
+  G -->|fallthrough| J["Back to the upstream prompt"]
 ```
 
 What ccgate puts in front of the LLM (representative fields):

--- a/README.md
+++ b/README.md
@@ -91,13 +91,7 @@ If `ccgate` is not on your `PATH` (e.g. when relying on `mise exec` instead of a
 
 ### 2. API key
 
-Set the API key for your chosen provider. `CCGATE_*_API_KEY` is preferred and overrides the bare variable, so you can keep ccgate's key separate from the AI tool's own key.
-
-| `provider.name` | Preferred                  | Fallback             | Get API key |
-|-----------------|----------------------------|----------------------|-------------|
-| `anthropic`     | `CCGATE_ANTHROPIC_API_KEY` | `ANTHROPIC_API_KEY`  | <https://platform.claude.com/settings/keys> |
-| `openai`        | `CCGATE_OPENAI_API_KEY`    | `OPENAI_API_KEY`     | <https://platform.openai.com/api-keys>      |
-| `gemini`        | `CCGATE_GEMINI_API_KEY`    | `GEMINI_API_KEY`     | <https://aistudio.google.com/app/api-keys>  |
+ccgate calls Anthropic's Claude Haiku by default. Export `CCGATE_ANTHROPIC_API_KEY` (or `ANTHROPIC_API_KEY` as fallback). For OpenAI / Gemini and the resolution order, see [docs/providers.md#api-keys](docs/providers.md#api-keys).
 
 That's it — ccgate is now running with its embedded defaults. To customize what is allowed or denied, see [Rule tuning](#rule-tuning); for background on how rules work, see [Concepts](#concepts).
 
@@ -150,7 +144,7 @@ See [docs/codex.md](docs/codex.md) for the full lookup order, project-local over
 
 ### 2. API key
 
-Same env vars as Claude Code — see the [provider table](#2-api-key).
+Same env vars as Claude Code — see [docs/providers.md#api-keys](docs/providers.md#api-keys).
 
 That's it — ccgate is now running with its embedded defaults. To customize what is allowed or denied, see [Rule tuning](#rule-tuning); for background on how rules work, see [Concepts](#concepts).
 
@@ -183,334 +177,107 @@ For the complete input list per target, see [docs/claude.md](docs/claude.md) and
 
 ## Configuration
 
-### Config file loading order (per target)
+### Config file loading order
 
 | Order | Claude Code | Codex CLI |
 |------:|-------------|-----------|
 | 1     | Embedded defaults (always applied as the base) | Embedded defaults |
-| 2     | `~/.claude/ccgate.jsonnet` — global (layered on top) | `~/.codex/ccgate.jsonnet` — global |
-| 3     | `{main_worktree}/.claude/ccgate.local.jsonnet` — main-worktree project-local (untracked only; only when running in a linked git worktree) | `{main_worktree}/.codex/ccgate.local.jsonnet` |
-| 4     | `{repo_root}/.claude/ccgate.local.jsonnet` — current-worktree project-local (untracked only) | `{repo_root}/.codex/ccgate.local.jsonnet` |
+| 2     | `~/.claude/ccgate.jsonnet` (global) | `~/.codex/ccgate.jsonnet` |
+| 3     | `{main_worktree}/.claude/ccgate.local.jsonnet` (linked worktree only, untracked-only) | `{main_worktree}/.codex/ccgate.local.jsonnet` |
+| 4     | `{repo_root}/.claude/ccgate.local.jsonnet` (untracked-only) | `{repo_root}/.codex/ccgate.local.jsonnet` |
 
-All layers compose with the same rules:
+Merge rules at a glance:
 
-- **Lists** — `allow` / `deny` / `environment` **replace** the value carried over from earlier layers when the layer sets them (even to `[]`). The `append_*` siblings (`append_allow`, `append_deny`, `append_environment`) **add** entries on top of whatever the earlier layers produced.
-- **Scalars** — `log_*`, `metrics_*`, `fallthrough_strategy` are overwritten per-field when the layer sets them, otherwise the earlier value survives.
-- **`provider` block** — a layer that writes `provider` **replaces the entire block** (`name` + `model` + `base_url` + `auth` + `timeout_ms`). Layers that omit `provider` inherit the earlier block unchanged. The block is replaced as a unit because the fields are tightly coupled. Important: when a project-local config restates `provider`, it must repeat any `auth` block from the global layer too — otherwise the helper config is silently dropped on that project.
+- **Lists (`allow` / `deny` / `environment`)** — a layer that sets the field **replaces** the carried-over list. `append_*` **appends** instead.
+- **Scalars (`log_*` / `metrics_*` / `fallthrough_strategy`)** — per-field overwrite.
+- **`provider` block** — replaced atomically as a unit (no per-field merge).
 
-Project-local configs are loaded only when **not tracked by Git**.
+Project-local configs are loaded only when **not tracked by Git**. `disable_load_main_worktree_local_config: true` in layer (1) or (2) skips layer (3); it is ignored when written into (3) or (4).
 
-Set `disable_load_main_worktree_local_config: true` in layer (1) or (2) to skip layer (3). The flag is honoured only at those two layers — written into (3) or (4) it is ignored. See [docs/configuration.md](docs/configuration.md#where-ccgate-looks-for-config).
-
-### Config fields
-
-| Field                    | Type                              | Default                                                                       | Description                                                                                            |
-|--------------------------|-----------------------------------|-------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
-| `provider.name`          | string                            | `"anthropic"`                                                                 | Provider name. One of `"anthropic"`, `"openai"`, `"gemini"`.                                            |
-| `provider.model`         | string                            | `"claude-haiku-4-5"`                                                          | Model name. Examples: `claude-haiku-4-5` / `claude-sonnet-4-6` (anthropic), `gpt-5.4-nano-2026-03-17` (openai), `gemini-3-flash-preview` (gemini). When routing through a compatible proxy, use whatever model name the proxy exposes (e.g. `anthropic/claude-haiku-4-5`). |
-| `provider.base_url`      | string                            | `""`                                                                          | Override the provider's API base URL. Empty = use the SDK default. Use this to route through an OpenAI- / Anthropic-compatible proxy. |
-| `provider.auth`          | object (`{type, ...}`)            | (omit = env var)                                                              | Discriminated union for short-lived / rotating credentials. `type=exec` / `type=file` / `type=profile`. See [docs/api-key-helper.md](docs/api-key-helper.md) for full reference. |
-| `provider.timeout_ms`    | int                               | `20000`                                                                       | API timeout (ms). `0` = no timeout.                                                                    |
-| `log_path`               | string                            | `$XDG_STATE_HOME/ccgate/<target>/ccgate.log`                                  | Log file path. Supports `~` for home directory.                                                        |
-| `log_disabled`           | bool                              | `false`                                                                       | Disable logging entirely                                                                               |
-| `log_max_size`           | int                               | `5242880`                                                                     | Max log file size in bytes before rotation (default 5MB). `0` = no rotation.                           |
-| `metrics_path`           | string                            | `$XDG_STATE_HOME/ccgate/<target>/metrics.jsonl`                               | Metrics JSONL file path.                                                                               |
-| `metrics_disabled`       | bool                              | `false`                                                                       | Disable metrics collection entirely                                                                    |
-| `metrics_max_size`       | int                               | `2097152`                                                                     | Max metrics file size in bytes before rotation (default 2MB). `0` = no rotation.                       |
-| `fallthrough_strategy`   | `"ask"` / `"allow"` / `"deny"`    | `"ask"`                                                                       | How to resolve LLM uncertainty (`fallthrough`). See [Fallthrough strategy](#fallthrough-strategy). |
-| `disable_load_main_worktree_local_config` | bool | `false`                                                                       | In a linked git worktree, skip the main worktree's `ccgate.local.jsonnet`. See [docs/configuration.md](docs/configuration.md#where-ccgate-looks-for-config). |
-| `allow`                  | string[]                          | `[]`                                                                          | Allow guidance rules. **Replaces** the value carried over from earlier layers when set.                |
-| `deny`                   | string[]                          | `[]`                                                                          | Deny guidance rules (mandatory). Supports inline `deny_message:` hints. Same replace semantics as `allow`. |
-| `environment`            | string[]                          | `[]`                                                                          | Context strings passed to the LLM (trust level, policies, etc.). Same replace semantics as `allow`.    |
-| `append_allow`           | string[]                          | `[]`                                                                          | Allow guidance rules **appended** on top of the carried-over list. Use this in project-local configs.   |
-| `append_deny`            | string[]                          | `[]`                                                                          | Deny guidance rules appended on top of the carried-over list.                                          |
-| `append_environment`     | string[]                          | `[]`                                                                          | Environment context appended on top of the carried-over list.                                          |
-
-`<target>` is `claude` or `codex` depending on which hook is invoked. When `XDG_STATE_HOME` is unset, ccgate falls back to `~/.local/state/ccgate/<target>/...`.
+Full merge details and the complete field reference are in [docs/configuration.md](docs/configuration.md#where-ccgate-looks-for-config).
 
 ## Rule tuning
 
-ccgate already runs safely on its embedded defaults. This section covers how to layer your own `allow` / `deny` / `environment` guidance on top.
+Once provider setup is done, this is the entry point for `allow` / `deny` / `append_*`.
 
-### What you can change
+- **Inspect defaults**: `ccgate claude init | less` / `ccgate codex init | less` (`-p` writes a `.local.jsonnet` skeleton).
+- **Where to put it**: global `~/.<target>/ccgate.jsonnet`, project-local `<repo>/.<target>/ccgate.local.jsonnet` (untracked-only).
+- **Replace vs append**: `append_allow` / `append_deny` / `append_environment` keep defaults and add (new defaults flow in on upgrade). `allow:` / `deny:` replaces wholesale (you re-check against `ccgate <target> init` on each release).
 
-- `allow` / `deny` / `environment` (string lists) — **replace** the inherited list when set.
-- `append_allow` / `append_deny` / `append_environment` — **append** entries on top of the inherited list. Embedded-default updates ccgate ships in a release flow in automatically when you upgrade.
-
-### Where to put it
-
-- Global: `~/.claude/ccgate.jsonnet` or `~/.codex/ccgate.jsonnet`.
-- Project-local: `<repo>/.claude/ccgate.local.jsonnet` or `<repo>/.codex/ccgate.local.jsonnet`, untracked-only.
-
-See [Config file loading order](#config-file-loading-order-per-target) above for how the layers compose.
-
-### Inspecting the embedded defaults
-
-```bash
-ccgate claude init           | less                   # Read the embedded Claude defaults.
-ccgate codex  init           | less                   # Same for Codex.
-ccgate claude init -p > .claude/ccgate.local.jsonnet  # Project-local skeleton you can extend.
-ccgate codex  init -p > .codex/ccgate.local.jsonnet   # Same for Codex.
-```
-
-### Replace vs append
-
-`append_*` keeps the inherited list and adds to it — embedded-default updates ccgate ships in a release land automatically when you upgrade. `allow:` / `deny:` replaces the inherited list wholesale; you take ownership of keeping your override in line with new embedded defaults, so re-check against `ccgate <target> init` output on each release.
-
-### Writing rules
-
-A rule is one line of natural-language guidance describing the operation, optionally with a `deny_message:` hint at the end (the deny message is shown to the AI when the rule fires). The LLM decides whether the actual request matches. Write at a granularity the LLM can judge from `tool_input` / `tool_input_raw` / `branch_name` / paths / command strings. Information not delivered to the LLM (e.g. the working-tree dirty/clean flag) cannot be used in guidance.
-
-Three example patterns, by which field you write the rule in:
-
-**Add to allow** (`append_allow`):
-
-```jsonnet
-{
-  ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/schemas/claude.schema.json',
-  append_allow: [
-    // Claude: target_path is in tool_input.file_path / referenced_paths
-    'Edit / Write / MultiEdit targeting a Markdown file under repo_root/docs/ is fine; the content review happens elsewhere.',
-  ],
-}
-```
-
-For Codex, write rules against `apply_patch` hunks (visible via `tool_input_raw`):
-
-```jsonnet
-{
-  ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/schemas/codex.schema.json',
-  append_allow: [
-    'apply_patch whose hunks all target *.md files under repo_root/docs/ is fine; the content review happens elsewhere.',
-  ],
-}
-```
-
-**Add to deny** (`append_deny`):
-
-```jsonnet
-{
-  append_deny: [
-    'Production database access: any psql / mysql connection to a *.prod.* host. deny_message: production access is gated behind the runbook.',
-    'Setting production environment variables in the running session. deny_message: configure production via the deployment system, not via shell exports.',
-  ],
-}
-```
-
-**Replace wholesale** (`allow:` / `deny:`):
-
-```jsonnet
-{
-  // You take ownership of the full lists; new embedded defaults will not flow in automatically.
-  allow: [
-    'Read-only filesystem inspection inside the repository.',
-    'Local development commands using project scripts (build, test, lint).',
-  ],
-  deny: [
-    'Downloading and executing remote code (curl | bash, eval $(curl ...), etc.). deny_message: vet the script first; install it via a package manager or a checked-in script.',
-  ],
-}
-```
-
-The `$schema` line enables editor autocompletion either way.
-
-ccgate registers `std.native('env')(name)` (empty string when undefined) and `std.native('must_env')(name)` (raises a config-load error) as jsonnet helpers. They let any string field pull values from the process environment without ccgate-specific syntax — useful for embedding host names or account IDs into a rule string.
-
-### Iteration workflow
-
-Run `ccgate <target> metrics --details N` after a day or two of real use. The "Top fallthrough commands" / "Top deny commands" drill-downs surface operations a rule could handle. Add one `append_deny` (or `append_allow`) entry, ship it, and re-check the metrics next round.
+The full guide — rule-writing patterns for Claude / Codex (`append_allow`, `append_deny`, full replace), `deny_message:` hints, `std.native('env')` / `must_env` for env-derived values, the `ccgate <target> metrics --details N` iteration workflow — lives in [docs/rule-tuning.md](docs/rule-tuning.md).
 
 ## Provider と credential
 
-### Switching to OpenAI / Gemini
-
-Set `provider.name` (and optionally `provider.model`) in any layer:
+Switch providers by setting `provider.name` (and `provider.model` if needed) in any layer:
 
 ```jsonnet
 {
   provider: {
     name: 'openai',
-    model: 'gpt-5.4-nano-2026-03-17',
+    model: 'gpt-4o-mini',
   },
 }
 ```
 
-Then export the matching API key (`CCGATE_OPENAI_API_KEY` / `CCGATE_GEMINI_API_KEY` — see the [provider table](#2-api-key)). If the key is missing, ccgate falls through to the upstream tool's permission prompt, so flipping providers cannot break the hook.
+Export the matching API key — see [docs/providers.md#api-keys](docs/providers.md#api-keys). If the key is missing, ccgate falls through to the upstream tool's permission prompt, so flipping providers cannot break the hook.
 
-> [!WARNING]
-> Avoid reasoning models (`gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-chat`, `o1*`, `o3*`, `o4-mini`). They reject `temperature=0` (every request fails) and add seconds of chain-of-thought that ccgate's classification doesn't need. Use `gpt-4.1-nano`, `gpt-4o-mini`, or `gpt-5.4-nano-2026-03-17`.
+Provider switching, model selection (avoiding reasoning models, etc.), API key resolution order, and compatible-proxy setup are all consolidated in [docs/providers.md](docs/providers.md).
 
-### Routing through a compatible proxy
-
-ccgate uses each provider SDK's standard chat / messages endpoint, so it works against any **OpenAI- or Anthropic-compatible** endpoint — including [LiteLLM proxy](https://docs.litellm.ai/docs/proxy/quick_start), Azure OpenAI, on-prem gateways, and regional endpoints. Pick the protocol the proxy speaks and set `provider.base_url`.
-
-`provider.base_url` is passed verbatim to the underlying SDK's `WithBaseURL`, so the path you write follows that SDK's convention — **not** something ccgate normalizes:
-
-| `provider.name` | Underlying SDK | Default base URL                | What you put in `base_url`           |
-|-----------------|----------------|---------------------------------|--------------------------------------|
-| `openai`        | `openai-go`    | `https://api.openai.com/v1/`    | host **+ `/v1`** (SDK appends `chat/completions`) |
-| `anthropic`     | `anthropic-sdk-go` | `https://api.anthropic.com/` | host root only (SDK appends `/v1/messages`) |
-| `gemini`        | `openai-go` against Gemini's OpenAI-compat endpoint | `https://generativelanguage.googleapis.com/v1beta/openai/` | host **+ `/v1beta/openai`** if overriding |
-
-**OpenAI-compatible endpoint** (e.g. LiteLLM proxy's `/v1/chat/completions`):
-
-```jsonnet
-{
-  provider: {
-    name: 'openai',
-    model: 'anthropic/claude-haiku-4-5', // whatever the proxy exposes
-    base_url: 'https://your-proxy.example/v1',
-  },
-}
-```
-
-Export the proxy's API key as `CCGATE_OPENAI_API_KEY`. The trailing `/v1` is required because the OpenAI SDK appends `/chat/completions` directly to the base URL.
-
-**Anthropic-compatible endpoint** (e.g. LiteLLM proxy's `/v1/messages`):
-
-```jsonnet
-{
-  provider: {
-    name: 'anthropic',
-    model: 'claude-haiku-4-5',
-    base_url: 'https://your-proxy.example',
-  },
-}
-```
-
-Export the proxy's API key as `CCGATE_ANTHROPIC_API_KEY`. The Anthropic SDK appends `/v1/messages` itself, so the base URL stops at the host root.
-
-### Refreshable credentials
-
-When the credential rotates faster than a static env var can keep up (AWS STS, Vertex ADC, OpenAI-compatible gateways with virtual keys, internal key brokers), use `provider.auth`. It's a discriminated union over three shapes:
-
-```jsonnet
-// Run a shell helper to mint a credential on demand
-{
-  provider: {
-    name: 'anthropic',
-    model: 'claude-haiku-4-5',
-    auth: {
-      type: 'exec',
-      command: '/usr/local/bin/my-key-broker --provider anthropic',
-    },
-  },
-}
-
-// Or have an external rotator write the credential to a file
-// (path optional; defaults to $XDG_STATE_HOME/ccgate/<target>/auth_key.json)
-{
-  provider: {
-    name: 'anthropic',
-    model: 'claude-haiku-4-5',
-    auth: {
-      type: 'file',
-      path: '~/.config/my-broker/anthropic.json',
-    },
-  },
-}
-
-// Or read credentials from an `ant auth login` profile (Anthropic only;
-// the SDK refreshes the access token on its own)
-{
-  provider: {
-    name: 'anthropic',
-    model: 'claude-haiku-4-5',
-    auth: {
-      type: 'profile',
-      profile: 'ccgate',       // matches `ant auth login --profile ccgate`
-    },
-  },
-}
-```
-
-The helper / file content is one of:
-
-- **JSON** `{"key":"sk-...","expires_at":"<RFC3339>"}` — for `auth.type=exec`, memoized in `$XDG_CACHE_HOME/ccgate/<target>/` and refreshed early.
-- **Plain string** — a single non-empty line, not cached.
-
-`auth.type=profile` is different: ccgate hands the loaded profile to anthropic-sdk-go via `option.WithConfig`, and the SDK's refresh-token loop owns the credential lifecycle. ccgate also calls `option.WithoutEnvironmentDefaults` so a leftover `ANTHROPIC_API_KEY` cannot silently shadow your declared profile.
-
-Resolution order: `provider.auth` (when configured) > `CCGATE_*_API_KEY` > `*_API_KEY`. When `auth` is configured ccgate **does not silently fall back to env vars on failure** — the hook falls through with `kind=credential_unavailable` instead.
-
-See [docs/api-key-helper.md](docs/api-key-helper.md) for the full helper contract, runnable examples, account-aware caching via `auth.cache_key`, browser-based first-run auth, the 401/403 behaviour matrix, and the operational recovery checklist.
+**Refreshable credentials** (AWS STS, Vertex ADC, OpenAI-compatible gateways with virtual keys, internal key brokers — anything a static env var cannot keep up with) are handled via `provider.auth`, a discriminated union over three shapes (`type=exec` / `type=file` / `type=profile`). The full helper contract, caching, 401/403 behaviour, and the recovery checklist live in [docs/api-key-helper.md](docs/api-key-helper.md).
 
 ## Fallthrough strategy
 
-By default, when the LLM is not confident enough to decide, ccgate returns `fallthrough` and the AI tool shows its interactive permission prompt. That is the right behavior for a human-in-the-loop session but blocks schedulers, bots, and any unattended run.
-
-Set `fallthrough_strategy` to force a fixed verdict on LLM uncertainty:
+When the LLM is not confident enough to decide, ccgate returns `fallthrough` and the AI tool shows its interactive permission prompt. That is fine in a human-in-the-loop session, but blocks unattended runs. Set `fallthrough_strategy` to force a fixed verdict on LLM uncertainty (default is `ask`):
 
 ```jsonnet
-{
-  // Safer: when the LLM is unsure, refuse. Recommended for anything that runs unattended.
-  fallthrough_strategy: 'deny',
-}
+{ fallthrough_strategy: 'deny' }  // Safer; recommended for anything unattended.
 ```
 
-Values:
-
-- `ask` (default) — defer to the upstream tool's prompt. No behavior change.
-- `deny` — auto-refuse uncertain operations. The deny message tells the AI not to re-ask and not to work around the restriction, so the run keeps moving instead of stalling.
-- `allow` — auto-approve uncertain operations. **Riskier**: you are letting ccgate green-light operations the LLM itself was unsure about. Both Claude Code and Codex only deliver `decision.message` on `deny`, so the AI never sees a warning on forced-allow.
-
-Only LLM-driven uncertainty is affected. Truncated/refused API responses, missing API keys, `bypassPermissions`/`dontAsk` mode (Claude only), and `ExitPlanMode` / `AskUserQuestion` (Claude only) continue to defer to the upstream tool regardless.
-
-`ccgate <target> metrics` surfaces how often the override fired through the `F.Allow` / `F.Deny` columns in the daily table (and `forced_allow` / `forced_deny` in JSON output), so you can audit whether the strategy you chose is making decisions you are comfortable with.
+`allow` auto-approves operations the LLM itself was unsure about, so use it sparingly. The full value semantics, what is **not** covered (truncated API responses, missing keys, `bypassPermissions` / `dontAsk`, user-interaction tools, etc.), and the metrics audit columns are in [docs/configuration.md](docs/configuration.md).
 
 ## Logging and metrics
 
-Logs and metrics live under `$XDG_STATE_HOME/ccgate/<target>/` (or `~/.local/state/ccgate/<target>/` when `XDG_STATE_HOME` is unset):
-
-- `$XDG_STATE_HOME/ccgate/claude/{ccgate.log,metrics.jsonl}` — Claude Code
-- `$XDG_STATE_HOME/ccgate/codex/{ccgate.log,metrics.jsonl}` — Codex CLI
-
-Both files rotate on size (`.log.1`, `.jsonl.1`).
-
-Override paths in jsonnet are respected — set `log_path` / `metrics_path` to put them anywhere.
+- Logs: `$XDG_STATE_HOME/ccgate/<target>/ccgate.log` (or `~/.local/state/ccgate/<target>/` when unset).
+- Metrics: `$XDG_STATE_HOME/ccgate/<target>/metrics.jsonl`.
+- Both rotate on a configurable `_max_size` threshold.
 
 ```bash
 ccgate claude metrics                 # last 7 days, TTY table
-ccgate claude metrics --days 30       # wider window
-ccgate claude metrics --json          # machine-readable output
-ccgate claude metrics --details 5     # top-5 fallthrough / deny commands
-ccgate claude metrics --details 0     # suppress the drill-down sections
-ccgate codex  metrics --days 7        # codex side
+ccgate claude metrics --details 5     # drill into the top-5 fallthrough / deny commands
+ccgate codex  metrics --json          # machine-readable output
 ```
 
-The daily table shows per-day counts (Allow, Deny, Fall, F.Allow, F.Deny, Err), automation rate, average latency, and token usage. The "Top fallthrough commands" / "Top deny commands" drill-downs surface which operations you could eliminate by adding a rule.
+Column meanings, the JSON entry schema, and the credential-failure aggregation are in [docs/configuration.md#metrics-output](docs/configuration.md#metrics-output).
 
 ## Known limitations
 
-- **Plan mode correctness is prompt-only (Claude only).** Under `permission_mode == "plan"`, ccgate relies on the LLM plus prose in the system prompt to (a) reject implementation-side writes and (b) allow read-only queries without requiring an allow-guidance match. Either side can misfire. Tracked in [#37](https://github.com/tak848/ccgate/issues/37).
-- **No surgical reset for a single embedded default rule.** A layer can either **replace** a list wholesale (`allow: [...]`) or **append** to it (`append_allow: [...]`). Removing one specific embedded `allow` / `deny` rule while keeping the rest of the embedded list requires re-stating the whole list under `allow:` / `deny:` minus that one entry.
-- **No runtime conditional logic in jsonnet.** jsonnet evaluation happens once per hook invocation, at config load time, **before ccgate sees `tool_input`**. So rules cannot branch on `tool_input` / git working-tree state / external command output. Runtime classification is the LLM's job — write guidance in prose and let the LLM judge from the request context. Config-time env reads via `std.native('env')(name)` / `std.native('must_env')(name)` are available for things like embedding a host name into a rule string.
+- **Plan mode correctness is prompt-only (Claude only).** Under `permission_mode == "plan"`, ccgate relies on the LLM plus prose in the system prompt to (a) reject implementation-side writes and (b) allow read-only queries without requiring an allow-guidance match. Either side can misfire.
+- **No surgical reset for a single embedded default rule.** A layer can either **replace** a list wholesale (`allow: [...]`) or **append** to it (`append_allow: [...]`). Removing one specific embedded `allow` / `deny` rule while keeping the rest requires re-stating the whole list minus that one entry.
+- **No runtime conditional logic in jsonnet.** jsonnet evaluation happens once per hook invocation, at config-load time, **before ccgate sees `tool_input`**. Rules cannot branch on `tool_input` / git working-tree state / external command output. Runtime classification is the LLM's job. Config-time env reads via `std.native('env')(name)` / `std.native('must_env')(name)` are available for things like embedding a host name into a rule string.
 
 ## Documentation
 
-- [docs/claude.md](docs/claude.md) — Claude Code specifics, full HookInput field reference
-- [docs/codex.md](docs/codex.md) — Codex CLI specifics, full HookInput field reference
-- [docs/configuration.md](docs/configuration.md) — config layering, fallthrough_strategy, metrics, known limits
+- [docs/providers.md](docs/providers.md) — Provider switching, API keys, base_url, compatible proxies
+- [docs/rule-tuning.md](docs/rule-tuning.md) — Rule tuning entry point (defaults inspection, append vs replace, three example patterns, iteration workflow)
+- [docs/configuration.md](docs/configuration.md) — Config layering, full field reference, fallthrough_strategy details, metrics output
 - [docs/api-key-helper.md](docs/api-key-helper.md) — `provider.auth` reference (helper contract, caching, 401/403 behaviour, recovery checklist)
+- [docs/claude.md](docs/claude.md) — Claude Code-specific HookInput
+- [docs/codex.md](docs/codex.md) — Codex CLI-specific HookInput
 - [日本語ドキュメント (docs/ja/)](docs/ja/README.md)
 
 ## CLI reference
 
 ```
-ccgate                         Read HookInput JSON from stdin (Claude Code hook).
-                               Equivalent to 'ccgate claude'. Permanent default — never
-                               deprecated, so existing ~/.claude/settings.json entries
-                               using "command": "ccgate" keep working forever.
+ccgate                         Read HookInput JSON from stdin (Claude Code hook). Equivalent to `ccgate claude`.
 ccgate claude                  Same as bare ccgate, explicit form (recommended for new users).
 ccgate claude init [-p|-o|-f]  Output the embedded Claude Code defaults.
 ccgate claude metrics [...]    Show Claude Code usage metrics.
-
 ccgate codex                   Read HookInput JSON from stdin (Codex CLI hook).
 ccgate codex init [-o|-f]      Output the embedded Codex CLI defaults.
 ccgate codex metrics [...]     Show Codex CLI usage metrics.
 ```
 
-Top-level `ccgate init` and `ccgate metrics` are not real subcommands — they print a one-line pointer to the per-target form and exit `2`. The bare `ccgate` hook invocation is a different code path and works as documented above.
+Top-level `ccgate init` and `ccgate metrics` are not real subcommands — they print a one-line pointer to the per-target form and exit `2`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -292,6 +292,11 @@ mise run vet      # Run go vet
 mise run schema   # Regenerate schemas/{claude,codex}.schema.json
 ```
 
+## Articles
+
+- English (dev.to): <https://dev.to/tak848/ccgate-delegate-claude-code-codex-cli-permission-prompts-to-an-llm-274c>
+- 日本語 (Zenn): <https://zenn.dev/layerx/articles/20260428-ccgate>
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -152,16 +152,17 @@ ccgate's `allow` / `deny` / `environment` lists are **strings of natural-languag
 
 Evaluation flow:
 
-```
-AI tool issues a PermissionRequest
-  │
-  │  stdin: HookInput JSON
-  ▼
-ccgate
-  ├── Load jsonnet config (embedded defaults + your global + project-local)
-  ├── Build context (git repo info, referenced paths, recent transcript [Claude only])
-  ├── Call the configured LLM (default: Claude Haiku) with structured output
-  └── stdout: allow / deny / fallthrough
+```mermaid
+flowchart TD
+  A["Claude Code / Codex CLI"] --> B{"Resolved by the upstream tool's static rules?"}
+  B -->|Yes| C["Run / refuse upstream"]
+  B -->|No| D["PermissionRequest hook"]
+  D --> E["ccgate"]
+  E --> F["tool_input / git context / jsonnet rules"]
+  F --> G{"LLM (default: Haiku) judges"}
+  G -->|allow| H["Run"]
+  G -->|deny| I["Refuse with reason"]
+  G -->|fallthrough| J["Back to user confirmation"]
 ```
 
 What ccgate puts in front of the LLM (representative fields):

--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ To try ccgate without installing it globally (similar to `npx` / `uvx`):
 mise exec aqua:tak848/ccgate -- ccgate --version
 ```
 
-If you want to keep this no-install style for the hook itself, set the hook `command` to `mise exec aqua:tak848/ccgate -- ccgate claude` (or `... -- ccgate codex`) in your settings. Each hook invocation pays the launcher startup cost; for day-to-day use, `mise use -g` above is recommended.
-
 ### aqua
 
 Via the [aqua](https://aquaproj.github.io/) standard registry (requires registry `v4.498.0` or later). In an aqua-managed project (run `aqua init` first if you don't have an `aqua.yaml` yet):
@@ -221,7 +219,7 @@ Switch providers by setting `provider.name` (and `provider.model` if needed) in 
 
 Export the matching API key — see [docs/providers.md#api-keys](docs/providers.md#api-keys). If the key is missing, ccgate falls through to the upstream tool's permission prompt, so flipping providers cannot break the hook.
 
-Provider switching, model selection (avoiding reasoning models, etc.), API key resolution order, and compatible-proxy setup are all consolidated in [docs/providers.md](docs/providers.md).
+Provider switching, model selection constraints, API key resolution order, and compatible-proxy setup are all consolidated in [docs/providers.md](docs/providers.md).
 
 **Refreshable credentials** (AWS STS, Vertex ADC, OpenAI-compatible gateways with virtual keys, internal key brokers — anything a static env var cannot keep up with) are handled via `provider.auth`, a discriminated union over three shapes (`type=exec` / `type=file` / `type=profile`). The full helper contract, caching, 401/403 behaviour, and the recovery checklist live in [docs/api-key-helper.md](docs/api-key-helper.md).
 

--- a/README.md
+++ b/README.md
@@ -200,11 +200,11 @@ Once provider setup is done, this is the entry point for `allow` / `deny` / `app
 
 - **Inspect defaults**: `ccgate claude init | less` / `ccgate codex init | less` (`-p` writes a `.local.jsonnet` skeleton).
 - **Where to put it**: global `~/.<target>/ccgate.jsonnet`, project-local `<repo>/.<target>/ccgate.local.jsonnet` (untracked-only).
-- **Replace vs append**: `append_allow` / `append_deny` / `append_environment` keep defaults and add (new defaults flow in on upgrade). `allow:` / `deny:` replaces wholesale (you re-check against `ccgate <target> init` on each release).
+- **Replace vs append**: `append_allow` / `append_deny` / `append_environment` keep the embedded defaults and add your entries. `allow:` / `deny:` replaces the list wholesale (only your entries are in effect).
 
 The full guide — rule-writing patterns for Claude / Codex (`append_allow`, `append_deny`, full replace), `deny_message:` hints, `std.native('env')` / `must_env` for env-derived values, the `ccgate <target> metrics --details N` iteration workflow — lives in [docs/rule-tuning.md](docs/rule-tuning.md).
 
-## Provider と credential
+## Providers and credentials
 
 Switch providers by setting `provider.name` (and `provider.model` if needed) in any layer:
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ That's it — ccgate is now running with its embedded defaults. To customize wha
 ## Quick start — Codex CLI
 
 > [!NOTE]
-> Codex hooks are still experimental upstream and live behind the `[features] codex_hooks = true` flag; their schema may change. Treat the [Codex hooks docs](https://developers.openai.com/codex/hooks) as the source of truth before relying on a specific field.
+> Codex hooks live behind the `[features] codex_hooks = true` flag upstream. Treat the [Codex hooks docs](https://developers.openai.com/codex/hooks) as the source of truth before relying on a specific field.
 
 ### 1. Register as a Codex hook
 
@@ -235,7 +235,7 @@ ccgate already runs safely on its embedded defaults. This section covers how to 
 ### What you can change
 
 - `allow` / `deny` / `environment` (string lists) — **replace** the inherited list when set.
-- `append_allow` / `append_deny` / `append_environment` — **append** entries on top of the inherited list. Future ccgate releases that improve the embedded defaults flow in automatically.
+- `append_allow` / `append_deny` / `append_environment` — **append** entries on top of the inherited list. Embedded-default updates ccgate ships in a release flow in automatically when you upgrade.
 
 ### Where to put it
 
@@ -255,7 +255,7 @@ ccgate codex  init -p > .codex/ccgate.local.jsonnet   # Same for Codex.
 
 ### Replace vs append
 
-`append_*` keeps the inherited list and adds to it — quality improvements ccgate ships in future releases land automatically. `allow:` / `deny:` replaces the inherited list wholesale; you take ownership of keeping your override in line with new embedded defaults, so re-check against `ccgate <target> init` output on each release.
+`append_*` keeps the inherited list and adds to it — embedded-default updates ccgate ships in a release land automatically when you upgrade. `allow:` / `deny:` replaces the inherited list wholesale; you take ownership of keeping your override in line with new embedded defaults, so re-check against `ccgate <target> init` output on each release.
 
 ### Writing rules
 

--- a/README.md
+++ b/README.md
@@ -43,12 +43,6 @@ aqua i
 
 For a [global aqua config](https://aquaproj.github.io/docs/tutorial/global-config), follow aqua's own tutorial.
 
-### Homebrew
-
-```bash
-brew install tak848/tap/ccgate
-```
-
 ### go install
 
 ```bash
@@ -58,6 +52,12 @@ go install github.com/tak848/ccgate@latest
 ### GitHub Releases
 
 Download a binary from [Releases](https://github.com/tak848/ccgate/releases) and place it on your `PATH`.
+
+### Homebrew
+
+```bash
+brew install tak848/tap/ccgate
+```
 
 ## Quick start — Claude Code
 
@@ -221,7 +221,13 @@ Export the matching API key — see [docs/providers.md#api-keys](docs/providers.
 
 Provider switching, model selection constraints, API key resolution order, and compatible-proxy setup are all consolidated in [docs/providers.md](docs/providers.md).
 
-**Refreshable credentials** (AWS STS, Vertex ADC, OpenAI-compatible gateways with virtual keys, internal key brokers — anything a static env var cannot keep up with) are handled via `provider.auth`, a discriminated union over three shapes (`type=exec` / `type=file` / `type=profile`). The full helper contract, caching, 401/403 behaviour, and the recovery checklist live in [docs/api-key-helper.md](docs/api-key-helper.md).
+**Refreshable credentials** (AWS STS, Vertex ADC, OpenAI-compatible gateways with virtual keys, internal key brokers — anything a static env var cannot keep up with) are handled via `provider.auth`. Three shapes are supported:
+
+- `type=exec` — ccgate runs a **credential helper** command and uses its stdout as the credential, with caching keyed on `expires_at`.
+- `type=file` — ccgate reads a credential file written by an external rotator.
+- `type=profile` — Anthropic-only; ccgate hands an `ant auth login` profile to the SDK and the SDK refresh-token loop owns the credential.
+
+The full helper contract, caching, 401/403 behaviour, and the recovery checklist live in [docs/api-key-helper.md](docs/api-key-helper.md).
 
 ## Fallthrough strategy
 

--- a/README.md
+++ b/README.md
@@ -322,8 +322,6 @@ Run `ccgate <target> metrics --details N` after a day or two of real use. The "T
 
 ## Provider と credential
 
-> The Japanese version of this section uses the title "Provider と credential" because retrieval engines look for both English and Japanese terms. The English README keeps the same section anchored as `#provider-と-credential`. (This is a docs-tooling note, not a behaviour note.)
-
 ### Switching to OpenAI / Gemini
 
 Set `provider.name` (and optionally `provider.model`) in any layer:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Download a binary from [Releases](https://github.com/tak848/ccgate/releases) and
 }
 ```
 
-`"command": "ccgate"` (no subcommand) is also accepted and will keep working forever — bare `ccgate` is the canonical Claude Code hook invocation.
+`"command": "ccgate"` (no subcommand) is the canonical Claude Code hook invocation; `ccgate claude` is the explicit form.
 
 If `ccgate` is not on your `PATH` (e.g. when relying on `mise exec` instead of a global install), set the hook `command` to the equivalent invocation, or use an absolute path to the binary.
 
@@ -91,7 +91,7 @@ If `ccgate` is not on your `PATH` (e.g. when relying on `mise exec` instead of a
 
 ccgate calls Anthropic's Claude Haiku by default. Export `CCGATE_ANTHROPIC_API_KEY` (or `ANTHROPIC_API_KEY` as fallback). For OpenAI / Gemini and the resolution order, see [docs/providers.md#api-keys](docs/providers.md#api-keys).
 
-That's it — ccgate is now running with its embedded defaults. To customize what is allowed or denied, see [Rule tuning](#rule-tuning); for background on how rules work, see [Concepts](#concepts).
+That's it — ccgate is now running with its embedded defaults. To customize what is allowed or denied, see [docs/rule-tuning.md](docs/rule-tuning.md); for background on how rules work, see [Concepts](#concepts).
 
 ## Quick start — Codex CLI
 
@@ -144,7 +144,7 @@ See [docs/codex.md](docs/codex.md) for the full lookup order, project-local over
 
 Same env vars as Claude Code — see [docs/providers.md#api-keys](docs/providers.md#api-keys).
 
-That's it — ccgate is now running with its embedded defaults. To customize what is allowed or denied, see [Rule tuning](#rule-tuning); for background on how rules work, see [Concepts](#concepts).
+That's it — ccgate is now running with its embedded defaults. To customize what is allowed or denied, see [docs/rule-tuning.md](docs/rule-tuning.md); for background on how rules work, see [Concepts](#concepts).
 
 ## Concepts
 
@@ -266,13 +266,13 @@ Column meanings, the JSON entry schema, and the credential-failure aggregation a
 ## CLI reference
 
 ```
-ccgate                         Read HookInput JSON from stdin (Claude Code hook). Equivalent to `ccgate claude`.
-ccgate claude                  Same as bare ccgate, explicit form (recommended for new users).
-ccgate claude init [-p|-o|-f]  Output the embedded Claude Code defaults.
-ccgate claude metrics [...]    Show Claude Code usage metrics.
-ccgate codex                   Read HookInput JSON from stdin (Codex CLI hook).
-ccgate codex init [-o|-f]      Output the embedded Codex CLI defaults.
-ccgate codex metrics [...]     Show Codex CLI usage metrics.
+ccgate                                       Read HookInput JSON from stdin (Claude Code hook). Equivalent to `ccgate claude`.
+ccgate claude                                Same as bare ccgate, explicit form (recommended for new users).
+ccgate claude init [-p] [-o FILE] [-f]       Output the embedded Claude Code defaults.
+ccgate claude metrics [...]                  Show Claude Code usage metrics.
+ccgate codex                                 Read HookInput JSON from stdin (Codex CLI hook).
+ccgate codex init [-p] [-o FILE] [-f]        Output the embedded Codex CLI defaults.
+ccgate codex metrics [...]                   Show Codex CLI usage metrics.
 ```
 
 Top-level `ccgate init` and `ccgate metrics` are not real subcommands — they print a one-line pointer to the per-target form and exit `2`.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 [![CI](https://github.com/tak848/ccgate/actions/workflows/ci.yml/badge.svg)](https://github.com/tak848/ccgate/actions/workflows/ci.yml)
 [![release](https://github.com/tak848/ccgate/actions/workflows/release.yml/badge.svg)](https://github.com/tak848/ccgate/releases)
 
-A **PermissionRequest** hook for AI coding tools that delegates tool-execution permission decisions to an LLM (Claude Haiku) based on rules defined in a configuration file.
+A **PermissionRequest** hook for AI coding tools. It delegates each tool-execution permission decision to an LLM (Claude Haiku) using rules written in a jsonnet configuration file. Rules are **natural-language guidance read by the LLM** — not deterministic jsonnet policy code — so the typical workflow is to describe what should be allowed or denied in prose and let the LLM classify the actual request.
+
+ccgate ships with built-in default rules, so it works out of the box without any configuration.
 
 ![ccgate in action: a safe `echo` is allowed while `curl ... | bash` is denied with a deny_message](docs/images/gate.png)
 
@@ -14,43 +16,7 @@ Supported targets:
 
 [日本語ドキュメント](docs/ja/README.md)
 
-## How it works
-
-```
-Claude Code / Codex CLI (PermissionRequest hook)
-  │
-  │  stdin: HookInput JSON
-  ▼
-ccgate
-  ├── Load config (~/.claude/ccgate.jsonnet  or  ~/.codex/ccgate.jsonnet)
-  ├── Build context (git repo, paths, recent transcript [Claude only])
-  ├── Call Claude Haiku API (Structured Output)
-  └── stdout: allow / deny / fallthrough
-```
-
-1. The AI tool invokes `ccgate` before executing a tool.
-2. `ccgate` embeds allow/deny rules from the jsonnet config into a system prompt, sends tool info, git context, and (for Claude) recent conversation history to Haiku.
-3. Returns Haiku's decision to the AI tool.
-
-## CLI
-
-```
-ccgate                         Read HookInput JSON from stdin (Claude Code hook).
-                               Equivalent to 'ccgate claude'. Permanent default — never
-                               deprecated, so existing ~/.claude/settings.json entries
-                               using "command": "ccgate" keep working forever.
-ccgate claude                  Same as bare ccgate, explicit form (recommended for new users).
-ccgate claude init [-p|-o|-f]  Output the embedded Claude Code defaults.
-ccgate claude metrics [...]    Show Claude Code usage metrics.
-
-ccgate codex                   Read HookInput JSON from stdin (Codex CLI hook).
-ccgate codex init [-o|-f]      Output the embedded Codex CLI defaults.
-ccgate codex metrics [...]     Show Codex CLI usage metrics.
-```
-
-> Top-level `ccgate init` and `ccgate metrics` are not real subcommands — they print a one-line pointer to the per-target form and exit `2`. The bare `ccgate` hook invocation is a different code path and works as documented above.
-
-## Installation
+## Install
 
 ### mise (recommended)
 
@@ -79,6 +45,12 @@ aqua i
 
 For a [global aqua config](https://aquaproj.github.io/docs/tutorial/global-config), follow aqua's own tutorial.
 
+### Homebrew
+
+```bash
+brew install tak848/tap/ccgate
+```
+
 ### go install
 
 ```bash
@@ -89,45 +61,9 @@ go install github.com/tak848/ccgate@latest
 
 Download a binary from [Releases](https://github.com/tak848/ccgate/releases) and place it on your `PATH`.
 
-### Homebrew
+## Quick start — Claude Code
 
-```bash
-brew install tak848/tap/ccgate
-```
-
-macOS and Linux.
-
-## Setup — Claude Code
-
-### 1. Create a config file (optional)
-
-ccgate ships with sensible default safety rules. Without any config file, it works out of the box.
-
-Customize at either layer; both follow the same merge rules:
-
-- `~/.claude/ccgate.jsonnet` — your global config across every Claude Code session.
-- `<repo>/.claude/ccgate.local.jsonnet` — project-local override (untracked-only, see [Configuration](docs/configuration.md#where-ccgate-looks-for-config)). Layered on top of the global config.
-
-Either file can use one (or both) of these shapes:
-
-- **Add to the inherited list** (`append_allow` / `append_deny` / `append_environment`). Keeps the embedded baseline + anything earlier layers added; quality improvements ccgate ships in future releases land automatically.
-
-  ```jsonnet
-  {
-    ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/schemas/claude.schema.json',
-    append_deny: [
-      'Production database access: any psql / mysql connection to a *.prod.* host. deny_message: production access is gated behind the runbook.',
-    ],
-  }
-  ```
-
-- **Replace the inherited list wholesale** (`allow:` / `deny:` set the lists, not append). Maximum control; you take ownership of keeping your `allow` / `deny` in line with future ccgate releases. `ccgate claude init | less` prints the embedded defaults you can copy-paste from.
-
-A common pattern is to keep the global config close to the embedded defaults (just `append_deny` for personal preferences) and put project-specific guardrails in the project-local file. The two layers are independent: a project may `append_*` even if the global file replaces the lists, or vice versa.
-
-The `$schema` line enables editor autocompletion either way.
-
-### 2. Register as a Claude Code hook
+### 1. Register as a Claude Code hook
 
 `~/.claude/settings.json`:
 
@@ -153,7 +89,7 @@ The `$schema` line enables editor autocompletion either way.
 
 If `ccgate` is not on your `PATH` (e.g. when relying on `mise exec` instead of a global install), set the hook `command` to the equivalent invocation, or use an absolute path to the binary.
 
-### 3. API key
+### 2. API key
 
 Set the API key for your chosen provider. `CCGATE_*_API_KEY` is preferred and overrides the bare variable, so you can keep ccgate's key separate from the AI tool's own key.
 
@@ -163,30 +99,14 @@ Set the API key for your chosen provider. `CCGATE_*_API_KEY` is preferred and ov
 | `openai`        | `CCGATE_OPENAI_API_KEY`    | `OPENAI_API_KEY`     | <https://platform.openai.com/api-keys>      |
 | `gemini`        | `CCGATE_GEMINI_API_KEY`    | `GEMINI_API_KEY`     | <https://aistudio.google.com/app/api-keys>  |
 
-To route through an OpenAI- or Anthropic-compatible proxy (LiteLLM proxy, Azure OpenAI, on-prem gateway, ...), set `provider.base_url` and use the matching native provider — see [Routing through a compatible proxy](#routing-through-a-compatible-proxy).
+That's it — ccgate is now running with its embedded defaults. To customize what is allowed or denied, see [Rule tuning](#rule-tuning); for background on how rules work, see [Concepts](#concepts).
 
-## Setup — Codex CLI
+## Quick start — Codex CLI
 
-> Codex hooks themselves are still experimental upstream and live behind `features.codex_hooks = true`; their schema may change. Treat the [Codex hooks docs](https://developers.openai.com/codex/hooks) as the source of truth before relying on a specific field.
+> [!NOTE]
+> Codex hooks are still experimental upstream and live behind the `[features] codex_hooks = true` flag; their schema may change. Treat the [Codex hooks docs](https://developers.openai.com/codex/hooks) as the source of truth before relying on a specific field.
 
-### 1. Create a config file (optional)
-
-ccgate ships sensible defaults for Codex too. Same merge rules as the Claude side: customize at either `~/.codex/ccgate.jsonnet` (global) or `<repo>/.codex/ccgate.local.jsonnet` (project-local, untracked-only), and at either layer use `append_*` to add on top of what's inherited or `allow:` / `deny:` to replace the list wholesale.
-
-```jsonnet
-{
-  ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/schemas/codex.schema.json',
-  append_deny: [
-    'Production database access: any psql / mysql connection to a *.prod.* host. deny_message: production access is gated behind the runbook.',
-  ],
-}
-```
-
-`ccgate codex init | less` prints the embedded defaults if you want to see what you would be replacing.
-
-The defaults follow Claude Code parity (allow + deny + environment guidance). Codex hooks fire for Bash, `apply_patch`, MCP tool calls, and other tool surfaces; the rules cover all of them and the system prompt instructs the LLM to classify by `tool_name` + the full `tool_input` JSON, not just Bash command shape.
-
-### 2. Register as a Codex hook
+### 1. Register as a Codex hook
 
 Codex reads hooks from `~/.codex/hooks.json` and `~/.codex/config.toml` (with `<repo>/.codex/{hooks.json,config.toml}` overlays once the project is trusted). Pick whichever fits your setup.
 
@@ -215,7 +135,7 @@ Codex reads hooks from `~/.codex/hooks.json` and `~/.codex/config.toml` (with `<
 
 ```toml
 [features]
-codex_hooks = true   # required: Codex hooks live behind this feature flag
+codex_hooks = true   # Codex hooks live behind this feature flag; keep it set for compatibility.
 
 [[hooks.PermissionRequest]]
 matcher = ""
@@ -228,9 +148,38 @@ statusMessage = "ccgate evaluating request"
 
 See [docs/codex.md](docs/codex.md) for the full lookup order, project-local overlays, and a `go run` recipe for in-tree dev builds. Refer to the upstream [Codex hooks documentation](https://developers.openai.com/codex/hooks) for the authoritative schema.
 
-### 3. API key
+### 2. API key
 
-Same env vars as Claude Code — see the [provider table](#3-api-key).
+Same env vars as Claude Code — see the [provider table](#2-api-key).
+
+That's it — ccgate is now running with its embedded defaults. To customize what is allowed or denied, see [Rule tuning](#rule-tuning); for background on how rules work, see [Concepts](#concepts).
+
+## Concepts
+
+ccgate's `allow` / `deny` / `environment` lists are **strings of natural-language guidance** that get embedded into a system prompt and sent to the LLM. They are not patterns matched by a deterministic engine — every PermissionRequest goes through the LLM, and the LLM classifies it as `allow`, `deny`, or `fallthrough` based on the rules plus the request context.
+
+Evaluation flow:
+
+```
+AI tool issues a PermissionRequest
+  │
+  │  stdin: HookInput JSON
+  ▼
+ccgate
+  ├── Load jsonnet config (embedded defaults + your global + project-local)
+  ├── Build context (git repo info, referenced paths, recent transcript [Claude only])
+  ├── Call the configured LLM (default: Claude Haiku) with structured output
+  └── stdout: allow / deny / fallthrough
+```
+
+What ccgate puts in front of the LLM (representative fields):
+
+- `tool_name`, `tool_input`, and `tool_input_raw` (the original JSON payload, passed through verbatim).
+- `cwd`, `repo_root`, `branch_name`, and worktree info from `gitutil.Context`. The working-tree dirty/clean state is **not** delivered.
+- `referenced_paths` — paths extracted from `tool_input` on a best-effort basis. Supported tools: `Read`, `Write`, `Edit`, `MultiEdit`, `Glob`, `Grep`, `Bash`. For `apply_patch` (Codex) and MCP tools, `referenced_paths` is empty; the LLM reads `tool_input_raw` directly to see hunk targets or call arguments.
+- Claude-only: `permission_mode` (switches the prompt to plan-mode rules when `"plan"`), `permission_suggestions`, `recent_transcript`, and `settings_permissions` (treated as a hint, not a whitelist).
+
+For the complete input list per target, see [docs/claude.md](docs/claude.md) and [docs/codex.md](docs/codex.md).
 
 ## Configuration
 
@@ -238,23 +187,20 @@ Same env vars as Claude Code — see the [provider table](#3-api-key).
 
 | Order | Claude Code | Codex CLI |
 |------:|-------------|-----------|
-| 1     | Embedded defaults (always applied as the base) | Embedded defaults (same) |
-| 2     | `~/.claude/ccgate.jsonnet` — global (layered on top) | `~/.codex/ccgate.jsonnet` — global (same) |
-| 3     | `{main_worktree}/.claude/ccgate.local.jsonnet` — main-worktree project-local (untracked only; only when running in a linked git worktree) | `{main_worktree}/.codex/ccgate.local.jsonnet` (same) |
-| 4     | `{repo_root}/.claude/ccgate.local.jsonnet` — current-worktree project-local (untracked only) | `{repo_root}/.codex/ccgate.local.jsonnet` (same) |
+| 1     | Embedded defaults (always applied as the base) | Embedded defaults |
+| 2     | `~/.claude/ccgate.jsonnet` — global (layered on top) | `~/.codex/ccgate.jsonnet` — global |
+| 3     | `{main_worktree}/.claude/ccgate.local.jsonnet` — main-worktree project-local (untracked only; only when running in a linked git worktree) | `{main_worktree}/.codex/ccgate.local.jsonnet` |
+| 4     | `{repo_root}/.claude/ccgate.local.jsonnet` — current-worktree project-local (untracked only) | `{repo_root}/.codex/ccgate.local.jsonnet` |
 
 All layers compose with the same rules:
 
 - **Lists** — `allow` / `deny` / `environment` **replace** the value carried over from earlier layers when the layer sets them (even to `[]`). The `append_*` siblings (`append_allow`, `append_deny`, `append_environment`) **add** entries on top of whatever the earlier layers produced.
 - **Scalars** — `log_*`, `metrics_*`, `fallthrough_strategy` are overwritten per-field when the layer sets them, otherwise the earlier value survives.
-- **`provider` block** — a layer that writes `provider` **replaces the entire block** (`name` + `model` + `base_url` + `auth` + `timeout_ms`, i.e. every `provider.*` field). Layers that omit `provider` inherit the earlier block unchanged. The block is replaced as a unit because the fields are tightly coupled (different `name` typically means a different `model` namespace and `base_url`); per-field merge would let stale settings from a lower layer leak through. Important: when a project-local config restates `provider`, it must repeat any `auth` block from the global layer too — otherwise the helper config is silently dropped on that project.
-
-So `~/.<target>/ccgate.jsonnet` that wants to bump just the model still has to restate the whole `provider` block (e.g. `provider: {name: 'anthropic', model: 'claude-sonnet-4-6'}`). A `~/.<target>/ccgate.jsonnet` that writes `allow: [...]` swaps the embedded allow list for its own (this is what most pre-v0.6 global configs already did, so it stays idempotent). Project-local configs typically use `append_deny: [...]` / `append_environment: [...]` to add restrictions on top of the inherited base.
+- **`provider` block** — a layer that writes `provider` **replaces the entire block** (`name` + `model` + `base_url` + `auth` + `timeout_ms`). Layers that omit `provider` inherit the earlier block unchanged. The block is replaced as a unit because the fields are tightly coupled. Important: when a project-local config restates `provider`, it must repeat any `auth` block from the global layer too — otherwise the helper config is silently dropped on that project.
 
 Project-local configs are loaded only when **not tracked by Git**.
 
 Set `disable_load_main_worktree_local_config: true` in layer (1) or (2) to skip layer (3). The flag is honoured only at those two layers — written into (3) or (4) it is ignored. See [docs/configuration.md](docs/configuration.md#where-ccgate-looks-for-config).
-
 
 ### Config fields
 
@@ -262,8 +208,8 @@ Set `disable_load_main_worktree_local_config: true` in layer (1) or (2) to skip 
 |--------------------------|-----------------------------------|-------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
 | `provider.name`          | string                            | `"anthropic"`                                                                 | Provider name. One of `"anthropic"`, `"openai"`, `"gemini"`.                                            |
 | `provider.model`         | string                            | `"claude-haiku-4-5"`                                                          | Model name. Examples: `claude-haiku-4-5` / `claude-sonnet-4-6` (anthropic), `gpt-5.4-nano-2026-03-17` (openai), `gemini-3-flash-preview` (gemini). When routing through a compatible proxy, use whatever model name the proxy exposes (e.g. `anthropic/claude-haiku-4-5`). |
-| `provider.base_url`      | string                            | `""`                                                                          | Override the provider's API base URL. Empty = use the SDK default. Use this to route through an OpenAI- / Anthropic-compatible proxy (LiteLLM proxy, Azure OpenAI, on-prem gateway, regional endpoint, ...). |
-| `provider.auth`          | object (`{type, ...}`)            | (omit = env var)                                                              | Discriminated union for short-lived / rotating credentials. `type=exec` (run a shell command), `type=file` (read a rotator-managed file), `type=profile` (Anthropic-only — reads `ant auth login --profile <name>` credentials, the SDK refreshes the access token on its own). See [docs/api-key-helper.md](docs/api-key-helper.md) for full reference. |
+| `provider.base_url`      | string                            | `""`                                                                          | Override the provider's API base URL. Empty = use the SDK default. Use this to route through an OpenAI- / Anthropic-compatible proxy. |
+| `provider.auth`          | object (`{type, ...}`)            | (omit = env var)                                                              | Discriminated union for short-lived / rotating credentials. `type=exec` / `type=file` / `type=profile`. See [docs/api-key-helper.md](docs/api-key-helper.md) for full reference. |
 | `provider.timeout_ms`    | int                               | `20000`                                                                       | API timeout (ms). `0` = no timeout.                                                                    |
 | `log_path`               | string                            | `$XDG_STATE_HOME/ccgate/<target>/ccgate.log`                                  | Log file path. Supports `~` for home directory.                                                        |
 | `log_disabled`           | bool                              | `false`                                                                       | Disable logging entirely                                                                               |
@@ -271,7 +217,7 @@ Set `disable_load_main_worktree_local_config: true` in layer (1) or (2) to skip 
 | `metrics_path`           | string                            | `$XDG_STATE_HOME/ccgate/<target>/metrics.jsonl`                               | Metrics JSONL file path.                                                                               |
 | `metrics_disabled`       | bool                              | `false`                                                                       | Disable metrics collection entirely                                                                    |
 | `metrics_max_size`       | int                               | `2097152`                                                                     | Max metrics file size in bytes before rotation (default 2MB). `0` = no rotation.                       |
-| `fallthrough_strategy`   | `"ask"` / `"allow"` / `"deny"`    | `"ask"`                                                                       | How to resolve LLM uncertainty (`fallthrough`). See [Unattended automation](#unattended-automation-fallthrough_strategy). |
+| `fallthrough_strategy`   | `"ask"` / `"allow"` / `"deny"`    | `"ask"`                                                                       | How to resolve LLM uncertainty (`fallthrough`). See [Fallthrough strategy](#fallthrough-strategy). |
 | `disable_load_main_worktree_local_config` | bool | `false`                                                                       | In a linked git worktree, skip the main worktree's `ccgate.local.jsonnet`. See [docs/configuration.md](docs/configuration.md#where-ccgate-looks-for-config). |
 | `allow`                  | string[]                          | `[]`                                                                          | Allow guidance rules. **Replaces** the value carried over from earlier layers when set.                |
 | `deny`                   | string[]                          | `[]`                                                                          | Deny guidance rules (mandatory). Supports inline `deny_message:` hints. Same replace semantics as `allow`. |
@@ -281,6 +227,102 @@ Set `disable_load_main_worktree_local_config: true` in layer (1) or (2) to skip 
 | `append_environment`     | string[]                          | `[]`                                                                          | Environment context appended on top of the carried-over list.                                          |
 
 `<target>` is `claude` or `codex` depending on which hook is invoked. When `XDG_STATE_HOME` is unset, ccgate falls back to `~/.local/state/ccgate/<target>/...`.
+
+## Rule tuning
+
+ccgate already runs safely on its embedded defaults. This section covers how to layer your own `allow` / `deny` / `environment` guidance on top.
+
+### What you can change
+
+- `allow` / `deny` / `environment` (string lists) — **replace** the inherited list when set.
+- `append_allow` / `append_deny` / `append_environment` — **append** entries on top of the inherited list. Future ccgate releases that improve the embedded defaults flow in automatically.
+
+### Where to put it
+
+- Global: `~/.claude/ccgate.jsonnet` or `~/.codex/ccgate.jsonnet`.
+- Project-local: `<repo>/.claude/ccgate.local.jsonnet` or `<repo>/.codex/ccgate.local.jsonnet`, untracked-only.
+
+See [Config file loading order](#config-file-loading-order-per-target) above for how the layers compose.
+
+### Inspecting the embedded defaults
+
+```bash
+ccgate claude init           | less                   # Read the embedded Claude defaults.
+ccgate codex  init           | less                   # Same for Codex.
+ccgate claude init -p > .claude/ccgate.local.jsonnet  # Project-local skeleton you can extend.
+ccgate codex  init -p > .codex/ccgate.local.jsonnet   # Same for Codex.
+```
+
+### Replace vs append
+
+`append_*` keeps the inherited list and adds to it — quality improvements ccgate ships in future releases land automatically. `allow:` / `deny:` replaces the inherited list wholesale; you take ownership of keeping your override in line with new embedded defaults, so re-check against `ccgate <target> init` output on each release.
+
+### Writing rules
+
+A rule is one line of natural-language guidance describing the operation, optionally with a `deny_message:` hint at the end (the deny message is shown to the AI when the rule fires). The LLM decides whether the actual request matches. Write at a granularity the LLM can judge from `tool_input` / `tool_input_raw` / `branch_name` / paths / command strings. Information not delivered to the LLM (e.g. the working-tree dirty/clean flag) cannot be used in guidance.
+
+Three example patterns, by which field you write the rule in:
+
+**Add to allow** (`append_allow`):
+
+```jsonnet
+{
+  ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/schemas/claude.schema.json',
+  append_allow: [
+    // Claude: target_path is in tool_input.file_path / referenced_paths
+    'Edit / Write / MultiEdit targeting a Markdown file under repo_root/docs/ is fine; the content review happens elsewhere.',
+  ],
+}
+```
+
+For Codex, write rules against `apply_patch` hunks (visible via `tool_input_raw`):
+
+```jsonnet
+{
+  ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/schemas/codex.schema.json',
+  append_allow: [
+    'apply_patch whose hunks all target *.md files under repo_root/docs/ is fine; the content review happens elsewhere.',
+  ],
+}
+```
+
+**Add to deny** (`append_deny`):
+
+```jsonnet
+{
+  append_deny: [
+    'Production database access: any psql / mysql connection to a *.prod.* host. deny_message: production access is gated behind the runbook.',
+    'Setting production environment variables in the running session. deny_message: configure production via the deployment system, not via shell exports.',
+  ],
+}
+```
+
+**Replace wholesale** (`allow:` / `deny:`):
+
+```jsonnet
+{
+  // You take ownership of the full lists; new embedded defaults will not flow in automatically.
+  allow: [
+    'Read-only filesystem inspection inside the repository.',
+    'Local development commands using project scripts (build, test, lint).',
+  ],
+  deny: [
+    'Downloading and executing remote code (curl | bash, eval $(curl ...), etc.). deny_message: vet the script first; install it via a package manager or a checked-in script.',
+  ],
+}
+```
+
+The `$schema` line enables editor autocompletion either way.
+
+ccgate registers `std.native('env')(name)` (empty string when undefined) and `std.native('must_env')(name)` (raises a config-load error) as jsonnet helpers. They let any string field pull values from the process environment without ccgate-specific syntax — useful for embedding host names or account IDs into a rule string.
+
+### Iteration workflow
+
+Run `ccgate <target> metrics --details N` after a day or two of real use. The "Top fallthrough commands" / "Top deny commands" drill-downs surface operations a rule could handle. Add one `append_deny` (or `append_allow`) entry, ship it, and re-check the metrics next round.
+
+## Provider と credential
+
+> The Japanese version of this section uses the title "Provider と credential" because retrieval engines look for both English and Japanese terms. The English README keeps the same section anchored as `#provider-と-credential`. (This is a docs-tooling note, not a behaviour note.)
 
 ### Switching to OpenAI / Gemini
 
@@ -295,9 +337,10 @@ Set `provider.name` (and optionally `provider.model`) in any layer:
 }
 ```
 
-Then export the matching API key (`CCGATE_OPENAI_API_KEY` / `CCGATE_GEMINI_API_KEY` — see the [provider table](#3-api-key)). If the key is missing, ccgate falls through to the upstream tool's permission prompt, so flipping providers cannot break the hook.
+Then export the matching API key (`CCGATE_OPENAI_API_KEY` / `CCGATE_GEMINI_API_KEY` — see the [provider table](#2-api-key)). If the key is missing, ccgate falls through to the upstream tool's permission prompt, so flipping providers cannot break the hook.
 
-> **Avoid reasoning models** (`gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-chat`, `o1*`, `o3*`, `o4-mini`): they reject `temperature=0` (every request fails) and add seconds of chain-of-thought that ccgate's classification doesn't need. Use `gpt-4.1-nano`, `gpt-4o-mini`, or `gpt-5.4-nano-2026-03-17`.
+> [!WARNING]
+> Avoid reasoning models (`gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-chat`, `o1*`, `o3*`, `o4-mini`). They reject `temperature=0` (every request fails) and add seconds of chain-of-thought that ccgate's classification doesn't need. Use `gpt-4.1-nano`, `gpt-4o-mini`, or `gpt-5.4-nano-2026-03-17`.
 
 ### Routing through a compatible proxy
 
@@ -339,9 +382,9 @@ Export the proxy's API key as `CCGATE_OPENAI_API_KEY`. The trailing `/v1` is req
 
 Export the proxy's API key as `CCGATE_ANTHROPIC_API_KEY`. The Anthropic SDK appends `/v1/messages` itself, so the base URL stops at the host root.
 
-### Short-lived / rotating API keys
+### Refreshable credentials
 
-When the credential rotates faster than a static env var can keep up (AWS STS, Vertex ADC, OpenAI-compatible gateways with virtual keys, internal key brokers), use `provider.auth`. It's a discriminated union over three shapes — pick the one that matches your setup:
+When the credential rotates faster than a static env var can keep up (AWS STS, Vertex ADC, OpenAI-compatible gateways with virtual keys, internal key brokers), use `provider.auth`. It's a discriminated union over three shapes:
 
 ```jsonnet
 // Run a shell helper to mint a credential on demand
@@ -370,8 +413,7 @@ When the credential rotates faster than a static env var can keep up (AWS STS, V
 }
 
 // Or read credentials from an `ant auth login` profile (Anthropic only;
-// the SDK refreshes the access token on its own, ccgate stays out of the
-// credential path entirely)
+// the SDK refreshes the access token on its own)
 {
   provider: {
     name: 'anthropic',
@@ -389,33 +431,13 @@ The helper / file content is one of:
 - **JSON** `{"key":"sk-...","expires_at":"<RFC3339>"}` — for `auth.type=exec`, memoized in `$XDG_CACHE_HOME/ccgate/<target>/` and refreshed early.
 - **Plain string** — a single non-empty line, not cached.
 
-`auth.type=profile` is different: ccgate hands the loaded profile to anthropic-sdk-go via `option.WithConfig`, and the SDK's refresh-token loop owns the credential lifecycle. ccgate also calls `option.WithoutEnvironmentDefaults` so a leftover `ANTHROPIC_API_KEY` cannot silently shadow your declared profile. After any `ant auth login` (auto-login or manual) check `ant auth status` — `ant` rewrites `<config_dir>/active_config` (shared with Claude Code) as a side effect of `--profile`; upstream PR [anthropics/anthropic-cli#45](https://github.com/anthropics/anthropic-cli/pull/45) adds a `--no-activate` flag to drop that side effect.
+`auth.type=profile` is different: ccgate hands the loaded profile to anthropic-sdk-go via `option.WithConfig`, and the SDK's refresh-token loop owns the credential lifecycle. ccgate also calls `option.WithoutEnvironmentDefaults` so a leftover `ANTHROPIC_API_KEY` cannot silently shadow your declared profile.
 
 Resolution order: `provider.auth` (when configured) > `CCGATE_*_API_KEY` > `*_API_KEY`. When `auth` is configured ccgate **does not silently fall back to env vars on failure** — the hook falls through with `kind=credential_unavailable` instead.
 
-ccgate also registers `std.native('env')(name)` (returns empty string for undefined) and `std.native('must_env')(name)` (raises a config-load error) as Jsonnet helpers, so any string field can pull values from the environment without ccgate-specific syntax.
+See [docs/api-key-helper.md](docs/api-key-helper.md) for the full helper contract, runnable examples, account-aware caching via `auth.cache_key`, browser-based first-run auth, the 401/403 behaviour matrix, and the operational recovery checklist.
 
-See [docs/api-key-helper.md](docs/api-key-helper.md) for the full helper contract, runnable examples, account-aware caching via `auth.cache_key`, browser-based first-run auth, the profile auto-login Beta + `active_config` caveat, the 401/403 behaviour matrix, and the operational recovery checklist.
-## Default Rules
-
-ccgate ships built-in default rules per target. They are always applied as the base; your global / project-local configs layer on top.
-
-**Allow:** Read-only operations, local development commands (build / test against project scripts), git feature-branch operations, package-manager installs scoped to the repo.
-
-**Deny:** Download-and-execute (`curl|bash`), direct one-shot remote package execution (`npx`/`pnpx`/`bunx` etc.), git destructive operations on protected branches, out-of-repo deletion, privilege escalation.
-
-Run `ccgate claude init` / `ccgate codex init` to inspect the full embedded defaults. ccgate updates these defaults occasionally for quality reasons; users on the `append_*` style pick those up automatically, while users who replaced the lists wholesale (`allow:` / `deny:`) need to re-check their override against the new defaults:
-
-```bash
-ccgate claude init           | less                   # Read the embedded Claude defaults.
-ccgate codex  init           | less                   # Same for Codex.
-ccgate claude init -p > .claude/ccgate.local.jsonnet  # Project-local skeleton you can extend.
-ccgate codex  init -p > .codex/ccgate.local.jsonnet   # Same for Codex.
-```
-
-Removing a single embedded rule while keeping the rest is not supported today; replace the whole list with `allow:` / `deny:` and drop the rule from your copy.
-
-## Unattended automation (`fallthrough_strategy`)
+## Fallthrough strategy
 
 By default, when the LLM is not confident enough to decide, ccgate returns `fallthrough` and the AI tool shows its interactive permission prompt. That is the right behavior for a human-in-the-loop session but blocks schedulers, bots, and any unattended run.
 
@@ -432,13 +454,13 @@ Values:
 
 - `ask` (default) — defer to the upstream tool's prompt. No behavior change.
 - `deny` — auto-refuse uncertain operations. The deny message tells the AI not to re-ask and not to work around the restriction, so the run keeps moving instead of stalling.
-- `allow` — auto-approve uncertain operations. **Riskier**: you are letting ccgate green-light operations the LLM itself was unsure about. Both Claude Code and Codex only deliver `decision.message` on `deny`, so the AI never sees a warning on forced-allow. Pick this only if that trade-off is acceptable.
+- `allow` — auto-approve uncertain operations. **Riskier**: you are letting ccgate green-light operations the LLM itself was unsure about. Both Claude Code and Codex only deliver `decision.message` on `deny`, so the AI never sees a warning on forced-allow.
 
-Only LLM-driven uncertainty is affected. Truncated/refused API responses, missing API keys, `bypassPermissions`/`dontAsk` mode (Claude only), and `ExitPlanMode` / `AskUserQuestion` (Claude only) continue to defer to the upstream tool regardless — so `fallthrough_strategy=allow` cannot silently auto-approve a request the LLM never actually classified.
+Only LLM-driven uncertainty is affected. Truncated/refused API responses, missing API keys, `bypassPermissions`/`dontAsk` mode (Claude only), and `ExitPlanMode` / `AskUserQuestion` (Claude only) continue to defer to the upstream tool regardless.
 
 `ccgate <target> metrics` surfaces how often the override fired through the `F.Allow` / `F.Deny` columns in the daily table (and `forced_allow` / `forced_deny` in JSON output), so you can audit whether the strategy you chose is making decisions you are comfortable with.
 
-## Logging & metrics
+## Logging and metrics
 
 Logs and metrics live under `$XDG_STATE_HOME/ccgate/<target>/` (or `~/.local/state/ccgate/<target>/` when `XDG_STATE_HOME` is unset):
 
@@ -455,24 +477,42 @@ ccgate claude metrics --days 30       # wider window
 ccgate claude metrics --json          # machine-readable output
 ccgate claude metrics --details 5     # top-5 fallthrough / deny commands
 ccgate claude metrics --details 0     # suppress the drill-down sections
-ccgate codex  metrics --days 7        # same shape, codex side
+ccgate codex  metrics --days 7        # codex side
 ```
 
-The daily table shows per-day counts (Allow, Deny, Fall, F.Allow, F.Deny, Err), automation rate, average latency, and token usage. The "Top fallthrough commands" / "Top deny commands" drill-downs surface which operations you could eliminate by adding a permission rule.
+The daily table shows per-day counts (Allow, Deny, Fall, F.Allow, F.Deny, Err), automation rate, average latency, and token usage. The "Top fallthrough commands" / "Top deny commands" drill-downs surface which operations you could eliminate by adding a rule.
 
 ## Known limitations
 
 - **Plan mode correctness is prompt-only (Claude only).** Under `permission_mode == "plan"`, ccgate relies on the LLM plus prose in the system prompt to (a) reject implementation-side writes and (b) allow read-only queries without requiring an allow-guidance match. Either side can misfire. Tracked in [#37](https://github.com/tak848/ccgate/issues/37).
 - **No surgical reset for a single embedded default rule.** A layer can either **replace** a list wholesale (`allow: [...]`) or **append** to it (`append_allow: [...]`). Removing one specific embedded `allow` / `deny` rule while keeping the rest of the embedded list requires re-stating the whole list under `allow:` / `deny:` minus that one entry.
-- **Codex hook schema may change.** Codex hooks live behind upstream's `features.codex_hooks = true` flag and are still evolving. ccgate does not currently expose `permission_mode` from Codex, parse the Codex transcript JSONL, ingest `~/.codex/config.toml`, or apply MCP-server-specific trust hints; classification runs from `tool_name` + `tool_input` + `cwd` only.
+- **No runtime conditional logic in jsonnet.** jsonnet evaluation happens once per hook invocation, at config load time, **before ccgate sees `tool_input`**. So rules cannot branch on `tool_input` / git working-tree state / external command output. Runtime classification is the LLM's job — write guidance in prose and let the LLM judge from the request context. Config-time env reads via `std.native('env')(name)` / `std.native('must_env')(name)` are available for things like embedding a host name into a rule string.
 
 ## Documentation
 
-- [docs/claude.md](docs/claude.md) — Claude Code specifics
-- [docs/codex.md](docs/codex.md) — Codex CLI specifics
+- [docs/claude.md](docs/claude.md) — Claude Code specifics, full HookInput field reference
+- [docs/codex.md](docs/codex.md) — Codex CLI specifics, full HookInput field reference
 - [docs/configuration.md](docs/configuration.md) — config layering, fallthrough_strategy, metrics, known limits
-- [docs/api-key-helper.md](docs/api-key-helper.md) — `provider.auth` reference (helper contract, caching, security guidance, 401/403 behaviour, recovery checklist)
+- [docs/api-key-helper.md](docs/api-key-helper.md) — `provider.auth` reference (helper contract, caching, 401/403 behaviour, recovery checklist)
 - [日本語ドキュメント (docs/ja/)](docs/ja/README.md)
+
+## CLI reference
+
+```
+ccgate                         Read HookInput JSON from stdin (Claude Code hook).
+                               Equivalent to 'ccgate claude'. Permanent default — never
+                               deprecated, so existing ~/.claude/settings.json entries
+                               using "command": "ccgate" keep working forever.
+ccgate claude                  Same as bare ccgate, explicit form (recommended for new users).
+ccgate claude init [-p|-o|-f]  Output the embedded Claude Code defaults.
+ccgate claude metrics [...]    Show Claude Code usage metrics.
+
+ccgate codex                   Read HookInput JSON from stdin (Codex CLI hook).
+ccgate codex init [-o|-f]      Output the embedded Codex CLI defaults.
+ccgate codex metrics [...]     Show Codex CLI usage metrics.
+```
+
+Top-level `ccgate init` and `ccgate metrics` are not real subcommands — they print a one-line pointer to the per-target form and exit `2`. The bare `ccgate` hook invocation is a different code path and works as documented above.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/tak848/ccgate/actions/workflows/ci.yml/badge.svg)](https://github.com/tak848/ccgate/actions/workflows/ci.yml)
 [![release](https://github.com/tak848/ccgate/actions/workflows/release.yml/badge.svg)](https://github.com/tak848/ccgate/releases)
 
-A **PermissionRequest** hook for AI coding tools. It delegates each tool-execution permission decision to an LLM (Claude Haiku) using rules written in a jsonnet configuration file. Rules are **natural-language guidance read by the LLM** — not deterministic jsonnet policy code — so the typical workflow is to describe what should be allowed or denied in prose and let the LLM classify the actual request.
+A **PermissionRequest** hook for AI coding tools. It delegates each tool-execution permission decision to an LLM (Claude Haiku) using rules written in a jsonnet configuration file.
 
 ccgate ships with built-in default rules, so it works out of the box without any configuration.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Supported targets:
 
 ### mise (recommended)
 
-Requires mise `2026.4.20` or later. Earlier releases bundle an aqua registry snapshot from before ccgate was added.
+Requires mise `2026.4.20` or later.
 
 ```bash
 mise use -g aqua:tak848/ccgate
@@ -36,7 +36,7 @@ If you want to keep this no-install style for the hook itself, set the hook `com
 
 ### aqua
 
-Via the [aqua](https://aquaproj.github.io/) standard registry (requires registry `v4.498.0` or later — ccgate's first registered version). In an aqua-managed project (run `aqua init` first if you don't have an `aqua.yaml` yet):
+Via the [aqua](https://aquaproj.github.io/) standard registry (requires registry `v4.498.0` or later). In an aqua-managed project (run `aqua init` first if you don't have an `aqua.yaml` yet):
 
 ```bash
 aqua g -i tak848/ccgate
@@ -98,7 +98,7 @@ That's it — ccgate is now running with its embedded defaults. To customize wha
 ## Quick start — Codex CLI
 
 > [!NOTE]
-> Codex hooks live behind the `[features] codex_hooks = true` flag upstream. Treat the [Codex hooks docs](https://developers.openai.com/codex/hooks) as the source of truth before relying on a specific field.
+> Codex hooks require `[features] codex_hooks = true` in `~/.codex/config.toml`. See [docs/codex.md](docs/codex.md) for details.
 
 ### 1. Register as a Codex hook
 
@@ -140,7 +140,7 @@ command = "ccgate codex"
 statusMessage = "ccgate evaluating request"
 ```
 
-See [docs/codex.md](docs/codex.md) for the full lookup order, project-local overlays, and a `go run` recipe for in-tree dev builds. Refer to the upstream [Codex hooks documentation](https://developers.openai.com/codex/hooks) for the authoritative schema.
+See [docs/codex.md](docs/codex.md) for the full lookup order, project-local overlays, and a `go run` recipe for in-tree dev builds.
 
 ### 2. API key
 
@@ -214,7 +214,7 @@ Switch providers by setting `provider.name` (and `provider.model` if needed) in 
 {
   provider: {
     name: 'openai',
-    model: 'gpt-4o-mini',
+    model: '<openai model name>',  // see docs/providers.md for model selection
   },
 }
 ```

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ See [docs/codex.md](docs/codex.md) for the full lookup order, project-local over
 
 ### 2. API key
 
-Same env vars as Claude Code — see [docs/providers.md#api-keys](docs/providers.md#api-keys).
+Export the provider API key — see [docs/providers.md#api-keys](docs/providers.md#api-keys).
 
 That's it — ccgate is now running with its embedded defaults. To customize what is allowed or denied, see [docs/rule-tuning.md](docs/rule-tuning.md); for background on how rules work, see [Concepts](#concepts).
 

--- a/docs/api-key-helper.md
+++ b/docs/api-key-helper.md
@@ -210,12 +210,12 @@ ccgate emits a `slog.Warn` when `auth.path` *or* the cache file is readable by a
 
 When the provider rejects the credential ccgate just used, the HTTP status alone determines the reaction.
 
-| HTTP status         | `auth.type=exec`                          | `auth.type=file`                         | `auth.type=profile`                                                    | env var      |
-|---------------------|-------------------------------------------|------------------------------------------|------------------------------------------------------------------------|--------------|
-| 401 / 403           | `provider_auth`, **invalidate cache + fallthrough** | `provider_auth`, fallthrough only (no cache) | `provider_auth`, fallthrough (SDK refresh-token loop owns the credential, no ccgate cache) | **exit 1**   |
-| 5xx / 429 / network | exit 1 (existing behaviour)               | exit 1                                   | exit 1                                                                 | exit 1       |
+| HTTP status         | `auth.type=exec`                  | `auth.type=file`               | `auth.type=profile`            | env var |
+|---------------------|-----------------------------------|--------------------------------|--------------------------------|---------|
+| 401 / 403           | invalidate cache, fallthrough     | fallthrough (no cache)         | fallthrough                    | exit 1  |
+| 5xx / 429 / network | exit 1                            | exit 1                         | exit 1                         | exit 1  |
 
-The env-var path keeps the existing exit-1 behaviour on 401/403 because ccgate cannot rotate env vars; swallowing the rejection would hide a user-side configuration error.
+On `auth.type=profile`, the SDK refresh-token loop owns the credential, so ccgate has no cache to invalidate. The env-var path exits 1 on 401/403 because ccgate cannot rotate env vars; swallowing the rejection would hide a user-side configuration error.
 
 To opt out of caching, return JSON without `expires_at` (or plain string) and the helper re-runs every fire.
 

--- a/docs/api-key-helper.md
+++ b/docs/api-key-helper.md
@@ -249,6 +249,6 @@ To opt out of caching, return JSON without `expires_at` (or plain string) and th
    - `profile_config_parse` / `profile_config_invalid`: restore `<config_dir>/configs/<name>.json` to mode `0644`, or delete it and re-run `ant auth login --profile <name>`.
    - `credentials_missing`: run `ant auth login --profile <name>` to publish credentials.
    - `credentials_stat_failed`: the credentials file or its parent dir failed `os.Stat` for a reason other than "missing" (typically permissions). Restore mode 0700 on `<config_dir>/credentials/`.
-8. After any `ant auth login`, confirm `<config_dir>/active_config` with `ant auth status`. If Claude Code starts using an unexpected profile, either `rm <config_dir>/active_config` (clears the pointer) or `ant profile activate <previous-profile>`. Upstream PR [anthropics/anthropic-cli#45](https://github.com/anthropics/anthropic-cli/pull/45) (`--no-activate`) will let `ant auth login` skip the retarget once it lands.
+8. After any `ant auth login`, confirm `<config_dir>/active_config` with `ant auth status`. If Claude Code starts using an unexpected profile, either `rm <config_dir>/active_config` (clears the pointer) or `ant profile activate <previous-profile>`.
 
 The full reason list is in [docs/configuration.md](configuration.md#reason-values-for-credential_unavailable).

--- a/docs/api-key-helper.md
+++ b/docs/api-key-helper.md
@@ -1,15 +1,18 @@
-# Short-lived / rotating API keys
+# Refreshable credentials
 
 [日本語版 (docs/ja/api-key-helper.md)](ja/api-key-helper.md)
 
 When the credential the provider needs rotates faster than a static env var can keep up — AWS STS sessions, Vertex ADC, OpenAI-compatible gateway virtual keys, internal key brokers — ccgate resolves it through `provider.auth` instead of `*_API_KEY`.
 
-`provider.auth` has two modes:
+`provider.auth` has three modes:
 
 - **`type: 'exec'`**: ccgate runs a shell command and uses its stdout as the credential.
 - **`type: 'file'`**: ccgate reads a file written by an external rotator.
+- **`type: 'profile'`**: Anthropic only. ccgate hands an `ant auth login` profile to anthropic-sdk-go and the SDK owns the refresh loop. See [Profile-based authentication](#profile-based-authentication-anthropic-only).
 
-Linux, macOS, *BSD, and Windows are supported. The shell that runs the helper command is selected per-config via `auth.shell` (default `bash`); set `shell: 'powershell'` on Windows boxes that don't have bash.
+(`*_API_KEY` env var is a separate path used when `provider.auth` is omitted — it's not one of the `auth` modes.)
+
+The shell that runs an `exec` helper is selected per-config via `auth.shell` (default `bash`); see [Helper contract](#helper-contract) for the shells ccgate currently spawns.
 
 ## Config
 
@@ -47,7 +50,7 @@ Linux, macOS, *BSD, and Windows are supported. The shell that runs the helper co
 |---|---|---|---|
 | `auth.type` | `"exec"` / `"file"` / `"profile"` | (required when `auth` is set) | Resolution mode. `profile` is Anthropic-only; see [Profile-based authentication](#profile-based-authentication-anthropic-only). |
 | `auth.command` | string | `""` | (`exec` only, required) Shell command; stdout is the credential. |
-| `auth.shell` | `"bash"` / `"powershell"` | `"bash"` | (`exec` only) Shell. `powershell` tries `pwsh` first, falls back to `powershell`. |
+| `auth.shell` | `"bash"` / `"powershell"` | `"bash"` | (`exec` only) Shell used to run `auth.command`. `powershell` tries `pwsh` first, falls back to `powershell`. |
 | `auth.path` | string | `$XDG_STATE_HOME/ccgate/<target>/auth_key.json` | (`file` only) Credential file path. Omit to use the default. |
 | `auth.profile` | string | `""` | (`profile` only) Anthropic profile name (the value `ant auth login --profile <name>` writes to `<config_dir>/credentials/<name>.json`). Empty/omitted lets the SDK resolve `$ANTHROPIC_PROFILE` → `<config_dir>/active_config` → `"default"`. |
 | `auth.refresh_margin_ms` | int (ms) | `60000` | Treat credentials as expired this many ms before `expires_at`. `0` disables. (`exec` / `file` only — `profile` delegates refresh to the SDK.) |
@@ -108,7 +111,6 @@ ant auth login --profile ccgate         # opens a browser, writes ~/.config/anth
 >   - `rm <config_dir>/active_config` to clear the pointer entirely (the SDK then resolves to `default`).
 >   - `ant profile activate <previous-profile-name>` if you have a profile you actively use.
 > - To bind a profile to a different org / workspace, ant rejects re-login on a profile that already has one bound. Delete `<config_dir>/configs/<name>.json` and run `ant auth login --profile <name>` again.
-> - An upstream `--no-activate` flag (upstream PR [anthropics/anthropic-cli#45](https://github.com/anthropics/anthropic-cli/pull/45)) would let `ant auth login --profile <name> --no-activate` skip the retarget once it lands.
 
 ## Examples
 

--- a/docs/api-key-helper.md
+++ b/docs/api-key-helper.md
@@ -78,7 +78,7 @@ A helper must:
 - Be **deterministic** for the same `(shell, command, provider.name, base_url, cache_key)` tuple. Two callers with the same config must agree on what the credential is.
 - **Not daemonize**. Forking past the process group escapes the timeout-kill.
 - Finish within `auth.timeout_ms`.
-- Avoid literal secrets in `auth.command`. The string is passed to the configured shell (`bash -c <command>`, or `pwsh -Command <command>` / `powershell -Command <command>` when `auth.shell: 'powershell'`) and shows up in `ps`, `/proc/<pid>/cmdline`, and shell history. Read secrets from a file or keychain inside the helper instead.
+- Avoid literal secrets in `auth.command`. The string is passed to the configured shell (`bash -c <command>`, or `pwsh -Command <command>` / `powershell -Command <command>` when `auth.shell: 'powershell'`) and shows up in process listings and shell history. Read secrets from a file or keychain inside the helper instead.
 
 ccgate exports `CCGATE_API_KEY_RESOLUTION=1` into the helper environment so a wrapper helper can detect recursive invocation. All other environment variables (including `*_API_KEY`) are inherited. Stdin is closed; the helper cannot read from the parent terminal.
 
@@ -139,10 +139,10 @@ When a real broker mints time-limited credentials, wrap the response in `{key, e
 #!/bin/sh
 # ~/bin/ccgate-key-broker.sh
 # Print a JSON line: {"key": "...", "expires_at": "<RFC3339>"}
-# Substitute the RFC3339 formatter your platform provides for `<rfc3339-now-plus-50m>`.
+# Replace `my-broker-expiry-rfc3339` with whatever produces an RFC3339 timestamp for "now + helper lifetime".
 set -eu
 TOKEN=$(my-key-broker --provider anthropic)
-EXP=<rfc3339-now-plus-50m>
+EXP=$(my-broker-expiry-rfc3339)
 jq -nc --arg key "$TOKEN" --arg expires_at "$EXP" '{key:$key, expires_at:$expires_at}'
 ```
 
@@ -203,7 +203,7 @@ Leaving `cache_key` empty is the explicit "share with anything that has the same
 
 `auth.path` reads are bounded by `auth.timeout_ms` (default 30000) just like the exec branch — a stalled mount surfaces as `reason=timeout` instead of blocking the hook. Local regular files are still strongly recommended (NFS / SMB / FUSE / keychain mounts will time out reliably but each fire pays a `timeout_ms` wait); a per-user local path is the cheapest path.
 
-ccgate emits a `slog.Warn` when `auth.path` *or* the cache file is readable by anyone other than the current user, or is owned by a different user. The check is a best-effort security nudge, not policy enforcement: it inspects only the well-known "world-readable" indicators reachable from the filesystem and does not compute effective access. The recommended setup is to keep the file user-only readable inside a user-only directory (e.g. `0600` file inside a `0700` parent on POSIX-style filesystems).
+ccgate emits a `slog.Warn` when `auth.path` *or* the cache file is readable by anyone other than the current user, or is owned by a different user. The check is a best-effort security nudge, not policy enforcement: it inspects only the well-known "world-readable" indicators reachable from the filesystem and does not compute effective access. Keep the file user-only readable inside a user-only directory.
 
 ## Provider 401/403 behaviour
 

--- a/docs/api-key-helper.md
+++ b/docs/api-key-helper.md
@@ -90,7 +90,7 @@ This pattern is supported. The default `auth.timeout_ms` (`30000`) covers most n
 
 ## Profile-based authentication (Anthropic only)
 
-Anthropic provider only. The official `ant` CLI (`ant auth login` for browser-based OAuth, `ant profile activate <name>` to switch the active profile) writes credentials to `<config_dir>/credentials/<name>.json` (mode 0600). `<config_dir>` defaults to `~/.config/anthropic`. The Anthropic profile resolution chain (`$ANTHROPIC_PROFILE` → `<config_dir>/active_config` → `"default"`) is shared between the Go SDK, Claude Code, and the Claude Agent SDK ([wif-reference doc](https://platform.claude.com/docs/en/api/authentication/wif-reference)). The Anthropic SDK refreshes the access token itself using the stored refresh token; ccgate stays out of the credential path entirely and only disables the SDK's static-credential env autoload (`ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN`) so a leftover env var does not silently shadow your declared profile. Workload Identity Federation is supported only via a profile config that declares `authentication.type=oidc_federation`; env-only WIF (no profile) is out of scope today.
+Anthropic provider only. The official `ant` CLI (`ant auth login` for browser-based OAuth, `ant profile activate <name>` to switch the active profile) writes credentials to `<config_dir>/credentials/<name>.json` (mode 0600). `<config_dir>` defaults to `~/.config/anthropic`. The Anthropic profile resolution chain (`$ANTHROPIC_PROFILE` → `<config_dir>/active_config` → `"default"`) is shared between the Go SDK, Claude Code, and the Claude Agent SDK ([wif-reference doc](https://platform.claude.com/docs/en/api/authentication/wif-reference)). The Anthropic SDK refreshes the access token itself using the stored refresh token; ccgate stays out of the credential path entirely and only disables the SDK's static-credential env autoload (`ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN`) so a leftover env var does not silently shadow your declared profile. Workload Identity Federation is supported only via a profile config that declares `authentication.type=oidc_federation`.
 
 ### Quick start
 
@@ -138,9 +138,11 @@ When a real broker mints time-limited credentials, wrap the response in `{key, e
 ```sh
 #!/bin/sh
 # ~/bin/ccgate-key-broker.sh
+# Print a JSON line: {"key": "...", "expires_at": "<RFC3339>"}
+# Substitute the RFC3339 formatter your platform provides for `<rfc3339-now-plus-50m>`.
 set -eu
 TOKEN=$(my-key-broker --provider anthropic)
-EXP=$(date -u -v+50M +%FT%TZ 2>/dev/null || date -u -d '+50 minutes' +%FT%TZ)
+EXP=<rfc3339-now-plus-50m>
 jq -nc --arg key "$TOKEN" --arg expires_at "$EXP" '{key:$key, expires_at:$expires_at}'
 ```
 
@@ -152,24 +154,11 @@ Test the script standalone first (`~/bin/ccgate-key-broker.sh | jq .` should pri
 
 ### External rotator (no helper exec on the hook path)
 
-When you want zero exec cost on the hook, schedule an external rotator (cron / launchd / systemd-timer) to write the same JSON shape atomically:
-
-```sh
-#!/bin/sh
-set -eu
-TOKEN=$(my-key-broker --provider anthropic)
-EXP=$(date -u -v+1H +%FT%TZ 2>/dev/null || date -u -d '+1 hour' +%FT%TZ)
-TMP=$(mktemp ~/.config/my-broker/anthropic.json.XXXXXX)
-jq -nc --arg key "$TOKEN" --arg expires_at "$EXP" '{key:$key, expires_at:$expires_at}' > "$TMP"
-chmod 0600 "$TMP"
-mv "$TMP" ~/.config/my-broker/anthropic.json
-```
+When you want zero exec cost on the hook, schedule an external rotator to write the same JSON shape and have it land at `auth.path` via an **atomic replace** (`write tmp` → `chmod 0600 tmp` → `rename tmp <auth.path>`). The rotator owns the refresh schedule; ccgate just reads the file on each hook invocation.
 
 ```jsonnet
 auth: { type: 'file', path: '~/.config/my-broker/anthropic.json' }
 ```
-
-The rotator owns refresh; ccgate just reads the file on each hook invocation.
 
 ## Caching
 

--- a/docs/api-key-helper.md
+++ b/docs/api-key-helper.md
@@ -95,7 +95,8 @@ Anthropic provider only. The official `ant` CLI (`ant auth login` for browser-ba
 ### Quick start
 
 ```sh
-mise use -g aqua:anthropics/anthropic-cli   # or `aqua g -i anthropics/anthropic-cli`; binary lands as `ant`
+# Install the `ant` CLI by your preferred method (e.g. `mise use -g aqua:anthropics/anthropic-cli`,
+# `aqua g -i anthropics/anthropic-cli`, or a direct download from the upstream release page).
 ant auth login --profile ccgate         # opens a browser, writes ~/.config/anthropic/credentials/ccgate.json
 # add to ccgate.jsonnet:
 #   provider: { ..., auth: { type: 'profile', profile: 'ccgate' } }
@@ -201,7 +202,7 @@ Leaving `cache_key` empty is the explicit "share with anything that has the same
 
 ## File mode notes
 
-`auth.path` reads are bounded by `auth.timeout_ms` (default 30000) just like the exec branch — a stalled mount surfaces as `reason=timeout` instead of blocking the hook. Local regular files are still strongly recommended (NFS / SMB / FUSE / keychain mounts will time out reliably but each fire pays a `timeout_ms` wait); a per-user local path is the cheapest path.
+`auth.path` reads are bounded by `auth.timeout_ms` (default 30000) just like the exec branch — a stalled file source surfaces as `reason=timeout` instead of blocking the hook. Local regular files are still strongly recommended (network or virtual file sources will time out reliably but each fire pays a `timeout_ms` wait); a per-user local path is the cheapest option.
 
 ccgate emits a `slog.Warn` when `auth.path` *or* the cache file is readable by anyone other than the current user, or is owned by a different user. The check is a best-effort security nudge, not policy enforcement: it inspects only the well-known "world-readable" indicators reachable from the filesystem and does not compute effective access. Keep the file user-only readable inside a user-only directory.
 

--- a/docs/api-key-helper.md
+++ b/docs/api-key-helper.md
@@ -214,7 +214,7 @@ Leaving `cache_key` empty is the explicit "share with anything that has the same
 
 `auth.path` reads are bounded by `auth.timeout_ms` (default 30000) just like the exec branch — a stalled mount surfaces as `reason=timeout` instead of blocking the hook. Local regular files are still strongly recommended (NFS / SMB / FUSE / keychain mounts will time out reliably but each fire pays a `timeout_ms` wait); a per-user local path is the cheapest path.
 
-ccgate emits a `slog.Warn` when `auth.path` *or* the cache file has any group/other read bit set, or is owned by a different UID than the current user (Unix), or grants direct read access to the `Everyone` / `BuiltinUsers` SIDs (Windows). Both checks are best-effort security nudges, not policy enforcement: the Windows DACL walk only inspects allow ACEs to those well-known SIDs and does not compute effective access, deny ACEs, or inheritance. The recommended setup is `chmod 0600` on Unix inside a `chmod 0700` parent, or a per-user-only ACL on Windows.
+ccgate emits a `slog.Warn` when `auth.path` *or* the cache file is readable by anyone other than the current user, or is owned by a different user. The check is a best-effort security nudge, not policy enforcement: it inspects only the well-known "world-readable" indicators reachable from the filesystem and does not compute effective access. The recommended setup is to keep the file user-only readable inside a user-only directory (e.g. `0600` file inside a `0700` parent on POSIX-style filesystems).
 
 ## Provider 401/403 behaviour
 
@@ -227,13 +227,6 @@ When the provider rejects the credential ccgate just used, the HTTP status alone
 
 The env-var path keeps the existing exit-1 behaviour on 401/403 because ccgate cannot rotate env vars; swallowing the rejection would hide a user-side configuration error.
 
-## Relationship to AWS `credential_process` and kubectl exec credential plugins
-
-`provider.auth` is shaped after the same family of credential helpers, but it is not a drop-in for any of them:
-
-- **AWS `credential_process`** prints `{"Version":1, "AccessKeyId", "SecretAccessKey", "SessionToken", "Expiration"}` for SigV4 callers, and the AWS CLI re-execs the helper every call. ccgate prints `{"key", "expires_at"}` for an Authorization-header bearer, and memoizes to disk. An AWS-style helper needs a thin adapter that picks the right field and reshapes the JSON.
-- **kubectl exec credential plugin** uses a separate `command` + `args` pair and prints an `ExecCredential` shape. ccgate uses a single shell-form `command` (matching the Claude Code / Codex hook conventions ccgate plugs into) and the JSON shape above.
-
 To opt out of caching, return JSON without `expires_at` (or plain string) and the helper re-runs every fire.
 
 ## Recovery checklist
@@ -242,7 +235,7 @@ To opt out of caching, return JSON without `expires_at` (or plain string) and th
 2. Run `ccgate <target> metrics` and check the **Credential failures** section, which groups failures by `(source, reason)`.
 3. For `cache_parse` / `cache_read` / `cache_write` (log-only warnings), remove `$XDG_CACHE_HOME/ccgate/<target>/api_key.*.json` to force a refresh. Leave the sibling `*.lock` files alone.
 4. For `expired`, compare the helper's `expires_at` with `date -u`. Clock skew or a broken TTL inside the helper is the usual cause.
-5. For `command_exit` on a fresh setup, check first whether the configured `auth.shell` binary is on `$PATH`. `bash` is universal on Linux / macOS; for `powershell`, at least one of `pwsh` (preferred) or `powershell` must resolve via `$PATH`. When ccgate cannot find the shell at all, the failure surfaces as `command_exit` from `os/exec`'s lookup error.
+5. For `command_exit` on a fresh setup, check whether the configured `auth.shell` binary is on `$PATH`. For `auth.shell: 'bash'`, `bash` must resolve; for `auth.shell: 'powershell'`, at least one of `pwsh` (preferred) or `powershell` must resolve. When ccgate cannot find the shell, the failure surfaces as `command_exit` from `os/exec`'s lookup error.
 6. For repeated `provider_auth` even after cache invalidation, the helper itself is producing a credential the provider rejects. Re-run the helper manually with the same shell ccgate would use — `bash -c "$your_command"`, or `pwsh -Command "$your_command"` / `powershell -Command "$your_command"` for `auth.shell: 'powershell'` — and inspect the stdout that reached the SDK.
 7. For `profile_load` (`auth.type=profile`), the slog `error_class` field narrows the cause:
    - `profile_config_missing`: run `ant auth login --profile <name>` to create the profile.

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -69,7 +69,7 @@ This is purely prompt-driven, so there is no hard guarantee.
 - If the user explicitly requested the operation in the recent transcript, prefer `allow` or `fallthrough` over `deny`.
 - An explicit user request can only escalate `deny` to `fallthrough`, never to `allow`. Deny guidance still wins.
 
-This is the only signal in the prompt that lets the LLM say "the deny rule matches but the user clearly asked for this, so let the user confirm via Claude Code's prompt instead of refusing outright". Codex has no transcript field today, so this lever is Claude-only.
+This is the only signal in the prompt that lets the LLM say "the deny rule matches but the user clearly asked for this, so let the user confirm via Claude Code's prompt instead of refusing outright".
 
 ## Why `settings.json` patterns are a hint, not a whitelist
 

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -60,7 +60,7 @@ Claude Code delivers the standard PermissionRequest payload (see the upstream [h
 
 Allow guidance does NOT promote write operations to allow in plan mode. The deny guidance still applies and can override read-only operations too.
 
-This is purely prompt-driven, so there is no hard guarantee. Tracked in [#37](https://github.com/tak848/ccgate/issues/37).
+This is purely prompt-driven, so there is no hard guarantee.
 
 ## How `recent_transcript` is used
 
@@ -93,10 +93,8 @@ Treating `settings_permissions.allow` as a whitelist requirement therefore break
 | State path                  | `$XDG_STATE_HOME/ccgate/claude/` (falls back to `~/.local/state/ccgate/claude/` when unset). |
 | Project-local config        | `{repo_root}/.claude/ccgate.local.jsonnet` (untracked-only). |
 
-See [docs/codex.md](codex.md) for the Codex equivalents.
+## Limitations
 
-## Known limitations
-
-- **Plan mode is prompt-only** ([#37](https://github.com/tak848/ccgate/issues/37)).
+- **Plan mode is prompt-only.** Under `permission_mode == "plan"`, ccgate relies on the LLM plus prose in the system prompt to (a) reject implementation-side writes and (b) allow read-only queries without requiring an allow-guidance match. Either side can misfire.
 - **No surgical reset for a single embedded default rule.** A layer either replaces a list wholesale (`allow: [...]`) or appends to it (`append_allow: [...]`); removing one specific embedded entry while keeping the rest requires re-stating the whole list under `allow` / `deny` minus that one entry.
 - **No deterministic short-circuit on `settings.json` deny patterns.** ccgate routes every Claude Code PermissionRequest through the LLM; literal `settings.json` deny matches do not exit ccgate early.

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -41,9 +41,11 @@ If you launch `ccgate` from a terminal with no stdin pipe, it prints a usage ban
 Claude Code delivers the standard PermissionRequest payload (see the upstream [hooks reference](https://code.claude.com/docs/en/hooks)). ccgate reads:
 
 - `tool_name`: routes early-return for user-interaction tools (`ExitPlanMode`, `AskUserQuestion`) -- those always fall through to Claude Code's prompt, ccgate never decides for them.
-- `tool_input`: forwarded to the LLM. The metrics layer captures `command` / `file_path` / `path` / `pattern` only.
+- `tool_input`: forwarded to the LLM as a typed object. The metrics layer captures `command` / `file_path` / `path` / `pattern` only.
+- `tool_input_raw`: the original `tool_input` JSON, forwarded verbatim. Use this to inspect fields that the typed view omits (e.g. nested MCP arguments).
+- `referenced_paths`: paths extracted from `tool_input` on a best-effort basis. Supported tools: `Read`, `Write`, `Edit`, `MultiEdit`, `Glob`, `Grep`, `Bash`. Other tools (MCP, user-interaction tools) produce an empty list -- the LLM still sees the raw payload via `tool_input_raw`.
 - `permission_mode`: switches the system prompt to plan-mode rules when `"plan"`. `"bypassPermissions"` and `"dontAsk"` short-circuit ccgate to fallthrough.
-- `cwd`: feeds the git context builder (`gitutil.RepoRoot`, branch, worktree).
+- `cwd`: feeds the git context builder (`gitutil.RepoRoot`, branch, worktree). Working-tree dirty/clean state is not delivered.
 - `transcript_path`: the recent-transcript loader reads up to N tail entries to give the LLM user-intent context.
 - `permission_suggestions`: forwarded to the LLM as background.
 - `settings_permissions`: ccgate reads `~/.claude/settings.json` separately and surfaces the user's own static allow / deny / ask patterns to the LLM as a hint, not as a whitelist requirement (see "Why settings.json patterns are a hint" below).
@@ -79,22 +81,22 @@ This is the only signal in the prompt that lets the LLM say "the deny rule match
 
 Treating `settings_permissions.allow` as a whitelist requirement therefore breaks the hook's normal operation. ccgate uses it as a hint about user preferences only -- a request can still be `allow`-ed by the LLM even when it does not appear in `settings_permissions.allow`.
 
-## Differences from Codex CLI
+## Claude-specific HookInput / state reference
 
-| Aspect                              | Claude Code                                        | Codex CLI                                                                                |
-|-------------------------------------|----------------------------------------------------|------------------------------------------------------------------------------------------|
-| Tool surface                        | `Bash`, `Read`, `Write`, `Edit`, `Glob`, MCP, ...  | `Bash`, `apply_patch`, MCP, ...                                                           |
-| `permission_mode`                   | `default` / `acceptEdits` / `plan` / `bypassPermissions` / `dontAsk` | Not delivered today.                                                |
-| `recent_transcript`                 | Forwarded to the LLM.                              | Not delivered. The LLM is told to judge from `tool_name` + `tool_input` + `cwd` alone.   |
-| `settings_permissions`              | Forwarded as background hint.                      | No equivalent. `~/.codex/config.toml` is not ingested.                                   |
-| `permission_suggestions`            | Forwarded.                                         | Not delivered.                                                                            |
-| State path                          | `$XDG_STATE_HOME/ccgate/claude/`                   | `$XDG_STATE_HOME/ccgate/codex/`                                                           |
-| Project-local config                | `{repo_root}/.claude/ccgate.local.jsonnet`         | `{repo_root}/.codex/ccgate.local.jsonnet`                                                 |
+| Aspect                      | Value |
+|-----------------------------|-------|
+| Tool surface                | `Bash`, `Read`, `Write`, `Edit`, `MultiEdit`, `Glob`, `Grep`, MCP, user-interaction tools (`ExitPlanMode`, `AskUserQuestion`) |
+| `permission_mode` values    | `default` / `acceptEdits` / `plan` / `bypassPermissions` / `dontAsk`. `plan` switches the system prompt; `bypassPermissions` / `dontAsk` short-circuit ccgate to fallthrough. |
+| `recent_transcript`         | Loaded from `transcript_path` and forwarded to the LLM as user-intent context (see "How `recent_transcript` is used" above). |
+| `settings_permissions`      | Forwarded as a hint -- see "Why `settings.json` patterns are a hint" above. |
+| `permission_suggestions`    | Forwarded verbatim. |
+| State path                  | `$XDG_STATE_HOME/ccgate/claude/` (falls back to `~/.local/state/ccgate/claude/` when unset). |
+| Project-local config        | `{repo_root}/.claude/ccgate.local.jsonnet` (untracked-only). |
 
-See [docs/codex.md](codex.md) for the Codex side.
+See [docs/codex.md](codex.md) for the Codex equivalents.
 
 ## Known limitations
 
 - **Plan mode is prompt-only** ([#37](https://github.com/tak848/ccgate/issues/37)).
 - **No surgical reset for a single embedded default rule.** A layer either replaces a list wholesale (`allow: [...]`) or appends to it (`append_allow: [...]`); removing one specific embedded entry while keeping the rest requires re-stating the whole list under `allow` / `deny` minus that one entry.
-- **No deterministic short-circuit on `settings.json` deny patterns**. ccgate routes every Claude Code PermissionRequest through the LLM today; a deterministic prefilter that exits early on a literal `settings.json` deny match is a possible future optimization, not a current behavior.
+- **No deterministic short-circuit on `settings.json` deny patterns.** ccgate routes every Claude Code PermissionRequest through the LLM; literal `settings.json` deny matches do not exit ccgate early.

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -6,7 +6,7 @@ Codex-CLI-specific notes for the `ccgate codex` hook.
 
 ## Status
 
-- **Hook schema may change.** Codex hooks themselves are still evolving upstream and live behind the `features.codex_hooks = true` flag. Treat the OpenAI [Codex hooks docs](https://developers.openai.com/codex/hooks) as the source of truth and re-check before relying on a specific field.
+- **Upstream schema is the source of truth.** Codex hooks live behind the `[features] codex_hooks = true` flag. Treat the OpenAI [Codex hooks docs](https://developers.openai.com/codex/hooks) as authoritative and re-check before relying on a specific field.
 - **Tool-agnostic.** Codex hooks fire for Bash, `apply_patch`, MCP tool calls, and other surfaces. ccgate classifies by `tool_name` + the full `tool_input` JSON, not by tool kind alone.
 
 ## Hook registration
@@ -49,7 +49,7 @@ If you want to keep hooks alongside the rest of your Codex config:
 
 ```toml
 [features]
-codex_hooks = true   # required: Codex hooks live behind this feature flag
+codex_hooks = true   # Codex hooks live behind this feature flag; keep it set for compatibility.
 
 [[hooks.PermissionRequest]]
 matcher = ""
@@ -99,21 +99,26 @@ Fields the upstream Codex docs declare and ccgate uses:
 - `model` (the AI side's model, e.g. `gpt-5`)
 - `turn_id`
 - `tool_name` (`Bash`, `apply_patch`, `mcp__<server>__<tool>`, ...)
-- `tool_input` (typed view + raw forwarding)
+- `tool_input` (typed view)
+- `tool_input_raw` (the original JSON payload, forwarded verbatim — the primary surface for inspecting `apply_patch` hunks and MCP arguments)
+- `referenced_paths` (best-effort path extraction from `tool_input`. Supported for `Bash`; `apply_patch` and MCP fall back to reading `tool_input_raw` directly.)
 
-Codex does not deliver Claude's `permission_mode`, `permission_suggestions`, `recent_transcript`, or `settings_permissions` today. The system prompt explicitly tells the LLM "no recent_transcript here -- judge from `tool_name` + `tool_input` + `cwd` alone" so it does not invent context that isn't there.
+Codex does not deliver Claude's `permission_mode`, `permission_suggestions`, `recent_transcript`, or `settings_permissions`. The system prompt tells the LLM to judge from `tool_name` + `tool_input` + `tool_input_raw` + `cwd` alone, so it does not invent context that isn't there.
+
+## Codex-specific state reference
+
+| Aspect                      | Value |
+|-----------------------------|-------|
+| Tool surface                | `Bash`, `apply_patch`, MCP (`mcp__<server>__<tool>`). Codex hooks fire for every PermissionRequest event regardless of tool kind. |
+| State path                  | `$XDG_STATE_HOME/ccgate/codex/` (falls back to `~/.local/state/ccgate/codex/` when unset). |
+| Project-local config        | `{repo_root}/.codex/ccgate.local.jsonnet` (untracked-only, project-trust required). |
 
 ## Defaults snapshot
 
-ccgate ships an embedded Codex defaults file (`internal/cmd/codex/defaults.jsonnet`) that mirrors the Claude side's allow + deny + environment shape. Notable Codex-specific entries:
+The embedded Codex defaults file (`internal/cmd/codex/defaults.jsonnet`) ships allow / deny / environment guidance tuned to the Codex tool surface. Notable entries:
 
 - `allow`: read-only Bash inspection, in-workspace writes (`apply_patch` hunks under cwd / repo_root, project file edits the AI is doing right now), project-script build/test, repo-confined package install, feature-branch git, MCP tools on user-trusted servers whose side effects stay within the user-authorized scope.
 - `deny`: pipe-to-shell of remote content, one-shot remote package execution (`npx` / `pnpx` / `bunx` against unfamiliar packages), `sudo`, out-of-workspace `rm -rf` / `mv` / `apply_patch` hunks, destructive git on protected branches, unrestricted network out (`nc` / `ssh` / `scp` / `ftp` to non-allowlisted hosts), MCP tools advertising destructive side effects without an explicit per-rule allow.
-- `environment`: heterogeneous tool surface, trusted-repo boundary, path scope rule, **ccgate replaces the upstream prompt** -- fallthrough only when genuinely ambiguous, otherwise default to allow / deny -- `recent_transcript` is absent.
+- `environment`: heterogeneous tool surface, trusted-repo boundary, path scope rule. ccgate replaces the upstream approval prompt, so the guidance defaults to allow / deny when it applies and reserves fallthrough for genuinely ambiguous cases. `recent_transcript` is not delivered to Codex hooks, so the prompt tells the LLM not to assume one.
 
-In-workspace `apply_patch` is in `allow` on purpose: this is the same bar Claude Code edits go through, and the user installed ccgate specifically to avoid being prompted for routine in-repo edits. Out-of-workspace patch hunks are denied via the existing deny rule. If you want to be more conservative, add a project-local rule that narrows the apply_patch allow scope (e.g. only specific subtrees).
-
-## Differences from Claude Code
-
-See [docs/claude.md](claude.md) for the full table.
-
+In-workspace `apply_patch` is in `allow` because the user installed ccgate specifically to avoid being prompted for routine in-repo edits; out-of-workspace patch hunks are denied via the existing deny rule. If you want to be more conservative, add a project-local rule that narrows the apply_patch allow scope (e.g. only specific subtrees).

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -103,7 +103,7 @@ Fields the upstream Codex docs declare and ccgate uses:
 - `tool_input_raw` (the original JSON payload, forwarded verbatim — the primary surface for inspecting `apply_patch` hunks and MCP arguments)
 - `referenced_paths` (best-effort path extraction from `tool_input`. Supported for `Bash`; `apply_patch` and MCP fall back to reading `tool_input_raw` directly.)
 
-Codex does not deliver Claude's `permission_mode`, `permission_suggestions`, `recent_transcript`, or `settings_permissions`. The system prompt tells the LLM to judge from `tool_name` + `tool_input` + `tool_input_raw` + `cwd` alone, so it does not invent context that isn't there.
+The Codex system prompt tells the LLM to judge from `tool_name` + `tool_input` + `tool_input_raw` + `cwd`, so it does not invent context that isn't present in the HookInput.
 
 ## Codex-specific state reference
 

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -6,7 +6,7 @@ Codex-CLI-specific notes for the `ccgate codex` hook.
 
 ## Status
 
-- **Upstream schema is the source of truth.** Codex hooks live behind the `[features] codex_hooks = true` flag. Treat the OpenAI [Codex hooks docs](https://developers.openai.com/codex/hooks) as authoritative and re-check before relying on a specific field.
+- Codex hooks require `[features] codex_hooks = true`. See [OpenAI's Codex hooks docs](https://developers.openai.com/codex/hooks) for the upstream payload schema.
 - **Tool-agnostic.** Codex hooks fire for Bash, `apply_patch`, MCP tool calls, and other surfaces. ccgate classifies by `tool_name` + the full `tool_input` JSON, not by tool kind alone.
 
 ## Hook registration
@@ -90,7 +90,7 @@ Project-local `<repo>/.codex/{hooks.json,config.toml}` only loads when the proje
 
 ccgate forwards the full `tool_input` JSON to the LLM verbatim, so MCP arguments and `apply_patch` hunk metadata reach the classifier untouched even when ccgate has no typed field for them. The metrics layer pulls a small parsed view (`command` / `description` / `file_path` / `path` / `pattern`) for the JSONL but never strips the raw payload from the LLM message.
 
-Fields the upstream Codex docs declare and ccgate uses:
+Fields ccgate reads from the Codex HookInput:
 
 - `session_id`
 - `transcript_path` (path only; ccgate does not parse the transcript JSONL)

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -113,12 +113,6 @@ The Codex system prompt tells the LLM to judge from `tool_name` + `tool_input` +
 | State path                  | `$XDG_STATE_HOME/ccgate/codex/` (falls back to `~/.local/state/ccgate/codex/` when unset). |
 | Project-local config        | `{repo_root}/.codex/ccgate.local.jsonnet` (untracked-only, project-trust required). |
 
-## Defaults snapshot
+## Embedded defaults
 
-The embedded Codex defaults file (`internal/cmd/codex/defaults.jsonnet`) ships allow / deny / environment guidance tuned to the Codex tool surface. Notable entries:
-
-- `allow`: read-only Bash inspection, in-workspace writes (`apply_patch` hunks under cwd / repo_root, project file edits the AI is doing right now), project-script build/test, repo-confined package install, feature-branch git, MCP tools on user-trusted servers whose side effects stay within the user-authorized scope.
-- `deny`: pipe-to-shell of remote content, one-shot remote package execution (`npx` / `pnpx` / `bunx` against unfamiliar packages), `sudo`, out-of-workspace `rm -rf` / `mv` / `apply_patch` hunks, destructive git on protected branches, unrestricted network out (`nc` / `ssh` / `scp` / `ftp` to non-allowlisted hosts), MCP tools advertising destructive side effects without an explicit per-rule allow.
-- `environment`: heterogeneous tool surface, trusted-repo boundary, path scope rule. ccgate replaces the upstream approval prompt, so the guidance defaults to allow / deny when it applies and reserves fallthrough for genuinely ambiguous cases. `recent_transcript` is not delivered to Codex hooks, so the prompt tells the LLM not to assume one.
-
-In-workspace `apply_patch` is in `allow` because the user installed ccgate specifically to avoid being prompted for routine in-repo edits; out-of-workspace patch hunks are denied via the existing deny rule. If you want to be more conservative, add a project-local rule that narrows the apply_patch allow scope (e.g. only specific subtrees).
+Run `ccgate codex init | less` to read the full allow / deny / environment guidance compiled into the binary. For how to extend or replace these defaults, see [docs/rule-tuning.md](rule-tuning.md).

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -4,7 +4,7 @@
 
 Codex-CLI-specific notes for the `ccgate codex` hook.
 
-## Status
+## Requirements
 
 - Codex hooks require `[features] codex_hooks = true`. See [OpenAI's Codex hooks docs](https://developers.openai.com/codex/hooks) for the upstream payload schema.
 - **Tool-agnostic.** Codex hooks fire for Bash, `apply_patch`, MCP tool calls, and other surfaces. ccgate classifies by `tool_name` + the full `tool_input` JSON, not by tool kind alone.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,9 +60,9 @@ If you want repo-wide policy that everyone gets, ship it in your own fork's embe
 | `metrics_max_size`       | int                               | `2097152`                                                                     | Max metrics file size in bytes before rotation (default 2MB). `0` = no rotation.                       |
 | `fallthrough_strategy`   | `"ask"` / `"allow"` / `"deny"`    | `"ask"`                                                                       | How to resolve LLM uncertainty (`fallthrough`). See [fallthrough_strategy](#fallthrough_strategy----choosing-what-to-do-on-llm-uncertainty). |
 | `disable_load_main_worktree_local_config` | bool | `false`                                                                       | In a linked git worktree, skip the main worktree's `ccgate.local.jsonnet`. See [Where ccgate looks for config](#where-ccgate-looks-for-config). |
-| `allow`                  | string[]                          | `[]`                                                                          | Allow guidance rules. **Replaces** the value carried over from earlier layers when set.                |
-| `deny`                   | string[]                          | `[]`                                                                          | Deny guidance rules (mandatory). Supports inline `deny_message:` hints. Same replace semantics as `allow`. |
-| `environment`            | string[]                          | `[]`                                                                          | Context strings passed to the LLM (trust level, policies, etc.). Same replace semantics as `allow`.    |
+| `allow`                  | string[]                          | embedded list (inspect with `ccgate <target> init`)                            | Allow guidance rules. **Replaces** the value carried over from earlier layers when set.                |
+| `deny`                   | string[]                          | embedded list (inspect with `ccgate <target> init`)                            | Deny guidance rules (mandatory). Supports inline `deny_message:` hints. Same replace semantics as `allow`. |
+| `environment`            | string[]                          | embedded list (inspect with `ccgate <target> init`)                            | Context strings passed to the LLM (trust level, policies, etc.). Same replace semantics as `allow`.    |
 | `append_allow`           | string[]                          | `[]`                                                                          | Allow guidance rules **appended** on top of the carried-over list. See [docs/rule-tuning.md](rule-tuning.md). |
 | `append_deny`            | string[]                          | `[]`                                                                          | Deny guidance rules appended on top of the carried-over list.                                          |
 | `append_environment`     | string[]                          | `[]`                                                                          | Environment context appended on top of the carried-over list.                                          |
@@ -81,7 +81,7 @@ The LLM returns one of: `allow`, `deny`, `fallthrough`. `fallthrough` is the LLM
 | `deny`    | Auto-deny. The deny message tells the AI not to re-ask and not to attempt workarounds.              | Unattended runs that should fail safely instead of waiting for approval.  |
 | `allow`   | Auto-allow.                                                                                         | Fully autonomous runs where you accept the risk that the LLM was unsure.  |
 
-**`allow` is riskier than it looks.** The hook spec on both Claude Code and Codex CLI only delivers `decision.message` to the AI when behavior is `deny`. Forced-allow messages are silently dropped, so the AI never sees a "ccgate auto-approved this; proceed with care" warning. Pick `allow` only when that trade-off is acceptable.
+**`allow` is riskier than it looks.** The hook spec only delivers `decision.message` to the AI when behavior is `deny`. Forced-allow messages are silently dropped, so the AI never sees a "ccgate auto-approved this; proceed with care" warning. Pick `allow` only when that trade-off is acceptable.
 
 ### What `fallthrough_strategy` does NOT cover
 
@@ -196,7 +196,7 @@ The cache layer recovers from these without falling through, so they are emitted
 
 `ccgate <target> metrics` adds three sections by default:
 
-- **Top fallthrough commands** -- the most frequent operations that the LLM was unsure about. These are good candidates for a project-local allow / deny rule that lets ccgate skip the LLM round-trip entirely.
+- **Top fallthrough commands** -- the most frequent operations that the LLM was unsure about. These are candidates for a project-local allow / deny rule that nudges the LLM toward a clear verdict instead of falling through to the upstream prompt.
 - **Top deny commands** -- the most frequent operations the LLM denied. Useful when an automated job keeps trying the same blocked thing -- often a sign that the AI's plan needs a different shape.
 - **Credential failures** -- aggregated from `ft_kind=credential_unavailable` entries, grouped by `(source, reason)`. Tool input is intentionally ignored here (every fire during a credential outage carries the same source/reason regardless of the tool the user invoked). Cache-layer warnings do not appear here; check `ccgate.log` for those.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,7 +33,9 @@ Relative paths in any layer (`log_path`, `metrics_path`, `auth.path`, …) resol
 | Lists: `allow`, `deny`, `environment` | A layer that sets the field **replaces** the carried-over list (even with `[]`). A layer that omits the field leaves the carried-over list untouched. | Embedded `allow: ["A","B"]` + global `allow: ["X"]` → final `allow: ["X"]`. |
 | Lists: `append_allow`, `append_deny`, `append_environment` | A layer that sets the field **appends** its entries to whatever the previous layers produced. | Embedded `deny: ["A"]` + project `append_deny: ["P"]` → final `deny: ["A","P"]`. |
 | Scalars: `log_*`, `metrics_*`, `fallthrough_strategy` | A layer **overwrites** the value per-field when it sets it; layers that omit a field leave the previous value untouched. | Embedded `log_max_size: 5MB` + global `log_max_size: 10MB` → final `log_max_size: 10MB`. |
-| Block: `provider` (every `provider.*` field, including `name` / `model` / `base_url` / `auth` / `timeout_ms`) | A layer that writes `provider` **replaces the entire block**; layers that omit `provider` leave it untouched. Per-field merge would let stale fields from a lower layer (e.g. a proxy `base_url`, or a helper `auth.command`) leak into a different provider when a higher layer switches `name`. | Embedded `provider: {name: anthropic, model: claude-haiku-4-5}` + global `provider: {name: openai, model: gpt-4o-mini}` → final `provider: {name: openai, model: gpt-4o-mini}`. To bump only the model, restate the whole block: `provider: {name: anthropic, model: claude-sonnet-4-6}`. When a global layer sets `auth`, any project-local `provider` override must repeat the whole `auth` block or the helper is silently dropped on that project. |
+| Block: `provider` (`name` / `model` / `base_url` / `auth` / `timeout_ms`) | A layer that writes `provider` **replaces the entire block**. | Embedded `provider: {name: anthropic, model: claude-haiku-4-5}` + global `provider: {name: openai, model: gpt-4o-mini}` → final `provider: {name: openai, model: gpt-4o-mini}`. |
+
+`provider` is replaced as a unit so that fields from a lower layer (e.g. a proxy `base_url`, or a helper `auth.command`) cannot leak into a different provider when a higher layer switches `name`. To bump only the model, restate the whole block: `provider: {name: anthropic, model: claude-sonnet-4-6}`. When a global layer sets `auth`, any project-local `provider` override must repeat the whole `auth` block or the helper is silently dropped on that project.
 
 `allow` and `append_allow` (same for the other lists) can coexist in the same layer: the replace runs first, then the append stacks onto the result. Use the pattern when you want to **swap** the embedded list for a curated one and **also** add a couple of project-specific extras: `{ allow: ['only this base'], append_allow: ['plus this project rule'] }`.
 
@@ -178,11 +180,15 @@ The `reason` field meaning depends on `ft_kind`:
 | `output_too_large`      | Helper stdout exceeded the 64 KiB limit.                                                               |
 | `lock_timeout`          | flock retry budget exhausted while peers were refreshing.                                              |
 | `lock_error`            | flock syscall returned a non-EWOULDBLOCK error (broken lock subsystem; helper exec is skipped).        |
-| `cache_unavailable`     | Cache directory cannot be created / `chmod`'d. Treated as fail-fast (helper exec is skipped) because without the sibling lock file we cannot prevent concurrent helpers from racing the broker. |
-| `provider_auth`         | Provider rejected the credential with **HTTP 401 or 403**. `auth.type=exec` invalidates the cache so the next fire re-runs the helper; `auth.type=file` falls through (no cache to clear); `auth.type=profile` falls through (the SDK's refresh-token loop owns the credential); env-var keys are **not** routed here because ccgate cannot rotate env vars and swallowing the rejection would hide user-side misconfiguration. |
-| `profile_load`          | `auth.type=profile` could not produce a usable credential before the SDK ran: profile config missing / parse error, profile name invalid, or credentials file missing / unreadable at preflight. The slog `error_class` field narrows the cause; see [docs/api-key-helper.md Recovery checklist](api-key-helper.md#recovery-checklist) for the full label list and triage steps. |
+| `cache_unavailable`     | Cache directory cannot be created or `chmod`'d. Fail-fast (helper exec is skipped). |
+| `provider_auth`         | Provider rejected the credential with HTTP 401 or 403. |
+| `profile_load`          | `auth.type=profile` could not produce a usable credential before the SDK ran. |
 
-`credential_unavailable` is therefore wider than just "credential resolution failed": it also covers "provider received and rejected the credential" (401 / 403).
+`cache_unavailable` is fail-fast because without the sibling lock file ccgate cannot serialise concurrent helpers and would let them race the broker.
+
+`provider_auth` reaction by `auth.type`: `exec` invalidates the cache so the next fire re-runs the helper, `file` falls through (no cache to clear), `profile` falls through (the SDK's refresh-token loop owns the credential). Env-var keys are not routed here because ccgate cannot rotate env vars and swallowing the rejection would hide user-side misconfiguration. So `credential_unavailable` covers both "credential resolution failed" and "provider received and rejected the credential" (401 / 403).
+
+`profile_load` cause is narrowed by the slog `error_class` field; see the [Recovery checklist in docs/api-key-helper.md](api-key-helper.md#recovery-checklist) for the full label list and triage steps.
 
 #### Log-only credential warnings (not in metrics)
 
@@ -221,4 +227,4 @@ The same fields exist for the log file (`log_path`, `log_disabled`, `log_max_siz
 
 - **Plan mode (Claude only) is prompt-only.** Under `permission_mode == "plan"`, ccgate relies on the LLM plus prose in the system prompt to (a) reject implementation-side writes and (b) allow read-only queries without an explicit allow-guidance match. Either side can misfire.
 - **No surgical reset for a single embedded default rule.** A layer either replaces a list wholesale or appends to it; removing one specific embedded entry while keeping the rest requires re-stating the whole list under `allow` / `deny` minus that one entry.
-- ccgate decides from the hook payload + ccgate config. Codex hooks require the `[features] codex_hooks = true` flag (see the [OpenAI Codex hooks docs](https://developers.openai.com/codex/hooks) for schema details), and ccgate does not consume Codex `~/.codex/config.toml` (`approval_policy`, `sandbox_mode`, `prefix_rules`).
+- ccgate decides from the hook payload + ccgate config. The Codex side requires `[features] codex_hooks = true` (see the [OpenAI Codex hooks docs](https://developers.openai.com/codex/hooks) for schema details).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,7 +129,7 @@ ccgate codex  metrics --days 7         # same shape, codex side
 
 `ft_kind` is filled when the LLM returned (or the runtime forced) a fallthrough; the value tells you which fallback path fired (`llm`, `api_unusable`, `no_apikey`, `credential_unavailable`, `unknown_provider`, `bypass`, `dontask`, `user_interaction`). `forced=true` means `fallthrough_strategy` promoted an LLM `fallthrough` into the recorded `decision`.
 
-`credential_source` is set only when `ft_kind=credential_unavailable`. It carries the credential stage that produced (or failed to produce) the credential — currently `exec` / `file` / `cache` / `lock` (matching the keystore-managed `auth.type=exec` / `auth.type=file` paths) plus `profile` (Anthropic-only `auth.type=profile`, which delegates resolution to anthropic-sdk-go and never touches the keystore). The set is open: future credential paths (e.g. a Windows native backend) may add new values, so consumers parsing this field should treat it as a free-form short string and tolerate unknown values rather than enum-validate it.
+`credential_source` is set only when `ft_kind=credential_unavailable`. It carries the credential stage that produced (or failed to produce) the credential — currently `exec` / `file` / `cache` / `lock` (matching the keystore-managed `auth.type=exec` / `auth.type=file` paths) plus `profile` (Anthropic-only `auth.type=profile`, which delegates resolution to anthropic-sdk-go and never touches the keystore). The set is open: future credential paths may add new values, so consumers parsing this field should treat it as a free-form short string and tolerate unknown values rather than enum-validate it.
 
 The `reason` field meaning depends on `ft_kind`:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 [日本語版 (docs/ja/configuration.md)](ja/configuration.md)
 
-Cross-target configuration reference. The [root README](../README.md) lists the field table and quick-start; this page goes into the layering rules, the fallthrough decision tree, and the metrics output schema.
+Cross-target configuration reference: layering rules, the full config field table, fallthrough_strategy, and the metrics output schema. The [README](../README.md) covers Quick start; this page is for the details.
 
 ## Where ccgate looks for config
 
@@ -33,7 +33,7 @@ Relative paths in any layer (`log_path`, `metrics_path`, `auth.path`, …) resol
 | Lists: `allow`, `deny`, `environment` | A layer that sets the field **replaces** the carried-over list (even with `[]`). A layer that omits the field leaves the carried-over list untouched. | Embedded `allow: ["A","B"]` + global `allow: ["X"]` → final `allow: ["X"]`. |
 | Lists: `append_allow`, `append_deny`, `append_environment` | A layer that sets the field **appends** its entries to whatever the previous layers produced. | Embedded `deny: ["A"]` + project `append_deny: ["P"]` → final `deny: ["A","P"]`. |
 | Scalars: `log_*`, `metrics_*`, `fallthrough_strategy` | A layer **overwrites** the value per-field when it sets it; layers that omit a field leave the previous value untouched. | Embedded `log_max_size: 5MB` + global `log_max_size: 10MB` → final `log_max_size: 10MB`. |
-| Block: `provider` (every `provider.*` field, including `name` / `model` / `base_url` / `auth` / `timeout_ms`) | A layer that writes `provider` **replaces the entire block**; layers that omit `provider` leave it untouched. Per-field merge would let stale fields from a lower layer (e.g. a proxy `base_url`, or a helper `auth.command`) leak into a different provider when a higher layer switches `name`. | Embedded `provider: {name: anthropic, model: haiku}` + global `provider: {name: openai, model: gpt-5.4-nano-2026-03-17}` → final `provider: {name: openai, model: gpt-5.4-nano-2026-03-17}`. To bump only the model, restate the whole block: `provider: {name: anthropic, model: claude-sonnet-4-6}`. When a global layer sets `auth`, any project-local `provider` override must repeat the whole `auth` block or the helper is silently dropped on that project. |
+| Block: `provider` (every `provider.*` field, including `name` / `model` / `base_url` / `auth` / `timeout_ms`) | A layer that writes `provider` **replaces the entire block**; layers that omit `provider` leave it untouched. Per-field merge would let stale fields from a lower layer (e.g. a proxy `base_url`, or a helper `auth.command`) leak into a different provider when a higher layer switches `name`. | Embedded `provider: {name: anthropic, model: claude-haiku-4-5}` + global `provider: {name: openai, model: gpt-4o-mini}` → final `provider: {name: openai, model: gpt-4o-mini}`. To bump only the model, restate the whole block: `provider: {name: anthropic, model: claude-sonnet-4-6}`. When a global layer sets `auth`, any project-local `provider` override must repeat the whole `auth` block or the helper is silently dropped on that project. |
 
 `allow` and `append_allow` (same for the other lists) can coexist in the same layer: the replace runs first, then the append stacks onto the result. Use the pattern when you want to **swap** the embedded list for a curated one and **also** add a couple of project-specific extras: `{ allow: ['only this base'], append_allow: ['plus this project rule'] }`.
 
@@ -42,6 +42,32 @@ Relative paths in any layer (`log_path`, `metrics_path`, `auth.path`, …) resol
 Project-local configs intentionally **only load when they are not tracked by git**. The intent is to let individual contributors layer their own restrictions on top of an ergonomic shared baseline without sneaking team-wide policy into the repo via the local-config path.
 
 If you want repo-wide policy that everyone gets, ship it in your own fork's embedded defaults, in your team's `~/.claude/ccgate.jsonnet` distribution (e.g. via a dotfiles bootstrap), or push individual contributors to add the same `.local.jsonnet` themselves.
+
+## Config fields
+
+| Field                    | Type                              | Default                                                                       | Description                                                                                            |
+|--------------------------|-----------------------------------|-------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
+| `provider.name`          | string                            | `"anthropic"`                                                                 | Provider name. One of `"anthropic"` / `"openai"` / `"gemini"`. See [docs/providers.md](providers.md).   |
+| `provider.model`         | string                            | `"claude-haiku-4-5"`                                                          | Model name. See [docs/providers.md](providers.md#model-selection) for selection guidance.              |
+| `provider.base_url`      | string                            | `""`                                                                          | API base URL override. Empty = SDK default. See [docs/providers.md#base_url-and-compatible-proxies](providers.md#base_url-and-compatible-proxies). |
+| `provider.auth`          | object (`{type, ...}`)            | (omit = env var)                                                              | Discriminated union for refreshable credentials. `type=exec` / `type=file` / `type=profile`. See [docs/api-key-helper.md](api-key-helper.md). |
+| `provider.timeout_ms`    | int                               | `20000`                                                                       | API timeout (ms). `0` = no timeout.                                                                    |
+| `log_path`               | string                            | `$XDG_STATE_HOME/ccgate/<target>/ccgate.log`                                  | Log file path. Supports `~` for home directory.                                                        |
+| `log_disabled`           | bool                              | `false`                                                                       | Disable logging entirely.                                                                              |
+| `log_max_size`           | int                               | `5242880`                                                                     | Max log file size in bytes before rotation (default 5MB). `0` = no rotation.                           |
+| `metrics_path`           | string                            | `$XDG_STATE_HOME/ccgate/<target>/metrics.jsonl`                               | Metrics JSONL file path.                                                                               |
+| `metrics_disabled`       | bool                              | `false`                                                                       | Disable metrics collection entirely.                                                                   |
+| `metrics_max_size`       | int                               | `2097152`                                                                     | Max metrics file size in bytes before rotation (default 2MB). `0` = no rotation.                       |
+| `fallthrough_strategy`   | `"ask"` / `"allow"` / `"deny"`    | `"ask"`                                                                       | How to resolve LLM uncertainty (`fallthrough`). See [fallthrough_strategy](#fallthrough_strategy----choosing-what-to-do-on-llm-uncertainty). |
+| `disable_load_main_worktree_local_config` | bool | `false`                                                                       | In a linked git worktree, skip the main worktree's `ccgate.local.jsonnet`. See [Where ccgate looks for config](#where-ccgate-looks-for-config). |
+| `allow`                  | string[]                          | `[]`                                                                          | Allow guidance rules. **Replaces** the value carried over from earlier layers when set.                |
+| `deny`                   | string[]                          | `[]`                                                                          | Deny guidance rules (mandatory). Supports inline `deny_message:` hints. Same replace semantics as `allow`. |
+| `environment`            | string[]                          | `[]`                                                                          | Context strings passed to the LLM (trust level, policies, etc.). Same replace semantics as `allow`.    |
+| `append_allow`           | string[]                          | `[]`                                                                          | Allow guidance rules **appended** on top of the carried-over list. See [docs/rule-tuning.md](rule-tuning.md). |
+| `append_deny`            | string[]                          | `[]`                                                                          | Deny guidance rules appended on top of the carried-over list.                                          |
+| `append_environment`     | string[]                          | `[]`                                                                          | Environment context appended on top of the carried-over list.                                          |
+
+`<target>` is `claude` or `codex` depending on which hook is invoked. When `XDG_STATE_HOME` is unset, ccgate falls back to `~/.local/state/ccgate/<target>/...`.
 
 ## `fallthrough_strategy` -- choosing what to do on LLM uncertainty
 
@@ -129,7 +155,7 @@ ccgate codex  metrics --days 7         # same shape, codex side
 
 `ft_kind` is filled when the LLM returned (or the runtime forced) a fallthrough; the value tells you which fallback path fired (`llm`, `api_unusable`, `no_apikey`, `credential_unavailable`, `unknown_provider`, `bypass`, `dontask`, `user_interaction`). `forced=true` means `fallthrough_strategy` promoted an LLM `fallthrough` into the recorded `decision`.
 
-`credential_source` is set only when `ft_kind=credential_unavailable`. It carries the credential stage that produced (or failed to produce) the credential — currently `exec` / `file` / `cache` / `lock` (matching the keystore-managed `auth.type=exec` / `auth.type=file` paths) plus `profile` (Anthropic-only `auth.type=profile`, which delegates resolution to anthropic-sdk-go and never touches the keystore). The set is open: future credential paths may add new values, so consumers parsing this field should treat it as a free-form short string and tolerate unknown values rather than enum-validate it.
+`credential_source` is set only when `ft_kind=credential_unavailable`. It carries the credential stage that produced (or failed to produce) the credential — `exec` / `file` / `cache` / `lock` (matching the keystore-managed `auth.type=exec` / `auth.type=file` paths) plus `profile` (Anthropic-only `auth.type=profile`, which delegates resolution to anthropic-sdk-go and never touches the keystore). The set is open and consumers parsing this field should treat it as a free-form short string and tolerate unknown values rather than enum-validate it.
 
 The `reason` field meaning depends on `ft_kind`:
 
@@ -196,4 +222,4 @@ The same fields exist for the log file (`log_path`, `log_disabled`, `log_max_siz
 - **Plan mode (Claude only) is prompt-only.** Under `permission_mode == "plan"`, ccgate relies on the LLM plus prose in the system prompt to (a) reject implementation-side writes and (b) allow read-only queries without an explicit allow-guidance match. Either side can misfire. Tracked in [#37](https://github.com/tak848/ccgate/issues/37).
 - **No surgical reset for a single embedded default rule.** A layer either replaces a list wholesale or appends to it; removing one specific embedded entry while keeping the rest requires re-stating the whole list under `allow` / `deny` minus that one entry.
 - **Codex hook schema is upstream-driven.** Codex hooks live behind upstream's `[features] codex_hooks = true` flag; treat the [OpenAI Codex hooks docs](https://developers.openai.com/codex/hooks) as the source of truth.
-- **Codex `~/.codex/config.toml` ingestion** (`approval_policy`, `sandbox_mode`, `prefix_rules`) is not done. ccgate decides purely from the hook payload + ccgate config; if Codex's own settings would have rejected something, that signal does not reach the LLM.
+- **Codex `~/.codex/config.toml` ingestion** (`approval_policy`, `sandbox_mode`, `prefix_rules`) is out of scope. ccgate decides purely from the hook payload + ccgate config; Codex's own settings do not reach the LLM.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -219,7 +219,6 @@ The same fields exist for the log file (`log_path`, `log_disabled`, `log_max_siz
 
 ## Known limitations
 
-- **Plan mode (Claude only) is prompt-only.** Under `permission_mode == "plan"`, ccgate relies on the LLM plus prose in the system prompt to (a) reject implementation-side writes and (b) allow read-only queries without an explicit allow-guidance match. Either side can misfire. Tracked in [#37](https://github.com/tak848/ccgate/issues/37).
+- **Plan mode (Claude only) is prompt-only.** Under `permission_mode == "plan"`, ccgate relies on the LLM plus prose in the system prompt to (a) reject implementation-side writes and (b) allow read-only queries without an explicit allow-guidance match. Either side can misfire.
 - **No surgical reset for a single embedded default rule.** A layer either replaces a list wholesale or appends to it; removing one specific embedded entry while keeping the rest requires re-stating the whole list under `allow` / `deny` minus that one entry.
-- **Codex hook schema is upstream-driven.** Codex hooks live behind upstream's `[features] codex_hooks = true` flag; treat the [OpenAI Codex hooks docs](https://developers.openai.com/codex/hooks) as the source of truth.
-- **Codex `~/.codex/config.toml` ingestion** (`approval_policy`, `sandbox_mode`, `prefix_rules`) is out of scope. ccgate decides purely from the hook payload + ccgate config; Codex's own settings do not reach the LLM.
+- ccgate decides from the hook payload + ccgate config. Codex hooks require the `[features] codex_hooks = true` flag (see the [OpenAI Codex hooks docs](https://developers.openai.com/codex/hooks) for schema details), and ccgate does not consume Codex `~/.codex/config.toml` (`approval_policy`, `sandbox_mode`, `prefix_rules`).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,8 +37,6 @@ Relative paths in any layer (`log_path`, `metrics_path`, `auth.path`, …) resol
 
 `allow` and `append_allow` (same for the other lists) can coexist in the same layer: the replace runs first, then the append stacks onto the result. Use the pattern when you want to **swap** the embedded list for a curated one and **also** add a couple of project-specific extras: `{ allow: ['only this base'], append_allow: ['plus this project rule'] }`.
 
-> Pre-v0.6 ccgate skipped the embedded defaults whenever a global config existed (the global layer "replaced" instead of layered). v0.6 makes embedded defaults the always-present base and uses explicit `append_*` for opt-in extension; see issue [#38](https://github.com/tak848/ccgate/issues/38). Pre-v0.6 global configs (which already used `allow:` / `deny:` to fully replace) keep their behavior with no edits. Pre-v0.6 project-local configs that used `allow:` / `deny:` / `environment:` to **add** restrictions need to rename those keys to `append_allow:` / `append_deny:` / `append_environment:` -- otherwise they now wholesale replace the inherited list.
-
 ### Why tracked files are skipped
 
 Project-local configs intentionally **only load when they are not tracked by git**. The intent is to let individual contributors layer their own restrictions on top of an ergonomic shared baseline without sneaking team-wide policy into the repo via the local-config path.
@@ -197,5 +195,5 @@ The same fields exist for the log file (`log_path`, `log_disabled`, `log_max_siz
 
 - **Plan mode (Claude only) is prompt-only.** Under `permission_mode == "plan"`, ccgate relies on the LLM plus prose in the system prompt to (a) reject implementation-side writes and (b) allow read-only queries without an explicit allow-guidance match. Either side can misfire. Tracked in [#37](https://github.com/tak848/ccgate/issues/37).
 - **No surgical reset for a single embedded default rule.** A layer either replaces a list wholesale or appends to it; removing one specific embedded entry while keeping the rest requires re-stating the whole list under `allow` / `deny` minus that one entry.
-- **Codex hook schema may change.** Codex hooks live behind upstream's `features.codex_hooks = true` flag and are still evolving.
-- **Codex `~/.codex/config.toml` ingestion** (`approval_policy`, `sandbox_mode`, `prefix_rules`) is not implemented yet. ccgate decides purely from the hook payload + ccgate config; if Codex's own settings would have rejected something, that signal does not reach the LLM today.
+- **Codex hook schema is upstream-driven.** Codex hooks live behind upstream's `[features] codex_hooks = true` flag; treat the [OpenAI Codex hooks docs](https://developers.openai.com/codex/hooks) as the source of truth.
+- **Codex `~/.codex/config.toml` ingestion** (`approval_policy`, `sandbox_mode`, `prefix_rules`) is not done. ccgate decides purely from the hook payload + ccgate config; if Codex's own settings would have rejected something, that signal does not reach the LLM.

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -217,7 +217,7 @@ target ごとの完全な入力一覧は [docs/claude.md](claude.md) / [docs/cod
 | `metrics_path`           | string                            | `$XDG_STATE_HOME/ccgate/<target>/metrics.jsonl`                                 | メトリクス JSONL のパス                                                                                    |
 | `metrics_disabled`       | bool                              | `false`                                                                         | メトリクス収集を完全に無効化                                                                               |
 | `metrics_max_size`       | int                               | `2097152`                                                                         | ローテーション閾値 (bytes, デフォルト 2MB)。`0` = ローテーションなし                                       |
-| `fallthrough_strategy`   | `"ask"` / `"allow"` / `"deny"`    | `"ask"`                                                                         | LLM が判定に迷った (`fallthrough`) 際の扱い。[Fallthrough 戦略](#fallthrough-戦略) 参照 |
+| `fallthrough_strategy`   | `"ask"` / `"allow"` / `"deny"`    | `"ask"`                                                                         | LLM が判定に迷った (`fallthrough`) 際の扱い。[Fallthrough strategy](#fallthrough-strategy) 参照 |
 | `disable_load_main_worktree_local_config` | bool | `false`                                                                         | linked git worktree で main worktree 側の `ccgate.local.jsonnet` を読むのをスキップ。詳細は [docs/configuration.md](configuration.md#where-ccgate-looks-for-config) |
 | `allow`                  | string[]                          | `[]`                                                                            | 許可ルール。設定すると前の layer から引き継いだ list を **完全置換**                                       |
 | `deny`                   | string[]                          | `[]`                                                                            | 拒否ルール (mandatory)。`deny_message:` ヒント対応。`allow` と同じく置換                                   |
@@ -436,7 +436,7 @@ helper / file の中身は次のいずれかを書きます。
 
 helper の完全な仕様 (動かせる例 / `auth.cache_key` によるアカウント別キャッシュ / 初回ブラウザ認証 / 401/403 の挙動マトリクス / 障害復旧チェックリスト) は [api-key-helper.md](api-key-helper.md) を参照してください。
 
-## Fallthrough 戦略
+## Fallthrough strategy
 
 デフォルトでは、LLM が判定に自信を持てない場合 ccgate は `fallthrough` を返し、上流ツール (Claude Code / Codex CLI) のインタラクティブ確認画面にフォールバックします。対話セッションでは妥当ですが、スケジューラやボットなど人間が「許可」を押せない環境では処理が止まります。
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -200,7 +200,7 @@ target ごとの完全な入力一覧は [docs/claude.md](claude.md) / [docs/cod
 
 プロジェクトローカル設定は **Git に追跡されていないファイルのみ** 読み込まれます。
 
-`disable_load_main_worktree_local_config: true` を (1) または (2) に書けば (3) をスキップします。この flag は (1) / (2) でのみ有効で、(3) / (4) に書いても無視されます。詳細は [docs/configuration.md](configuration.md#where-ccgate-looks-for-config) を参照。
+`disable_load_main_worktree_local_config: true` を (1) または (2) に書けば (3) をスキップします。この flag は (1) / (2) でのみ有効で、(3) / (4) に書いても無視されます。詳細は [docs/configuration.md](configuration.md#ccgate-が-config-を探す場所) を参照。
 
 ### 設定項目
 
@@ -218,7 +218,7 @@ target ごとの完全な入力一覧は [docs/claude.md](claude.md) / [docs/cod
 | `metrics_disabled`       | bool                              | `false`                                                                         | メトリクス収集を完全に無効化                                                                               |
 | `metrics_max_size`       | int                               | `2097152`                                                                         | ローテーション閾値 (bytes, デフォルト 2MB)。`0` = ローテーションなし                                       |
 | `fallthrough_strategy`   | `"ask"` / `"allow"` / `"deny"`    | `"ask"`                                                                         | LLM が判定に迷った (`fallthrough`) 際の扱い。[Fallthrough strategy](#fallthrough-strategy) 参照 |
-| `disable_load_main_worktree_local_config` | bool | `false`                                                                         | linked git worktree で main worktree 側の `ccgate.local.jsonnet` を読むのをスキップ。詳細は [docs/configuration.md](configuration.md#where-ccgate-looks-for-config) |
+| `disable_load_main_worktree_local_config` | bool | `false`                                                                         | linked git worktree で main worktree 側の `ccgate.local.jsonnet` を読むのをスキップ。詳細は [docs/configuration.md](configuration.md#ccgate-が-config-を探す場所) |
 | `allow`                  | string[]                          | `[]`                                                                            | 許可ルール。設定すると前の layer から引き継いだ list を **完全置換**                                       |
 | `deny`                   | string[]                          | `[]`                                                                            | 拒否ルール (mandatory)。`deny_message:` ヒント対応。`allow` と同じく置換                                   |
 | `environment`            | string[]                          | `[]`                                                                            | LLM に渡すコンテキスト (信頼レベル、ポリシー等)。`allow` と同じく置換                                       |

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -156,13 +156,15 @@ ccgate の `allow` / `deny` / `environment` はいずれも **自然言語の文
 flowchart TD
   A["Claude Code / Codex CLI"] --> B{"上流側の静的ルールで解決できる?"}
   B -->|Yes| C["そのまま実行 / 拒否"]
-  B -->|No| D["PermissionRequest hook"]
+  B -->|No| D["PermissionRequest hook<br/>(stdin: HookInput JSON)"]
   D --> E["ccgate"]
-  E --> F["tool_input / git context / jsonnet rules"]
-  F --> G{"LLM (default: Haiku) が判定"}
+  E --> F1["jsonnet config を読み込む<br/>embedded defaults + global + project-local"]
+  E --> F2["context を組み立てる<br/>git context, referenced_paths,<br/>recent_transcript (Claude のみ)"]
+  F1 --> G{"LLM (default: Haiku) が<br/>structured output で判定"}
+  F2 --> G
   G -->|allow| H["実行"]
-  G -->|deny| I["理由付きで拒否"]
-  G -->|fallthrough| J["ユーザー確認へ戻す"]
+  G -->|deny| I["deny_message 付きで拒否"]
+  G -->|fallthrough| J["上流の確認 prompt に戻す"]
 ```
 
 ccgate が LLM に渡す情報 (代表項目):

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -142,7 +142,7 @@ lookup 順序、 project-local overlay、 in-tree dev build 用の `go run` レ�
 
 ### 2. API キー
 
-Claude Code と同じ環境変数を使います — [docs/ja/providers.md#api-キー](providers.md#api-キー) を参照。
+provider の API キーを export してください — [docs/ja/providers.md#api-キー](providers.md#api-キー) を参照。
 
 ここまでで ccgate は組み込みデフォルトで動き始めます。allow / deny を自分で書きたい場合は [docs/ja/rule-tuning.md](rule-tuning.md) を、ルールの仕組みを先に押さえたい場合は [コンセプト](#コンセプト) を参照してください。
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -3,7 +3,9 @@
 [![CI](https://github.com/tak848/ccgate/actions/workflows/ci.yml/badge.svg)](https://github.com/tak848/ccgate/actions/workflows/ci.yml)
 [![release](https://github.com/tak848/ccgate/actions/workflows/release.yml/badge.svg)](https://github.com/tak848/ccgate/releases)
 
-AI コーディングツール向けの **PermissionRequest** フックです。ツール実行の許可判定を LLM (Claude Haiku) に委任し、設定ファイルに記述したルールに基づいて allow / deny / fallthrough を返します。
+AI コーディングツール向けの **PermissionRequest** フックです。ツール実行の許可判定を LLM (Claude Haiku) に委任し、jsonnet 設定に書いたルールに基づいて allow / deny / fallthrough を返します。ルールは **LLM への自然言語 guidance** であって、jsonnet による条件分岐ポリシーコードではありません。「何を許可し何を拒否したいか」を散文で書き、実際のリクエストの分類は LLM に任せる、という運用です。
+
+ccgate は組み込みのデフォルトルールを持っているので、設定ファイルなしでも動きます。
 
 ![ccgate の動作例: 安全な `echo` は allow、`curl ... | bash` は deny_message 付きで deny](../images/gate.png)
 
@@ -13,41 +15,6 @@ AI コーディングツール向けの **PermissionRequest** フックです。
 - **[OpenAI Codex CLI](https://developers.openai.com/codex/hooks)**
 
 [English README](../../README.md)
-
-## 仕組み
-
-```
-Claude Code / Codex CLI (PermissionRequest hook)
-  │
-  │  stdin: HookInput JSON
-  ▼
-ccgate
-  ├── 設定読み込み (~/.claude/ccgate.jsonnet  または  ~/.codex/ccgate.jsonnet)
-  ├── コンテキスト構築 (git repo, paths, recent transcript [Claude のみ])
-  ├── Claude Haiku API 呼び出し (Structured Output)
-  └── stdout: allow / deny / fallthrough
-```
-
-1. AI ツールがツール実行前に `ccgate` を呼び出す
-2. `ccgate` は jsonnet 設定の allow/deny ルールをシステムプロンプトに組み込み、ツール情報・git コンテキスト・(Claude のみ) 直近の会話履歴を Haiku に送信
-3. Haiku の判定結果を AI ツールに返す
-
-## CLI
-
-```
-ccgate                         stdin から HookInput JSON を読み込む (Claude Code hook)。
-                               'ccgate claude' と等価。**今後も維持されるデフォルト挙動** で、廃止予定はありません。
-                               既存の ~/.claude/settings.json の "command": "ccgate" 設定はそのまま動作し続ける。
-ccgate claude                  bare ccgate と完全等価 (新規ユーザー向け推奨表記)
-ccgate claude init [-p|-o|-f]  Claude Code 用の埋込デフォルトを出力
-ccgate claude metrics [...]    Claude Code のメトリクス集計
-
-ccgate codex                   stdin から HookInput JSON を読み込む (Codex CLI hook)
-ccgate codex init [-o|-f]      Codex CLI 用の埋込デフォルトを出力
-ccgate codex metrics [...]     Codex CLI のメトリクス集計
-```
-
-> top-level の `ccgate init` / `ccgate metrics` は実 subcommand ではなく、per-target 形式への 1 行案内を出して exit `2` します。bare `ccgate` (hook 起動) は別経路で、上述の通り動作します。
 
 ## インストール
 
@@ -78,6 +45,12 @@ aqua i
 
 [グローバル aqua 設定](https://aquaproj.github.io/docs/tutorial/global-config) に入れる場合は aqua 公式チュートリアルに従ってください。
 
+### Homebrew
+
+```bash
+brew install tak848/tap/ccgate
+```
+
 ### go install
 
 ```bash
@@ -88,37 +61,9 @@ go install github.com/tak848/ccgate@latest
 
 [Releases](https://github.com/tak848/ccgate/releases) からバイナリをダウンロードし、PATH の通った場所に配置してください。
 
-## セットアップ — Claude Code
+## クイックスタート — Claude Code
 
-### 1. 設定ファイルを配置 (オプション)
-
-ccgate はデフォルトの安全ルールを内蔵しているため、設定ファイルなしでも動作します。
-
-カスタマイズはどちらのレイヤーでもできます。両方とも同じ merge ルールに従います。
-
-- `~/.claude/ccgate.jsonnet` — Claude Code セッション全体に効くグローバル設定
-- `<repo>/.claude/ccgate.local.jsonnet` — プロジェクトローカル設定 (Git 未追跡のみ、詳細は [configuration.md](configuration.md#ccgate-が-config-を探す場所))。グローバル設定の上にさらに重なります
-
-どちらのファイルでも、次の 2 種類のいずれか (もしくは両方) を書けます。
-
-- **継承した list に追加する** (`append_allow` / `append_deny` / `append_environment`): 組み込みデフォルト + これまでのレイヤーに乗ったまま、ccgate が今後リリースで品質改善したルールも自動で取り込まれます。
-
-  ```jsonnet
-  {
-    ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/schemas/claude.schema.json',
-    append_deny: [
-      'Production database access: any psql / mysql connection to a *.prod.* host. deny_message: production access is gated behind the runbook.',
-    ],
-  }
-  ```
-
-- **継承した list を丸ごと置き換える** (`allow:` / `deny:` を直接書く): 細部まで自分で握ります。今後 ccgate がデフォルトを更新したときに、自分の `allow` / `deny` を新デフォルトと突き合わせて取り込むかどうかは都度自分で判断する必要があります。`ccgate claude init | less` で組み込みデフォルトの中身を確認できます。
-
-典型的な使い分けは、グローバル設定を組み込みデフォルトに近づけておき (個人的な好みは `append_deny` だけにする等)、プロジェクト固有の制約はプロジェクトローカル側に置く形です。2 つのレイヤーは独立しており、グローバルが list を置き換えていてもプロジェクトローカルで `append_*` を重ねられますし、その逆も可能です。
-
-`$schema` 行はどちらの形でもエディタ補完を有効にします。
-
-### 2. Claude Code の hooks に登録
+### 1. Claude Code の hooks に登録
 
 `~/.claude/settings.json`:
 
@@ -144,7 +89,7 @@ ccgate はデフォルトの安全ルールを内蔵しているため、設定�
 
 `ccgate` が PATH に通っていない場合は、hook の `command` を等価な呼び出し (例: `mise exec aqua:tak848/ccgate -- ccgate claude`) または絶対パスに書き換えてください。
 
-### 3. API キー
+### 2. API キー
 
 選択した provider の API キーを設定してください。`CCGATE_*_API_KEY` が優先され bare 変数を上書きするので、AI ツール本体の API キーと ccgate 用キーを分離できます。
 
@@ -154,30 +99,14 @@ ccgate はデフォルトの安全ルールを内蔵しているため、設定�
 | `openai`        | `CCGATE_OPENAI_API_KEY`    | `OPENAI_API_KEY`      | <https://platform.openai.com/api-keys>      |
 | `gemini`        | `CCGATE_GEMINI_API_KEY`    | `GEMINI_API_KEY`      | <https://aistudio.google.com/app/api-keys>  |
 
-OpenAI 互換 / Anthropic 互換 proxy (LiteLLM proxy, Azure OpenAI, オンプレ gateway 等) を経由したい場合は、`provider.base_url` を設定して対応する native provider を使います — 詳細は [互換 proxy 経由で利用する](#互換-proxy-経由で利用する) を参照。
+ここまでで ccgate は組み込みデフォルトで動き始めます。allow / deny を自分で書きたい場合は [ルールチューニング](#ルールチューニング) を、ルールの仕組みを先に押さえたい場合は [コンセプト](#コンセプト) を参照してください。
 
-## セットアップ — Codex CLI
+## クイックスタート — Codex CLI
 
-> Codex hooks 自体が upstream で experimental 扱いで、`features.codex_hooks = true` flag 配下にあり、schema が今後変わる可能性があります。特定 field に依存する前に [Codex hooks docs](https://developers.openai.com/codex/hooks) を一次情報として確認してください。
+> [!NOTE]
+> Codex hooks 自体が upstream で experimental 扱いで、`[features] codex_hooks = true` flag 配下にあり、schema が今後変わる可能性があります。特定 field に依存する前に [Codex hooks docs](https://developers.openai.com/codex/hooks) を一次情報として確認してください。
 
-### 1. 設定ファイルを配置 (オプション)
-
-ccgate は Codex 側にもデフォルト設定を内蔵しています。Claude 側と同じ merge ルールで、`~/.codex/ccgate.jsonnet` (グローバル) と `<repo>/.codex/ccgate.local.jsonnet` (プロジェクトローカル、Git 未追跡のみ) のどちらでも、`append_*` で継承した list に追加することも、`allow:` / `deny:` で丸ごと置き換えることもできます。
-
-```jsonnet
-{
-  ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/schemas/codex.schema.json',
-  append_deny: [
-    'Production database access: any psql / mysql connection to a *.prod.* host. deny_message: production access is gated behind the runbook.',
-  ],
-}
-```
-
-`ccgate codex init | less` で組み込みデフォルトの中身を確認できます (置き換える前提なら参考にしてください)。
-
-デフォルト設定は Claude Code と同じ方針 (allow + deny + environment) です。Codex hooks は Bash、`apply_patch`、MCP tool 呼び出しなど複数種類の tool で発火し、ccgate のルールはそれらすべてを対象にします。system prompt は LLM に「`tool_name` + `tool_input` の JSON 全体を見て分類せよ」と指示します。
-
-### 2. Codex hook として登録
+### 1. Codex hook として登録
 
 Codex は `~/.codex/hooks.json` と `~/.codex/config.toml` から hook を読み込みます (project が trusted なら `<repo>/.codex/{hooks.json,config.toml}` も overlay)。好きな方で登録してください。
 
@@ -206,7 +135,7 @@ Codex は `~/.codex/hooks.json` と `~/.codex/config.toml` から hook を読み
 
 ```toml
 [features]
-codex_hooks = true   # 必須: Codex hooks はこの feature flag 配下に置かれている
+codex_hooks = true   # Codex hooks はこの feature flag 配下にあり、互換性のため明示しておく
 
 [[hooks.PermissionRequest]]
 matcher = ""
@@ -217,11 +146,40 @@ command = "ccgate codex"
 statusMessage = "ccgate evaluating request"
 ```
 
-lookup 順序、project-local overlay、in-tree dev build 用の `go run` レシピは [docs/codex.md](../codex.md) を参照。upstream の [Codex hooks ドキュメント](https://developers.openai.com/codex/hooks) が schema の正本です。
+lookup 順序、project-local overlay、in-tree dev build 用の `go run` レシピは [docs/codex.md](codex.md) を参照。upstream の [Codex hooks ドキュメント](https://developers.openai.com/codex/hooks) が schema の正本です。
 
-### 3. API キー
+### 2. API キー
 
-Claude Code と同じ環境変数を使います — [provider table](#3-api-キー) を参照してください。
+Claude Code と同じ環境変数を使います — [provider table](#2-api-キー) を参照してください。
+
+ここまでで ccgate は組み込みデフォルトで動き始めます。allow / deny を自分で書きたい場合は [ルールチューニング](#ルールチューニング) を、ルールの仕組みを先に押さえたい場合は [コンセプト](#コンセプト) を参照してください。
+
+## コンセプト
+
+ccgate の `allow` / `deny` / `environment` はいずれも **自然言語の文字列リスト**です。これらが system prompt に埋め込まれて LLM に送られ、LLM が `allow` / `deny` / `fallthrough` のいずれかを返します。jsonnet 側で deterministic にマッチする engine ではなく、すべての PermissionRequest が LLM を経由する設計です。
+
+評価フロー:
+
+```
+AI ツールが PermissionRequest を発火
+  │
+  │  stdin: HookInput JSON
+  ▼
+ccgate
+  ├── jsonnet config を読み込む (embedded defaults + global + project-local)
+  ├── context を組み立て (git repo info, referenced paths, recent transcript [Claude のみ])
+  ├── 設定済みの LLM (default: Claude Haiku) を structured output で呼ぶ
+  └── stdout: allow / deny / fallthrough
+```
+
+ccgate が LLM に渡す情報 (代表項目):
+
+- `tool_name`, `tool_input`, `tool_input_raw` (元の JSON payload をそのまま渡す)。
+- `cwd`, `repo_root`, `branch_name`, worktree info (`gitutil.Context` から)。working tree の dirty/clean は **渡していない**。
+- `referenced_paths` — `tool_input` から best-effort で抽出した path リスト。対象 tool は `Read` / `Write` / `Edit` / `MultiEdit` / `Glob` / `Grep` / `Bash` のみ。`apply_patch` (Codex) や MCP tool では空で、LLM は `tool_input_raw` の hunk / args を直接読む。
+- Claude のみ: `permission_mode` (`"plan"` で system prompt が plan mode rule に切替), `permission_suggestions`, `recent_transcript`, `settings_permissions` hint (whitelist ではなく hint 扱い)。
+
+target ごとの完全な入力一覧は [docs/claude.md](claude.md) / [docs/codex.md](codex.md) を参照してください。
 
 ## 設定
 
@@ -230,21 +188,19 @@ Claude Code と同じ環境変数を使います — [provider table](#3-api-キ
 | 順序 | Claude Code | Codex CLI |
 |----:|-------------|-----------|
 | 1 | 組み込みデフォルト (常にベースとして適用) | 同じ |
-| 2 | `~/.claude/ccgate.jsonnet` — グローバル (上に重ねる) | `~/.codex/ccgate.jsonnet` — グローバル (同じ) |
-| 3 | `{main_worktree}/.claude/ccgate.local.jsonnet` — main worktree プロジェクトローカル (Git 未追跡のみ、linked git worktree のときのみ) | `{main_worktree}/.codex/ccgate.local.jsonnet` (同じ) |
-| 4 | `{repo_root}/.claude/ccgate.local.jsonnet` — current worktree プロジェクトローカル (Git 未追跡のみ) | `{repo_root}/.codex/ccgate.local.jsonnet` (同じ) |
+| 2 | `~/.claude/ccgate.jsonnet` — グローバル (上に重ねる) | `~/.codex/ccgate.jsonnet` — グローバル |
+| 3 | `{main_worktree}/.claude/ccgate.local.jsonnet` — main worktree プロジェクトローカル (Git 未追跡のみ、linked git worktree のときのみ) | `{main_worktree}/.codex/ccgate.local.jsonnet` |
+| 4 | `{repo_root}/.claude/ccgate.local.jsonnet` — current worktree プロジェクトローカル (Git 未追跡のみ) | `{repo_root}/.codex/ccgate.local.jsonnet` |
 
 各 layer はすべて同じ merge ルールで合成されます:
 
 - **list**: `allow` / `deny` / `environment` は値を設定した layer が前の layer から引き継いだ list を **置き換える** (`[]` を書けば空 list に置き換え)。`append_*` 系 (`append_allow` / `append_deny` / `append_environment`) は前の layer の累積 list の **末尾に追加** する。
 - **スカラー**: `log_*` / `metrics_*` / `fallthrough_strategy` はその layer がフィールドを設定していれば per-field で上書き、設定していなければ前の値を保持。
-- **`provider` block**: `provider` を書いた layer では `provider.*` の全フィールド (`name` / `model` / `base_url` / `auth` / `timeout_ms`) をまとめて置き換えます。書かなかった layer では前の block をそのまま引き継ぎます。`name` を切り替えると `model` の名前空間や `base_url` の意味も変わる密結合のため、フィールド単位では merge しません。注意: project-local 設定で `provider` を再掲する場合、global layer に書いた `auth` ブロックも忘れずに書き写してください。書き漏らすと当該プロジェクトだけ helper 設定が静かに消えます。
+- **`provider` block**: `provider` を書いた layer では `provider.*` の全フィールド (`name` / `model` / `base_url` / `auth` / `timeout_ms`) をまとめて置き換える。書かなかった layer では前の block をそのまま引き継ぐ。`name` を切り替えると `model` の名前空間や `base_url` の意味も変わる密結合のため、フィールド単位では merge しない。project-local 設定で `provider` を再掲する場合、global layer の `auth` ブロックも忘れずに書き写すこと。書き漏らすと当該プロジェクトだけ helper 設定が静かに消える。
 
-`~/.<target>/ccgate.jsonnet` で model だけ変えたい場合でも `provider: {name: 'anthropic', model: 'claude-sonnet-4-6'}` のように block 全体を書き直す必要があります (embedded の `allow` / `deny` はそのまま残ります)。`allow: [...]` を書けば embedded の allow を完全に差し替え (これは v0.6 以前のグローバル設定がすでに行っていた挙動なので、そのまま冪等)。プロジェクトローカル設定は典型的に `append_deny: [...]` / `append_environment: [...]` で追加制限を載せます。
 プロジェクトローカル設定は **Git に追跡されていないファイルのみ** 読み込まれます。
 
-`disable_load_main_worktree_local_config: true` を (1) または (2) に書けば (3) をスキップします。この flag は (1) / (2) でのみ有効で、(3) / (4) に書いても無視されます。詳細は [docs/configuration.md](configuration.md#ccgate-が-config-を探す場所) を参照。
-
+`disable_load_main_worktree_local_config: true` を (1) または (2) に書けば (3) をスキップします。この flag は (1) / (2) でのみ有効で、(3) / (4) に書いても無視されます。詳細は [docs/configuration.md](configuration.md#where-ccgate-looks-for-config) を参照。
 
 ### 設定項目
 
@@ -252,17 +208,17 @@ Claude Code と同じ環境変数を使います — [provider table](#3-api-キ
 |--------------------------|-----------------------------------|---------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
 | `provider.name`          | string                            | `"anthropic"`                                                                   | プロバイダー名。`"anthropic"` / `"openai"` / `"gemini"` のいずれか                                          |
 | `provider.model`         | string                            | `"claude-haiku-4-5"`                                                            | モデル名。例: `claude-haiku-4-5` / `claude-sonnet-4-6` (anthropic)、`gpt-5.4-nano-2026-03-17` (openai)、`gemini-3-flash-preview` (gemini)。互換 proxy 経由なら proxy が公開している任意の名前 (例: `anthropic/claude-haiku-4-5`) |
-| `provider.base_url`      | string                            | `""`                                                                            | API base URL の上書き。空文字列 (default) で SDK の既定 endpoint を使用。OpenAI 互換 / Anthropic 互換 proxy (LiteLLM proxy, Azure OpenAI, オンプレ gateway, 地域別 endpoint 等) 経由で叩きたい時に指定 |
-| `provider.auth`          | object (`{type, ...}`)            | (省略時は env var)                                                              | 短命 / ローテーションする認証情報を扱う discriminated union。`type=exec` (helper コマンド) / `type=file` (rotator が更新するファイル) / `type=profile` (Anthropic 専用 — `ant auth login --profile <name>` の credentials を読み、access token の refresh は SDK 自身が担当)。詳細は [api-key-helper.md](api-key-helper.md) |
+| `provider.base_url`      | string                            | `""`                                                                            | API base URL の上書き。空文字列 (default) で SDK の既定 endpoint を使用。OpenAI 互換 / Anthropic 互換 proxy 経由で叩きたい時に指定 |
+| `provider.auth`          | object (`{type, ...}`)            | (省略時は env var)                                                              | 短命 / ローテーションする credential を扱う discriminated union。`type=exec` / `type=file` / `type=profile` の 3 系統。詳細は [api-key-helper.md](api-key-helper.md) |
 | `provider.timeout_ms`    | int                               | `20000`                                                                         | API タイムアウト (ms)。`0` = タイムアウトなし                                                              |
 | `log_path`               | string                            | `$XDG_STATE_HOME/ccgate/<target>/ccgate.log`                                    | ログファイルパス。`~` でホームディレクトリ展開                                                             |
 | `log_disabled`           | bool                              | `false`                                                                         | ログ出力を完全に無効化                                                                                     |
 | `log_max_size`           | int                               | `5242880`                                                                       | ローテーション閾値 (bytes, デフォルト 5MB)。`0` = ローテーションなし                                       |
 | `metrics_path`           | string                            | `$XDG_STATE_HOME/ccgate/<target>/metrics.jsonl`                                 | メトリクス JSONL のパス                                                                                    |
 | `metrics_disabled`       | bool                              | `false`                                                                         | メトリクス収集を完全に無効化                                                                               |
-| `metrics_max_size`       | int                               | `2097152`                                                                       | ローテーション閾値 (bytes, デフォルト 2MB)。`0` = ローテーションなし                                       |
-| `fallthrough_strategy`   | `"ask"` / `"allow"` / `"deny"`    | `"ask"`                                                                         | LLM が判定に迷った (`fallthrough`) 際の扱い。[完全自動運転モード](#完全自動運転モード-fallthrough_strategy) 参照 |
-| `disable_load_main_worktree_local_config` | bool | `false`                                                                         | linked git worktree で main worktree 側の `ccgate.local.jsonnet` を読むのをスキップ。詳細は [docs/configuration.md](configuration.md#ccgate-が-config-を探す場所) |
+| `metrics_max_size`       | int                               | `2097152`                                                                         | ローテーション閾値 (bytes, デフォルト 2MB)。`0` = ローテーションなし                                       |
+| `fallthrough_strategy`   | `"ask"` / `"allow"` / `"deny"`    | `"ask"`                                                                         | LLM が判定に迷った (`fallthrough`) 際の扱い。[Fallthrough 戦略](#fallthrough-戦略) 参照 |
+| `disable_load_main_worktree_local_config` | bool | `false`                                                                         | linked git worktree で main worktree 側の `ccgate.local.jsonnet` を読むのをスキップ。詳細は [docs/configuration.md](configuration.md#where-ccgate-looks-for-config) |
 | `allow`                  | string[]                          | `[]`                                                                            | 許可ルール。設定すると前の layer から引き継いだ list を **完全置換**                                       |
 | `deny`                   | string[]                          | `[]`                                                                            | 拒否ルール (mandatory)。`deny_message:` ヒント対応。`allow` と同じく置換                                   |
 | `environment`            | string[]                          | `[]`                                                                            | LLM に渡すコンテキスト (信頼レベル、ポリシー等)。`allow` と同じく置換                                       |
@@ -271,6 +227,100 @@ Claude Code と同じ環境変数を使います — [provider table](#3-api-キ
 | `append_environment`     | string[]                          | `[]`                                                                            | 引き継いだ environment list の末尾に追加                                                                   |
 
 `<target>` は Claude / Codex どちらの hook が呼ばれたかで `claude` / `codex` になります。`XDG_STATE_HOME` が未設定の場合は `~/.local/state/ccgate/<target>/...` が fallback として使われます。
+
+## ルールチューニング
+
+ccgate は組み込みデフォルトだけで安全に動きます。この章は、その上に自分の `allow` / `deny` / `environment` を載せる方法です。
+
+### 何を変えられるか
+
+- `allow` / `deny` / `environment` (string list) — 値を設定すると前 layer からの引き継ぎを **置換**。
+- `append_allow` / `append_deny` / `append_environment` — 前 layer からの引き継ぎに **追加**。ccgate が今後リリースで品質改善した defaults もそのまま流れ込んでくる。
+
+### どこに書くか
+
+- グローバル: `~/.claude/ccgate.jsonnet` または `~/.codex/ccgate.jsonnet`。
+- プロジェクトローカル: `<repo>/.claude/ccgate.local.jsonnet` または `<repo>/.codex/ccgate.local.jsonnet`、Git 未追跡のみ。
+
+layer の合成順は上の [設定ファイルの読み込み順序](#設定ファイルの読み込み順序-target-ごと) を参照。
+
+### 組み込み defaults を確認する
+
+```bash
+ccgate claude init           | less                   # Claude embedded defaults を確認
+ccgate codex  init           | less                   # Codex も同じ
+ccgate claude init -p > .claude/ccgate.local.jsonnet  # プロジェクトローカルのスケルトン
+ccgate codex  init -p > .codex/ccgate.local.jsonnet   # Codex も同じ
+```
+
+### 置換 vs 追加の判断
+
+`append_*` は前 layer からの引き継ぎを残して追加するので、ccgate が今後リリースで defaults を改善したぶんは自動で取り込まれます。`allow:` / `deny:` で丸ごと置き換える場合は、新 defaults に対する突き合わせを毎リリース自分でやる必要があります (`ccgate <target> init` の出力と diff を取る)。
+
+### ルールの書き方
+
+1 ルール 1 行、対象操作を自然言語で書きます。末尾に `deny_message:` を書くと、その文字列が deny 時に AI に返ります。判定は LLM がやるので、LLM が `tool_input` / `tool_input_raw` / `branch_name` / 各種 path / コマンド文字列から判断できる粒度で書きます。LLM に渡らない情報 (例: working tree の dirty/clean) を guidance に書いても効きません。
+
+書く field によって挙動が変わるので、3 パターンに分けて例を示します。
+
+**追加で広げる** (`append_allow`):
+
+```jsonnet
+{
+  ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/schemas/claude.schema.json',
+  append_allow: [
+    // Claude: target path は tool_input.file_path / referenced_paths から判定可能
+    'Edit / Write / MultiEdit で repo_root/docs/ 配下の Markdown を target にするものは allow (内容レビューは別途行う)。',
+  ],
+}
+```
+
+Codex では `apply_patch` の hunk target を `tool_input_raw` から LLM が読みます:
+
+```jsonnet
+{
+  ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/schemas/codex.schema.json',
+  append_allow: [
+    'apply_patch の全 hunk が repo_root/docs/ 配下の *.md を target にしている場合は allow (内容レビューは別途行う)。',
+  ],
+}
+```
+
+**追加で狭める** (`append_deny`):
+
+```jsonnet
+{
+  append_deny: [
+    'Production database access: any psql / mysql connection to a *.prod.* host. deny_message: production access is gated behind the runbook.',
+    'Setting production environment variables in the running session. deny_message: configure production via the deployment system, not via shell exports.',
+  ],
+}
+```
+
+**完全置換で絞る** (`allow:` / `deny:`):
+
+```jsonnet
+{
+  // 引き継いだ defaults を全部捨てて自分で list を書く。新 defaults は自動で流れ込まない。
+  allow: [
+    'Read-only filesystem inspection inside the repository.',
+    'Local development commands using project scripts (build, test, lint).',
+  ],
+  deny: [
+    'Downloading and executing remote code (curl | bash, eval $(curl ...), etc.). deny_message: vet the script first; install it via a package manager or a checked-in script.',
+  ],
+}
+```
+
+`$schema` 行はどちらの形でもエディタ補完を有効にします。
+
+ccgate は jsonnet helper として `std.native('env')(name)` (未定義は空文字) と `std.native('must_env')(name)` (未定義は config-load エラー) を register しているので、任意の文字列フィールドから ccgate 独自記法を使わずに env を読めます — ホスト名やアカウント ID をルール文字列に埋め込むときに便利です。
+
+### iteration workflow
+
+1-2 日 ccgate を実利用したら `ccgate <target> metrics --details N` を回します。「Top fallthrough commands」「Top deny commands」のドリルダウンを見ると、追加すれば削減できる操作が分かります。`append_deny` (もしくは `append_allow`) を 1 件足して、また次回 metrics を見る、を繰り返すのが基本サイクルです。
+
+## Provider と credential
 
 ### OpenAI / Gemini に切り替える
 
@@ -285,9 +335,10 @@ Claude Code と同じ環境変数を使います — [provider table](#3-api-キ
 }
 ```
 
-対応する API キー (`CCGATE_OPENAI_API_KEY` / `CCGATE_GEMINI_API_KEY` — [provider table](#3-api-キー)) を export してください。キーが見つからない場合 ccgate は上流ツールの確認画面に fallthrough するため、provider 切替で hook が壊れることはありません。
+対応する API キー (`CCGATE_OPENAI_API_KEY` / `CCGATE_GEMINI_API_KEY` — [provider table](#2-api-キー)) を export してください。キーが見つからない場合 ccgate は上流ツールの確認画面に fallthrough するため、provider 切替で hook が壊れることはありません。
 
-> **reasoning model は避ける** (`gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-chat`, `o1*`, `o3*`, `o4-mini`): `temperature=0` を拒否するため全リクエストが失敗し、分類タスクには不要な chain-of-thought に数秒かかります。`gpt-4.1-nano` / `gpt-4o-mini` / `gpt-5.4-nano-2026-03-17` を推奨。
+> [!WARNING]
+> reasoning model は避けること (`gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-chat`, `o1*`, `o3*`, `o4-mini`)。`temperature=0` を拒否するため全リクエストが失敗し、分類タスクには不要な chain-of-thought に数秒かかります。`gpt-4.1-nano` / `gpt-4o-mini` / `gpt-5.4-nano-2026-03-17` を推奨。
 
 ### 互換 proxy 経由で利用する
 
@@ -329,12 +380,12 @@ proxy の API キーを `CCGATE_OPENAI_API_KEY` で export。OpenAI SDK は base
 
 proxy の API キーを `CCGATE_ANTHROPIC_API_KEY` で export。Anthropic SDK が `/v1/messages` を自分で append するので、base URL は host root で止めます。
 
-### 期限付き・自動更新される API キー
+### Refresh される credential
 
-認証情報が静的な環境変数では追従できない頻度で更新される (AWS STS / Vertex ADC / OpenAI 互換 gateway の virtual key / 社内 key broker など) 場合は `provider.auth` を使います。3 つの形式の discriminated union — 用途に合う方を選びます。
+credential が静的な環境変数では追従できない頻度で更新される (AWS STS / Vertex ADC / OpenAI 互換 gateway の virtual key / 社内 key broker など) 場合は `provider.auth` を使います。3 つの形式の discriminated union — 用途に合う方を選びます。
 
 ```jsonnet
-// helper コマンドを実行して認証情報を取得
+// helper コマンドを実行して credential を取得
 {
   provider: {
     name: 'anthropic',
@@ -346,7 +397,7 @@ proxy の API キーを `CCGATE_ANTHROPIC_API_KEY` で export。Anthropic SDK �
   },
 }
 
-// 外部 rotator が認証情報をファイルに書き込む
+// 外部 rotator が credential をファイルに書き込む
 // (path 省略時は $XDG_STATE_HOME/ccgate/<target>/auth_key.json)
 {
   provider: {
@@ -359,7 +410,7 @@ proxy の API キーを `CCGATE_ANTHROPIC_API_KEY` で export。Anthropic SDK �
   },
 }
 
-// `ant auth login` の profile から認証情報を読む (Anthropic 専用)
+// `ant auth login` の profile から credential を読む (Anthropic 専用)
 // access token の refresh は SDK 自身が行うので ccgate は credential 経路に
 // 一切介入しない
 {
@@ -379,33 +430,13 @@ helper / file の中身は次のいずれかを書きます。
 - **JSON** `{"key":"sk-...","expires_at":"<RFC3339>"}` — `auth.type=exec` の場合 `$XDG_CACHE_HOME/ccgate/<target>/` にキャッシュされ、期限前に更新されます
 - **plain string** — 単一行の非空文字列。キャッシュなし
 
-`auth.type=profile` は別経路です: ccgate は読み込んだ profile を `option.WithConfig` で anthropic-sdk-go に渡し、SDK の refresh-token loop が credential ライフサイクルを保有します。さらに `option.WithoutEnvironmentDefaults` を付けるので、残っている `ANTHROPIC_API_KEY` が、宣言した profile を silent に上書きすることはありません。`ant auth login` の後は `ant auth status` を確認してください — `ant` は `--profile` の副作用として `<config_dir>/active_config` (Claude Code と共有) を書き換えます。upstream PR [anthropics/anthropic-cli#45](https://github.com/anthropics/anthropic-cli/pull/45) (`--no-activate` flag) がマージされればその副作用が消えます。
+`auth.type=profile` は別経路です: ccgate は読み込んだ profile を `option.WithConfig` で anthropic-sdk-go に渡し、SDK の refresh-token loop が credential ライフサイクルを保有します。さらに `option.WithoutEnvironmentDefaults` を付けるので、残っている `ANTHROPIC_API_KEY` が、宣言した profile を silent に上書きすることはありません。
 
-解決順序: `provider.auth` (設定済み) > `CCGATE_*_API_KEY` > `*_API_KEY`。`auth` を設定済みのときに失敗しても **env var に黙って fallback はしません**。代わりに `kind=credential_unavailable` で fallthrough します。
+解決順序: `provider.auth` (設定済み) > `CCGATE_*_API_KEY` > `*_API_KEY`。`auth` を設定済みのときに失敗しても **env var に silent に fallback はしない**。代わりに `kind=credential_unavailable` で fallthrough します。
 
-ccgate は jsonnet helper として `std.native('env')(name)` (未定義は空文字) と `std.native('must_env')(name)` (未定義は config-load エラー) を register しているので、任意の文字列フィールドから ccgate 独自記法を使わずに env を読めます。
+helper の完全な仕様 (動かせる例 / `auth.cache_key` によるアカウント別キャッシュ / 初回ブラウザ認証 / 401/403 の挙動マトリクス / 障害復旧チェックリスト) は [api-key-helper.md](api-key-helper.md) を参照してください。
 
-helper の完全な仕様 (動かせる例 / `auth.cache_key` によるアカウント別キャッシュ / 初回ブラウザ認証 / `auth.type=profile` と `active_config` の注意 / 401/403 の挙動マトリクス / 障害復旧チェックリスト) は [api-key-helper.md](api-key-helper.md) を参照してください。
-## デフォルトルール
-
-ccgate は target ごとに組み込みのデフォルトルールを持っています。常にベースとして適用され、その上にグローバル / プロジェクトローカル設定が重なります。
-
-**許可:** 読み取り専用操作、ローカル開発コマンド (project script 経由の build / test)、git フィーチャーブランチ操作、リポジトリ内に閉じたパッケージインストール。
-
-**拒否:** リモートコードのダウンロード実行 (`curl|bash`)、リモートパッケージの直接実行 (`npx` / `pnpx` / `bunx` 等)、git 破壊的操作 (protected branch 含む)、リポジトリ外の削除、特権昇格。
-
-`ccgate claude init` / `ccgate codex init` で組み込みデフォルトの全容を確認できます。ccgate は品質改善のためにデフォルトを更新することがあり、`append_*` 形式で書いている設定はそのまま新デフォルトを取り込みますが、`allow:` / `deny:` で丸ごと置き換えている場合は、新デフォルトと自分の上書きを突き合わせて反映するかを都度判断する必要があります:
-
-```bash
-ccgate claude init           | less                   # Claude embedded defaults を確認
-ccgate codex  init           | less                   # Codex も同じ
-ccgate claude init -p > .claude/ccgate.local.jsonnet  # プロジェクトローカルのスケルトン
-ccgate codex  init -p > .codex/ccgate.local.jsonnet   # Codex も同じ
-```
-
-embedded のルールを 1 件だけ削除する仕組みはありません。リストを `allow:` / `deny:` で丸ごと差し替えて、削除したいルールだけ自分のコピーから抜いてください。
-
-## 完全自動運転モード (`fallthrough_strategy`)
+## Fallthrough 戦略
 
 デフォルトでは、LLM が判定に自信を持てない場合 ccgate は `fallthrough` を返し、上流ツール (Claude Code / Codex CLI) のインタラクティブ確認画面にフォールバックします。対話セッションでは妥当ですが、スケジューラやボットなど人間が「許可」を押せない環境では処理が止まります。
 
@@ -422,13 +453,13 @@ embedded のルールを 1 件だけ削除する仕組みはありません。�
 
 - `ask` (デフォルト) — 上流ツールの確認画面に委ねる (既存の挙動)
 - `deny` — 迷ったら自動拒否。deny メッセージには「user に聞くな、別コマンドで回避するな」という指示が含まれるため、実行が止まらず前に進む
-- `allow` — 迷ったら自動許可。**危険側**: LLM 自身が判断に迷った操作を無条件に通すことになります。Claude Code / Codex とも `decision.message` は `deny` のときしか AI に届かないため、強制 allow の際 AI には警告が渡りません
+- `allow` — 迷ったら自動許可。**危険側**: LLM 自身が判断に迷った操作を無条件に通すことになる。Claude Code / Codex とも `decision.message` は `deny` のときしか AI に届かないため、強制 allow の際 AI には警告が渡らない
 
-対象は **LLM 判定の fallthrough に限定** です。API 応答の打ち切り/拒否、API キー欠損、`bypassPermissions`/`dontAsk` モード (Claude のみ)、`ExitPlanMode` / `AskUserQuestion` (Claude のみ) はいずれも従来通り上流ツールにフォールスルーされます。
+対象は **LLM 判定の fallthrough に限定** です。API 応答の打ち切り/拒否、API キー欠損、`bypassPermissions` / `dontAsk` モード (Claude のみ)、`ExitPlanMode` / `AskUserQuestion` (Claude のみ) はいずれも従来通り上流ツールにフォールスルーされます。
 
 強制的に allow / deny へ変換された回数は `ccgate <target> metrics` の `F.Allow` / `F.Deny` 列 (JSON では `forced_allow` / `forced_deny`) で確認できるため、選んだ戦略が妥当に機能しているか後から監査できます。
 
-## ログ・メトリクス
+## ログとメトリクス
 
 ログ・メトリクスは `$XDG_STATE_HOME/ccgate/<target>/` 配下 (`XDG_STATE_HOME` 未設定時は `~/.local/state/ccgate/<target>/`) に保存されます:
 
@@ -445,7 +476,7 @@ ccgate claude metrics --days 30       # 集計範囲を拡張
 ccgate claude metrics --json          # JSON 出力 (機械可読)
 ccgate claude metrics --details 5     # 上位 5 件の fallthrough / deny コマンドを表示
 ccgate claude metrics --details 0     # ドリルダウン節を非表示
-ccgate codex  metrics --days 7        # codex 側、同じシェイプ
+ccgate codex  metrics --days 7        # codex 側
 ```
 
 日次テーブルには Allow / Deny / Fall / F.Allow / F.Deny / Err、自動化率、平均レイテンシ、トークン使用量が並びます。「Top fallthrough commands」「Top deny commands」のドリルダウンを見ると、ルール追加で削減できる操作が特定できます。
@@ -454,15 +485,32 @@ ccgate codex  metrics --days 7        # codex 側、同じシェイプ
 
 - **Plan mode の正しさはプロンプトのみに依存 (Claude のみ)。** `permission_mode == "plan"` では、(a) 実装系 write を拒絶する判定と (b) allow guidance に載っていない read-only クエリを許可する判定の両方を、LLM とシステムプロンプトの指示文に委ねています。プロンプトで記述する以上、どちらの方向にも誤判定の余地があります。[#37](https://github.com/tak848/ccgate/issues/37) で追跡しています。
 - **embedded default の特定ルールだけを部分削除する手段なし。** layer は list を **完全置換** (`allow: [...]`) するか **末尾追加** (`append_allow: [...]`) するかのどちらかです。embedded の中の 1 ルールだけ消したい場合は、その 1 件を除いた残り全部を `allow:` / `deny:` に書き直すしかありません。
-- **Codex hook の schema は変わる可能性があります。** Codex hooks 自体が upstream の `features.codex_hooks = true` flag 配下にあり、まだ進化中です。ccgate は現在 Codex 側の `permission_mode` を expose せず、transcript JSONL を parse せず、`~/.codex/config.toml` も取り込まず、MCP server 単位の trust hint も適用しません。判定は `tool_name` + `tool_input` + `cwd` のみで行います。
+- **jsonnet 側に runtime conditional logic はありません。** jsonnet 評価は hook 発火ごとの config load 時に、ccgate が `tool_input` を見る前に 1 回だけ実行されます。したがって `tool_input` / git working tree state / 外部コマンド出力に基づく分岐は jsonnet では書けません。runtime の分類は LLM の仕事で、ルールには散文で意図を書いて LLM に判断させます。config 評価時の env 読み込みは `std.native('env')(name)` / `std.native('must_env')(name)` で可能 (ホスト名などをルール文字列に埋め込む程度の用途)。
 
 ## ドキュメント
 
-- [claude.md](claude.md) — Claude Code 固有
-- [codex.md](codex.md) — Codex CLI 固有
+- [claude.md](claude.md) — Claude Code 固有、HookInput field リファレンス
+- [codex.md](codex.md) — Codex CLI 固有、HookInput field リファレンス
 - [configuration.md](configuration.md) — 設定 layering、fallthrough_strategy、metrics、既知の制約
-- [api-key-helper.md](api-key-helper.md) — `provider.auth` リファレンス (helper の契約、キャッシュ、初回ブラウザ認証、401/403 挙動、復旧手順)
+- [api-key-helper.md](api-key-helper.md) — `provider.auth` リファレンス (helper の契約、キャッシュ、401/403 挙動、復旧手順)
 - [English documentation (docs/)](../claude.md)
+
+## CLI リファレンス
+
+```
+ccgate                         stdin から HookInput JSON を読み込む (Claude Code hook)。
+                               'ccgate claude' と等価。**今後も維持されるデフォルト挙動** で、廃止予定はない。
+                               既存の ~/.claude/settings.json の "command": "ccgate" 設定はそのまま動作し続ける。
+ccgate claude                  bare ccgate と完全等価 (新規ユーザー向け推奨表記)
+ccgate claude init [-p|-o|-f]  Claude Code 用の埋込デフォルトを出力
+ccgate claude metrics [...]    Claude Code のメトリクス集計
+
+ccgate codex                   stdin から HookInput JSON を読み込む (Codex CLI hook)
+ccgate codex init [-o|-f]      Codex CLI 用の埋込デフォルトを出力
+ccgate codex metrics [...]     Codex CLI のメトリクス集計
+```
+
+top-level の `ccgate init` / `ccgate metrics` は実 subcommand ではなく、per-target 形式への 1 行案内を出して exit `2` します。bare `ccgate` (hook 起動) は別経路で、上述の通り動作します。
 
 ## 開発
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -83,7 +83,7 @@ go install github.com/tak848/ccgate@latest
 }
 ```
 
-`"command": "ccgate"` (subcommand なし) でも永続的に動作します。bare `ccgate` は Claude Code hook の正規呼び出し方法です。
+`"command": "ccgate"` (subcommand なし) が Claude Code hook の正規呼び出し方法です。 `ccgate claude` はその明示形。
 
 `ccgate` が PATH に通っていない場合は、hook の `command` を等価な呼び出し (例: `mise exec aqua:tak848/ccgate -- ccgate claude`) または絶対パスに書き換えてください。
 
@@ -91,7 +91,7 @@ go install github.com/tak848/ccgate@latest
 
 ccgate は default で Anthropic の Claude Haiku を呼びます。 `CCGATE_ANTHROPIC_API_KEY` (`ANTHROPIC_API_KEY` でも可) を export してください。 OpenAI / Gemini に切り替える場合や、 各 provider の発行ページと環境変数の解決順は [docs/ja/providers.md#api-キー](providers.md#api-キー) を参照。
 
-ここまでで ccgate は組み込みデフォルトで動き始めます。allow / deny を自分で書きたい場合は [ルールチューニング](#ルールチューニング) を、ルールの仕組みを先に押さえたい場合は [コンセプト](#コンセプト) を参照してください。
+ここまでで ccgate は組み込みデフォルトで動き始めます。allow / deny を自分で書きたい場合は [docs/ja/rule-tuning.md](rule-tuning.md) を、ルールの仕組みを先に押さえたい場合は [コンセプト](#コンセプト) を参照してください。
 
 ## クイックスタート — Codex CLI
 
@@ -144,7 +144,7 @@ lookup 順序、 project-local overlay、 in-tree dev build 用の `go run` レ�
 
 Claude Code と同じ環境変数を使います — [docs/ja/providers.md#api-キー](providers.md#api-キー) を参照。
 
-ここまでで ccgate は組み込みデフォルトで動き始めます。allow / deny を自分で書きたい場合は [ルールチューニング](#ルールチューニング) を、ルールの仕組みを先に押さえたい場合は [コンセプト](#コンセプト) を参照してください。
+ここまでで ccgate は組み込みデフォルトで動き始めます。allow / deny を自分で書きたい場合は [docs/ja/rule-tuning.md](rule-tuning.md) を、ルールの仕組みを先に押さえたい場合は [コンセプト](#コンセプト) を参照してください。
 
 ## コンセプト
 
@@ -264,13 +264,13 @@ ccgate codex  metrics --json          # JSON 出力 (機械可読)
 ## CLI リファレンス
 
 ```
-ccgate                         stdin から HookInput JSON を読み込む (Claude Code hook)。`ccgate claude` と等価。
-ccgate claude                  bare ccgate と等価 (新規ユーザー向け推奨表記)
-ccgate claude init [-p|-o|-f]  Claude Code 用の埋込デフォルトを出力
-ccgate claude metrics [...]    Claude Code のメトリクス集計
-ccgate codex                   stdin から HookInput JSON を読み込む (Codex CLI hook)
-ccgate codex init [-o|-f]      Codex CLI 用の埋込デフォルトを出力
-ccgate codex metrics [...]     Codex CLI のメトリクス集計
+ccgate                                       stdin から HookInput JSON を読み込む (Claude Code hook)。`ccgate claude` と等価。
+ccgate claude                                bare ccgate と等価 (新規ユーザー向け推奨表記)
+ccgate claude init [-p] [-o FILE] [-f]       Claude Code 用の埋込デフォルトを出力
+ccgate claude metrics [...]                  Claude Code のメトリクス集計
+ccgate codex                                 stdin から HookInput JSON を読み込む (Codex CLI hook)
+ccgate codex init [-p] [-o FILE] [-f]        Codex CLI 用の埋込デフォルトを出力
+ccgate codex metrics [...]                   Codex CLI のメトリクス集計
 ```
 
 top-level の `ccgate init` / `ccgate metrics` は実 subcommand ではなく、 per-target 形式への 1 行案内を出して exit `2` します。

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -20,7 +20,7 @@ ccgate は組み込みのデフォルトルールを持っているので、設�
 
 ### mise (推奨)
 
-mise `2026.4.20` 以降が必要です。このリリースから、同梱の aqua registry に ccgate が含まれます。
+mise `2026.4.20` 以降が必要です。
 
 ```bash
 mise use -g aqua:tak848/ccgate
@@ -36,7 +36,7 @@ mise exec aqua:tak848/ccgate -- ccgate --version
 
 ### aqua
 
-[aqua](https://aquaproj.github.io/) 標準 registry 経由 (registry `v4.498.0` 以降が必要 — ccgate が初めて登録された version)。aqua 管理下のプロジェクトで (`aqua.yaml` がない場合は `aqua init` を先に走らせる):
+[aqua](https://aquaproj.github.io/) 標準 registry 経由 (registry `v4.498.0` 以降が必要)。aqua 管理下のプロジェクトで (`aqua.yaml` がない場合は `aqua init` を先に走らせる):
 
 ```bash
 aqua g -i tak848/ccgate
@@ -98,7 +98,7 @@ ccgate は default で Anthropic の Claude Haiku を呼びます。 `CCGATE_ANT
 ## クイックスタート — Codex CLI
 
 > [!NOTE]
-> Codex hooks は upstream の `[features] codex_hooks = true` flag 配下にあります。特定 field に依存する前に [Codex hooks docs](https://developers.openai.com/codex/hooks) を一次情報として確認してください。
+> Codex hooks は `~/.codex/config.toml` に `[features] codex_hooks = true` の設定が必要です。詳細は [docs/codex.md](codex.md) を参照。
 
 ### 1. Codex hook として登録
 
@@ -140,7 +140,7 @@ command = "ccgate codex"
 statusMessage = "ccgate evaluating request"
 ```
 
-lookup 順序、project-local overlay、in-tree dev build 用の `go run` レシピは [docs/codex.md](codex.md) を参照。upstream の [Codex hooks ドキュメント](https://developers.openai.com/codex/hooks) が schema の正本です。
+lookup 順序、 project-local overlay、 in-tree dev build 用の `go run` レシピは [docs/codex.md](codex.md) を参照。
 
 ### 2. API キー
 
@@ -212,7 +212,7 @@ provider と hook の登録が済んでから、自分の `allow` / `deny` / `ap
 {
   provider: {
     name: 'openai',
-    model: 'gpt-4o-mini',
+    model: '<openai model name>',  // model 選定は docs/ja/providers.md 参照
   },
 }
 ```

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -152,16 +152,17 @@ ccgate の `allow` / `deny` / `environment` はいずれも **自然言語の文
 
 評価フロー:
 
-```
-AI ツールが PermissionRequest を発火
-  │
-  │  stdin: HookInput JSON
-  ▼
-ccgate
-  ├── jsonnet config を読み込む (embedded defaults + global + project-local)
-  ├── context を組み立て (git repo info, referenced paths, recent transcript [Claude のみ])
-  ├── 設定済みの LLM (default: Claude Haiku) を structured output で呼ぶ
-  └── stdout: allow / deny / fallthrough
+```mermaid
+flowchart TD
+  A["Claude Code / Codex CLI"] --> B{"上流側の静的ルールで解決できる?"}
+  B -->|Yes| C["そのまま実行 / 拒否"]
+  B -->|No| D["PermissionRequest hook"]
+  D --> E["ccgate"]
+  E --> F["tool_input / git context / jsonnet rules"]
+  F --> G{"LLM (default: Haiku) が判定"}
+  G -->|allow| H["実行"]
+  G -->|deny| I["理由付きで拒否"]
+  G -->|fallthrough| J["ユーザー確認へ戻す"]
 ```
 
 ccgate が LLM に渡す情報 (代表項目):

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -104,7 +104,7 @@ go install github.com/tak848/ccgate@latest
 ## クイックスタート — Codex CLI
 
 > [!NOTE]
-> Codex hooks 自体が upstream で experimental 扱いで、`[features] codex_hooks = true` flag 配下にあり、schema が今後変わる可能性があります。特定 field に依存する前に [Codex hooks docs](https://developers.openai.com/codex/hooks) を一次情報として確認してください。
+> Codex hooks は upstream の `[features] codex_hooks = true` flag 配下にあります。特定 field に依存する前に [Codex hooks docs](https://developers.openai.com/codex/hooks) を一次情報として確認してください。
 
 ### 1. Codex hook として登録
 
@@ -235,7 +235,7 @@ ccgate は組み込みデフォルトだけで安全に動きます。この章�
 ### 何を変えられるか
 
 - `allow` / `deny` / `environment` (string list) — 値を設定すると前 layer からの引き継ぎを **置換**。
-- `append_allow` / `append_deny` / `append_environment` — 前 layer からの引き継ぎに **追加**。ccgate が今後リリースで品質改善した defaults もそのまま流れ込んでくる。
+- `append_allow` / `append_deny` / `append_environment` — 前 layer からの引き継ぎに **追加**。ccgate のリリースで embedded defaults が更新されると、upgrade 時に自動で流れ込んでくる。
 
 ### どこに書くか
 
@@ -255,7 +255,7 @@ ccgate codex  init -p > .codex/ccgate.local.jsonnet   # Codex も同じ
 
 ### 置換 vs 追加の判断
 
-`append_*` は前 layer からの引き継ぎを残して追加するので、ccgate が今後リリースで defaults を改善したぶんは自動で取り込まれます。`allow:` / `deny:` で丸ごと置き換える場合は、新 defaults に対する突き合わせを毎リリース自分でやる必要があります (`ccgate <target> init` の出力と diff を取る)。
+`append_*` は前 layer からの引き継ぎを残して追加するので、ccgate のリリースで embedded defaults が更新された分は upgrade 時に自動で取り込まれます。`allow:` / `deny:` で丸ごと置き換える場合は、新 defaults に対する突き合わせを毎リリース自分でやる必要があります (`ccgate <target> init` の出力と diff を取る)。
 
 ### ルールの書き方
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -290,6 +290,11 @@ mise run vet      # go vet
 mise run schema   # schemas/{claude,codex}.schema.json を再生成
 ```
 
+## 関連記事
+
+- 日本語 (Zenn): <https://zenn.dev/layerx/articles/20260428-ccgate>
+- English (dev.to): <https://dev.to/tak848/ccgate-delegate-claude-code-codex-cli-permission-prompts-to-an-llm-274c>
+
 ## ライセンス
 
 MIT

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -91,13 +91,7 @@ go install github.com/tak848/ccgate@latest
 
 ### 2. API キー
 
-選択した provider の API キーを設定してください。`CCGATE_*_API_KEY` が優先され bare 変数を上書きするので、AI ツール本体の API キーと ccgate 用キーを分離できます。
-
-| `provider.name` | 優先                       | フォールバック        | API キー発行ページ |
-|-----------------|----------------------------|-----------------------|--------------------|
-| `anthropic`     | `CCGATE_ANTHROPIC_API_KEY` | `ANTHROPIC_API_KEY`   | <https://platform.claude.com/settings/keys> |
-| `openai`        | `CCGATE_OPENAI_API_KEY`    | `OPENAI_API_KEY`      | <https://platform.openai.com/api-keys>      |
-| `gemini`        | `CCGATE_GEMINI_API_KEY`    | `GEMINI_API_KEY`      | <https://aistudio.google.com/app/api-keys>  |
+ccgate は default で Anthropic の Claude Haiku を呼びます。 `CCGATE_ANTHROPIC_API_KEY` (`ANTHROPIC_API_KEY` でも可) を export してください。 OpenAI / Gemini に切り替える場合や、 各 provider の発行ページと環境変数の解決順は [docs/ja/providers.md#api-キー](providers.md#api-キー) を参照。
 
 ここまでで ccgate は組み込みデフォルトで動き始めます。allow / deny を自分で書きたい場合は [ルールチューニング](#ルールチューニング) を、ルールの仕組みを先に押さえたい場合は [コンセプト](#コンセプト) を参照してください。
 
@@ -150,7 +144,7 @@ lookup 順序、project-local overlay、in-tree dev build 用の `go run` レシ
 
 ### 2. API キー
 
-Claude Code と同じ環境変数を使います — [provider table](#2-api-キー) を参照してください。
+Claude Code と同じ環境変数を使います — [docs/ja/providers.md#api-キー](providers.md#api-キー) を参照。
 
 ここまでで ccgate は組み込みデフォルトで動き始めます。allow / deny を自分で書きたい場合は [ルールチューニング](#ルールチューニング) を、ルールの仕組みを先に押さえたい場合は [コンセプト](#コンセプト) を参照してください。
 
@@ -183,334 +177,105 @@ target ごとの完全な入力一覧は [docs/claude.md](claude.md) / [docs/cod
 
 ## 設定
 
-### 設定ファイルの読み込み順序 (target ごと)
+### 設定ファイルの読み込み順序
 
 | 順序 | Claude Code | Codex CLI |
 |----:|-------------|-----------|
 | 1 | 組み込みデフォルト (常にベースとして適用) | 同じ |
-| 2 | `~/.claude/ccgate.jsonnet` — グローバル (上に重ねる) | `~/.codex/ccgate.jsonnet` — グローバル |
-| 3 | `{main_worktree}/.claude/ccgate.local.jsonnet` — main worktree プロジェクトローカル (Git 未追跡のみ、linked git worktree のときのみ) | `{main_worktree}/.codex/ccgate.local.jsonnet` |
-| 4 | `{repo_root}/.claude/ccgate.local.jsonnet` — current worktree プロジェクトローカル (Git 未追跡のみ) | `{repo_root}/.codex/ccgate.local.jsonnet` |
+| 2 | `~/.claude/ccgate.jsonnet` (グローバル) | `~/.codex/ccgate.jsonnet` |
+| 3 | `{main_worktree}/.claude/ccgate.local.jsonnet` (linked worktree のときのみ、Git 未追跡のみ) | `{main_worktree}/.codex/ccgate.local.jsonnet` |
+| 4 | `{repo_root}/.claude/ccgate.local.jsonnet` (Git 未追跡のみ) | `{repo_root}/.codex/ccgate.local.jsonnet` |
 
-各 layer はすべて同じ merge ルールで合成されます:
+合成ルール (要点):
 
-- **list**: `allow` / `deny` / `environment` は値を設定した layer が前の layer から引き継いだ list を **置き換える** (`[]` を書けば空 list に置き換え)。`append_*` 系 (`append_allow` / `append_deny` / `append_environment`) は前の layer の累積 list の **末尾に追加** する。
-- **スカラー**: `log_*` / `metrics_*` / `fallthrough_strategy` はその layer がフィールドを設定していれば per-field で上書き、設定していなければ前の値を保持。
-- **`provider` block**: `provider` を書いた layer では `provider.*` の全フィールド (`name` / `model` / `base_url` / `auth` / `timeout_ms`) をまとめて置き換える。書かなかった layer では前の block をそのまま引き継ぐ。`name` を切り替えると `model` の名前空間や `base_url` の意味も変わる密結合のため、フィールド単位では merge しない。project-local 設定で `provider` を再掲する場合、global layer の `auth` ブロックも忘れずに書き写すこと。書き漏らすと当該プロジェクトだけ helper 設定が静かに消える。
+- **list (`allow` / `deny` / `environment`)**: 設定した layer が引き継ぎを **置換**。`append_*` は **末尾追加**。
+- **スカラー (`log_*` / `metrics_*` / `fallthrough_strategy`)**: per-field 上書き。
+- **`provider` block**: ブロック全体を atomic に置換 (フィールド単位 merge なし)。
 
-プロジェクトローカル設定は **Git に追跡されていないファイルのみ** 読み込まれます。
-
-`disable_load_main_worktree_local_config: true` を (1) または (2) に書けば (3) をスキップします。この flag は (1) / (2) でのみ有効で、(3) / (4) に書いても無視されます。詳細は [docs/configuration.md](configuration.md#ccgate-が-config-を探す場所) を参照。
-
-### 設定項目
-
-| フィールド               | 型                                | デフォルト                                                                       | 説明                                                                                                       |
-|--------------------------|-----------------------------------|---------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
-| `provider.name`          | string                            | `"anthropic"`                                                                   | プロバイダー名。`"anthropic"` / `"openai"` / `"gemini"` のいずれか                                          |
-| `provider.model`         | string                            | `"claude-haiku-4-5"`                                                            | モデル名。例: `claude-haiku-4-5` / `claude-sonnet-4-6` (anthropic)、`gpt-5.4-nano-2026-03-17` (openai)、`gemini-3-flash-preview` (gemini)。互換 proxy 経由なら proxy が公開している任意の名前 (例: `anthropic/claude-haiku-4-5`) |
-| `provider.base_url`      | string                            | `""`                                                                            | API base URL の上書き。空文字列 (default) で SDK の既定 endpoint を使用。OpenAI 互換 / Anthropic 互換 proxy 経由で叩きたい時に指定 |
-| `provider.auth`          | object (`{type, ...}`)            | (省略時は env var)                                                              | 短命 / ローテーションする credential を扱う discriminated union。`type=exec` / `type=file` / `type=profile` の 3 系統。詳細は [api-key-helper.md](api-key-helper.md) |
-| `provider.timeout_ms`    | int                               | `20000`                                                                         | API タイムアウト (ms)。`0` = タイムアウトなし                                                              |
-| `log_path`               | string                            | `$XDG_STATE_HOME/ccgate/<target>/ccgate.log`                                    | ログファイルパス。`~` でホームディレクトリ展開                                                             |
-| `log_disabled`           | bool                              | `false`                                                                         | ログ出力を完全に無効化                                                                                     |
-| `log_max_size`           | int                               | `5242880`                                                                       | ローテーション閾値 (bytes, デフォルト 5MB)。`0` = ローテーションなし                                       |
-| `metrics_path`           | string                            | `$XDG_STATE_HOME/ccgate/<target>/metrics.jsonl`                                 | メトリクス JSONL のパス                                                                                    |
-| `metrics_disabled`       | bool                              | `false`                                                                         | メトリクス収集を完全に無効化                                                                               |
-| `metrics_max_size`       | int                               | `2097152`                                                                         | ローテーション閾値 (bytes, デフォルト 2MB)。`0` = ローテーションなし                                       |
-| `fallthrough_strategy`   | `"ask"` / `"allow"` / `"deny"`    | `"ask"`                                                                         | LLM が判定に迷った (`fallthrough`) 際の扱い。[Fallthrough strategy](#fallthrough-strategy) 参照 |
-| `disable_load_main_worktree_local_config` | bool | `false`                                                                         | linked git worktree で main worktree 側の `ccgate.local.jsonnet` を読むのをスキップ。詳細は [docs/configuration.md](configuration.md#ccgate-が-config-を探す場所) |
-| `allow`                  | string[]                          | `[]`                                                                            | 許可ルール。設定すると前の layer から引き継いだ list を **完全置換**                                       |
-| `deny`                   | string[]                          | `[]`                                                                            | 拒否ルール (mandatory)。`deny_message:` ヒント対応。`allow` と同じく置換                                   |
-| `environment`            | string[]                          | `[]`                                                                            | LLM に渡すコンテキスト (信頼レベル、ポリシー等)。`allow` と同じく置換                                       |
-| `append_allow`           | string[]                          | `[]`                                                                            | 引き継いだ list の末尾に **追加**。プロジェクトローカル設定で典型的に使用                                  |
-| `append_deny`            | string[]                          | `[]`                                                                            | 引き継いだ deny list の末尾に追加                                                                          |
-| `append_environment`     | string[]                          | `[]`                                                                            | 引き継いだ environment list の末尾に追加                                                                   |
-
-`<target>` は Claude / Codex どちらの hook が呼ばれたかで `claude` / `codex` になります。`XDG_STATE_HOME` が未設定の場合は `~/.local/state/ccgate/<target>/...` が fallback として使われます。
+プロジェクトローカル設定は **Git に追跡されていないファイルのみ** 読み込む。 `disable_load_main_worktree_local_config: true` を (1) / (2) に書けば (3) をスキップ ((3) / (4) に書いても無視)。 詳細・全フィールドリファレンスは [docs/configuration.md](configuration.md#ccgate-が-config-を探す場所) を参照。
 
 ## ルールチューニング
 
-ccgate は組み込みデフォルトだけで安全に動きます。この章は、その上に自分の `allow` / `deny` / `environment` を載せる方法です。
+provider と hook の登録が済んでから、自分の `allow` / `deny` / `append_*` を書きたくなったらここから。
 
-### 何を変えられるか
+- **defaults を確認**: `ccgate claude init | less` / `ccgate codex init | less` (`-p` 付きで `.local.jsonnet` の雛形も出せる)。
+- **どこに書く**: グローバル `~/.<target>/ccgate.jsonnet`、プロジェクトローカル `<repo>/.<target>/ccgate.local.jsonnet` (Git 未追跡のみ)。
+- **置換 vs 追加**: 基本は `append_allow` / `append_deny` / `append_environment` (defaults を残して追加、upgrade 時に新 defaults を自動取り込み)。 `allow:` / `deny:` は完全置換で defaults を捨てる選択肢。
 
-- `allow` / `deny` / `environment` (string list) — 値を設定すると前 layer からの引き継ぎを **置換**。
-- `append_allow` / `append_deny` / `append_environment` — 前 layer からの引き継ぎに **追加**。ccgate のリリースで embedded defaults が更新されると、upgrade 時に自動で流れ込んでくる。
-
-### どこに書くか
-
-- グローバル: `~/.claude/ccgate.jsonnet` または `~/.codex/ccgate.jsonnet`。
-- プロジェクトローカル: `<repo>/.claude/ccgate.local.jsonnet` または `<repo>/.codex/ccgate.local.jsonnet`、Git 未追跡のみ。
-
-layer の合成順は上の [設定ファイルの読み込み順序](#設定ファイルの読み込み順序-target-ごと) を参照。
-
-### 組み込み defaults を確認する
-
-```bash
-ccgate claude init           | less                   # Claude embedded defaults を確認
-ccgate codex  init           | less                   # Codex も同じ
-ccgate claude init -p > .claude/ccgate.local.jsonnet  # プロジェクトローカルのスケルトン
-ccgate codex  init -p > .codex/ccgate.local.jsonnet   # Codex も同じ
-```
-
-### 置換 vs 追加の判断
-
-`append_*` は前 layer からの引き継ぎを残して追加するので、ccgate のリリースで embedded defaults が更新された分は upgrade 時に自動で取り込まれます。`allow:` / `deny:` で丸ごと置き換える場合は、新 defaults に対する突き合わせを毎リリース自分でやる必要があります (`ccgate <target> init` の出力と diff を取る)。
-
-### ルールの書き方
-
-1 ルール 1 行、対象操作を自然言語で書きます。末尾に `deny_message:` を書くと、その文字列が deny 時に AI に返ります。判定は LLM がやるので、LLM が `tool_input` / `tool_input_raw` / `branch_name` / 各種 path / コマンド文字列から判断できる粒度で書きます。LLM に渡らない情報 (例: working tree の dirty/clean) を guidance に書いても効きません。
-
-書く field によって挙動が変わるので、3 パターンに分けて例を示します。
-
-**追加で広げる** (`append_allow`):
-
-```jsonnet
-{
-  ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/schemas/claude.schema.json',
-  append_allow: [
-    // Claude: target path は tool_input.file_path / referenced_paths から判定可能
-    'Edit / Write / MultiEdit で repo_root/docs/ 配下の Markdown を target にするものは allow (内容レビューは別途行う)。',
-  ],
-}
-```
-
-Codex では `apply_patch` の hunk target を `tool_input_raw` から LLM が読みます:
-
-```jsonnet
-{
-  ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/schemas/codex.schema.json',
-  append_allow: [
-    'apply_patch の全 hunk が repo_root/docs/ 配下の *.md を target にしている場合は allow (内容レビューは別途行う)。',
-  ],
-}
-```
-
-**追加で狭める** (`append_deny`):
-
-```jsonnet
-{
-  append_deny: [
-    'Production database access: any psql / mysql connection to a *.prod.* host. deny_message: production access is gated behind the runbook.',
-    'Setting production environment variables in the running session. deny_message: configure production via the deployment system, not via shell exports.',
-  ],
-}
-```
-
-**完全置換で絞る** (`allow:` / `deny:`):
-
-```jsonnet
-{
-  // 引き継いだ defaults を全部捨てて自分で list を書く。新 defaults は自動で流れ込まない。
-  allow: [
-    'Read-only filesystem inspection inside the repository.',
-    'Local development commands using project scripts (build, test, lint).',
-  ],
-  deny: [
-    'Downloading and executing remote code (curl | bash, eval $(curl ...), etc.). deny_message: vet the script first; install it via a package manager or a checked-in script.',
-  ],
-}
-```
-
-`$schema` 行はどちらの形でもエディタ補完を有効にします。
-
-ccgate は jsonnet helper として `std.native('env')(name)` (未定義は空文字) と `std.native('must_env')(name)` (未定義は config-load エラー) を register しているので、任意の文字列フィールドから ccgate 独自記法を使わずに env を読めます — ホスト名やアカウント ID をルール文字列に埋め込むときに便利です。
-
-### iteration workflow
-
-1-2 日 ccgate を実利用したら `ccgate <target> metrics --details N` を回します。「Top fallthrough commands」「Top deny commands」のドリルダウンを見ると、追加すれば削減できる操作が分かります。`append_deny` (もしくは `append_allow`) を 1 件足して、また次回 metrics を見る、を繰り返すのが基本サイクルです。
+書き方の典型例 (Claude / Codex 別の append_allow / append_deny / 完全置換)、`deny_message:` ヒントの形式、`std.native('env')` / `must_env` で env を埋め込む方法、`ccgate <target> metrics --details N` を使った iteration workflow、`fallthrough_strategy` を含むその他の細部は [docs/rule-tuning.md](rule-tuning.md) に集約してあります。
 
 ## Provider と credential
 
-### OpenAI / Gemini に切り替える
-
-任意の layer で `provider.name`（必要に応じて `provider.model` も）を書き換えるだけです:
+`provider.name` (+ 必要なら `model`) を任意の layer で書き換えると provider を切り替えられます:
 
 ```jsonnet
 {
   provider: {
     name: 'openai',
-    model: 'gpt-5.4-nano-2026-03-17',
+    model: 'gpt-4o-mini',
   },
 }
 ```
 
-対応する API キー (`CCGATE_OPENAI_API_KEY` / `CCGATE_GEMINI_API_KEY` — [provider table](#2-api-キー)) を export してください。キーが見つからない場合 ccgate は上流ツールの確認画面に fallthrough するため、provider 切替で hook が壊れることはありません。
+対応する API キーは [docs/ja/providers.md#api-キー](providers.md#api-キー) を参照して export してください。 キーが見つからない場合 ccgate は上流ツールの確認画面に fallthrough するので、 provider 切替で hook が壊れることはありません。
 
-> [!WARNING]
-> reasoning model は避けること (`gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-chat`, `o1*`, `o3*`, `o4-mini`)。`temperature=0` を拒否するため全リクエストが失敗し、分類タスクには不要な chain-of-thought に数秒かかります。`gpt-4.1-nano` / `gpt-4o-mini` / `gpt-5.4-nano-2026-03-17` を推奨。
+provider の切替手順、 モデル選定 (reasoning model を避ける等)、 API キーの解決順、 互換 proxy 経由での利用は [docs/ja/providers.md](providers.md) にまとめてあります。
 
-### 互換 proxy 経由で利用する
-
-ccgate は各 provider SDK の標準 chat / messages エンドポイントを使うので、**OpenAI 互換 / Anthropic 互換**の任意の endpoint — [LiteLLM proxy](https://docs.litellm.ai/docs/proxy/quick_start), Azure OpenAI, オンプレ gateway, 地域別 endpoint など — に対して動きます。proxy が話すプロトコルに合わせて `provider.base_url` を設定します。
-
-`provider.base_url` は underlying SDK の `WithBaseURL` にそのまま渡されるので、書く path は **その SDK の慣習**に従います (ccgate 側で正規化しません):
-
-| `provider.name` | underlying SDK | default base URL                  | `base_url` に書く形              |
-|-----------------|----------------|-----------------------------------|----------------------------------|
-| `openai`        | `openai-go`    | `https://api.openai.com/v1/`      | host **+ `/v1`** (SDK が `chat/completions` を追加) |
-| `anthropic`     | `anthropic-sdk-go` | `https://api.anthropic.com/` | host root のみ (SDK が `/v1/messages` を追加) |
-| `gemini`        | Gemini の OpenAI 互換 endpoint 経由で `openai-go` | `https://generativelanguage.googleapis.com/v1beta/openai/` | override する場合は host **+ `/v1beta/openai`** |
-
-**OpenAI 互換 endpoint** (LiteLLM proxy の `/v1/chat/completions` 等):
-
-```jsonnet
-{
-  provider: {
-    name: 'openai',
-    model: 'anthropic/claude-haiku-4-5', // proxy が公開している名前
-    base_url: 'https://your-proxy.example/v1',
-  },
-}
-```
-
-proxy の API キーを `CCGATE_OPENAI_API_KEY` で export。OpenAI SDK は base URL に `/chat/completions` を直接 append するので、末尾の `/v1` が必要。
-
-**Anthropic 互換 endpoint** (LiteLLM proxy の `/v1/messages` 等):
-
-```jsonnet
-{
-  provider: {
-    name: 'anthropic',
-    model: 'claude-haiku-4-5',
-    base_url: 'https://your-proxy.example',
-  },
-}
-```
-
-proxy の API キーを `CCGATE_ANTHROPIC_API_KEY` で export。Anthropic SDK が `/v1/messages` を自分で append するので、base URL は host root で止めます。
-
-### Refresh される credential
-
-credential が静的な環境変数では追従できない頻度で更新される (AWS STS / Vertex ADC / OpenAI 互換 gateway の virtual key / 社内 key broker など) 場合は `provider.auth` を使います。3 つの形式の discriminated union — 用途に合う方を選びます。
-
-```jsonnet
-// helper コマンドを実行して credential を取得
-{
-  provider: {
-    name: 'anthropic',
-    model: 'claude-haiku-4-5',
-    auth: {
-      type: 'exec',
-      command: '/usr/local/bin/my-key-broker --provider anthropic',
-    },
-  },
-}
-
-// 外部 rotator が credential をファイルに書き込む
-// (path 省略時は $XDG_STATE_HOME/ccgate/<target>/auth_key.json)
-{
-  provider: {
-    name: 'anthropic',
-    model: 'claude-haiku-4-5',
-    auth: {
-      type: 'file',
-      path: '~/.config/my-broker/anthropic.json',
-    },
-  },
-}
-
-// `ant auth login` の profile から credential を読む (Anthropic 専用)
-// access token の refresh は SDK 自身が行うので ccgate は credential 経路に
-// 一切介入しない
-{
-  provider: {
-    name: 'anthropic',
-    model: 'claude-haiku-4-5',
-    auth: {
-      type: 'profile',
-      profile: 'ccgate',       // `ant auth login --profile ccgate` と一致
-    },
-  },
-}
-```
-
-helper / file の中身は次のいずれかを書きます。
-
-- **JSON** `{"key":"sk-...","expires_at":"<RFC3339>"}` — `auth.type=exec` の場合 `$XDG_CACHE_HOME/ccgate/<target>/` にキャッシュされ、期限前に更新されます
-- **plain string** — 単一行の非空文字列。キャッシュなし
-
-`auth.type=profile` は別経路です: ccgate は読み込んだ profile を `option.WithConfig` で anthropic-sdk-go に渡し、SDK の refresh-token loop が credential ライフサイクルを保有します。さらに `option.WithoutEnvironmentDefaults` を付けるので、残っている `ANTHROPIC_API_KEY` が、宣言した profile を silent に上書きすることはありません。
-
-解決順序: `provider.auth` (設定済み) > `CCGATE_*_API_KEY` > `*_API_KEY`。`auth` を設定済みのときに失敗しても **env var に silent に fallback はしない**。代わりに `kind=credential_unavailable` で fallthrough します。
-
-helper の完全な仕様 (動かせる例 / `auth.cache_key` によるアカウント別キャッシュ / 初回ブラウザ認証 / 401/403 の挙動マトリクス / 障害復旧チェックリスト) は [api-key-helper.md](api-key-helper.md) を参照してください。
+**Refresh される credential** (AWS STS / Vertex ADC / OpenAI 互換 gateway の virtual key / 社内 key broker など、 静的 env では追従できないケース) を扱いたいときは `provider.auth` を設定します。 3 形式の discriminated union (`type=exec` / `type=file` / `type=profile`) で、 helper 契約・キャッシュ・401/403 挙動・復旧手順を含む完全な仕様は [docs/ja/api-key-helper.md](api-key-helper.md) を参照。
 
 ## Fallthrough strategy
 
-デフォルトでは、LLM が判定に自信を持てない場合 ccgate は `fallthrough` を返し、上流ツール (Claude Code / Codex CLI) のインタラクティブ確認画面にフォールバックします。対話セッションでは妥当ですが、スケジューラやボットなど人間が「許可」を押せない環境では処理が止まります。
-
-`fallthrough_strategy` を設定すると、LLM の判定迷いを allow/deny に強制変換できます:
+LLM が判定に自信を持てないと `fallthrough` を返し、上流ツールの確認画面にフォールバックします。これは対話セッションでは妥当ですが、スケジューラ / ボット等の無人実行では処理が止まります。 `fallthrough_strategy` を設定すれば LLM の迷いを `allow` / `deny` に強制変換できます (default は `ask`):
 
 ```jsonnet
-{
-  // 安全側: 迷ったら拒否。無人実行ではこちらを推奨
-  fallthrough_strategy: 'deny',
-}
+{ fallthrough_strategy: 'deny' }  // 安全側: 迷ったら拒否。無人実行ではこちらを推奨
 ```
 
-値:
-
-- `ask` (デフォルト) — 上流ツールの確認画面に委ねる (既存の挙動)
-- `deny` — 迷ったら自動拒否。deny メッセージには「user に聞くな、別コマンドで回避するな」という指示が含まれるため、実行が止まらず前に進む
-- `allow` — 迷ったら自動許可。**危険側**: LLM 自身が判断に迷った操作を無条件に通すことになる。Claude Code / Codex とも `decision.message` は `deny` のときしか AI に届かないため、強制 allow の際 AI には警告が渡らない
-
-対象は **LLM 判定の fallthrough に限定** です。API 応答の打ち切り/拒否、API キー欠損、`bypassPermissions` / `dontAsk` モード (Claude のみ)、`ExitPlanMode` / `AskUserQuestion` (Claude のみ) はいずれも従来通り上流ツールにフォールスルーされます。
-
-強制的に allow / deny へ変換された回数は `ccgate <target> metrics` の `F.Allow` / `F.Deny` 列 (JSON では `forced_allow` / `forced_deny`) で確認できるため、選んだ戦略が妥当に機能しているか後から監査できます。
+`allow` は LLM が迷った操作を無条件に通すので使う場面は限定されます。値の意味、対象外となるケース (API 応答打ち切り、API キー欠損、`bypassPermissions` / `dontAsk`、ユーザー対話 tool 等)、 metrics による監査は [docs/ja/configuration.md](configuration.md) を参照。
 
 ## ログとメトリクス
 
-ログ・メトリクスは `$XDG_STATE_HOME/ccgate/<target>/` 配下 (`XDG_STATE_HOME` 未設定時は `~/.local/state/ccgate/<target>/`) に保存されます:
-
-- `$XDG_STATE_HOME/ccgate/claude/{ccgate.log,metrics.jsonl}` — Claude Code
-- `$XDG_STATE_HOME/ccgate/codex/{ccgate.log,metrics.jsonl}` — Codex CLI
-
-両ファイルともサイズベースでローテーションします (`.log.1`, `.jsonl.1`)。
-
-jsonnet で `log_path` / `metrics_path` を明示している場合はその設定が尊重されます。
+- ログ: `$XDG_STATE_HOME/ccgate/<target>/ccgate.log` (未設定なら `~/.local/state/ccgate/<target>/`)
+- メトリクス: `$XDG_STATE_HOME/ccgate/<target>/metrics.jsonl`
+- 両ファイルとも `_max_size` 閾値でローテーション。
 
 ```bash
-ccgate claude metrics                 # 直近 7 日間、TTY テーブル
-ccgate claude metrics --days 30       # 集計範囲を拡張
-ccgate claude metrics --json          # JSON 出力 (機械可読)
-ccgate claude metrics --details 5     # 上位 5 件の fallthrough / deny コマンドを表示
-ccgate claude metrics --details 0     # ドリルダウン節を非表示
-ccgate codex  metrics --days 7        # codex 側
+ccgate claude metrics                 # 直近 7 日、TTY テーブル
+ccgate claude metrics --details 5     # fallthrough / deny の上位 5 コマンドをドリルダウン
+ccgate codex  metrics --json          # JSON 出力 (機械可読)
 ```
 
-日次テーブルには Allow / Deny / Fall / F.Allow / F.Deny / Err、自動化率、平均レイテンシ、トークン使用量が並びます。「Top fallthrough commands」「Top deny commands」のドリルダウンを見ると、ルール追加で削減できる操作が特定できます。
+列の意味、JSON エントリ schema、credential 障害集計は [docs/ja/configuration.md#メトリクス出力](configuration.md#メトリクス出力) を参照。
 
 ## 既知の制約
 
-- **Plan mode の正しさはプロンプトのみに依存 (Claude のみ)。** `permission_mode == "plan"` では、(a) 実装系 write を拒絶する判定と (b) allow guidance に載っていない read-only クエリを許可する判定の両方を、LLM とシステムプロンプトの指示文に委ねています。プロンプトで記述する以上、どちらの方向にも誤判定の余地があります。[#37](https://github.com/tak848/ccgate/issues/37) で追跡しています。
-- **embedded default の特定ルールだけを部分削除する手段なし。** layer は list を **完全置換** (`allow: [...]`) するか **末尾追加** (`append_allow: [...]`) するかのどちらかです。embedded の中の 1 ルールだけ消したい場合は、その 1 件を除いた残り全部を `allow:` / `deny:` に書き直すしかありません。
-- **jsonnet 側に runtime conditional logic はありません。** jsonnet 評価は hook 発火ごとの config load 時に、ccgate が `tool_input` を見る前に 1 回だけ実行されます。したがって `tool_input` / git working tree state / 外部コマンド出力に基づく分岐は jsonnet では書けません。runtime の分類は LLM の仕事で、ルールには散文で意図を書いて LLM に判断させます。config 評価時の env 読み込みは `std.native('env')(name)` / `std.native('must_env')(name)` で可能 (ホスト名などをルール文字列に埋め込む程度の用途)。
+- **Plan mode の正しさはプロンプトのみに依存 (Claude のみ)**: `permission_mode == "plan"` では、(a) 実装系 write の拒絶と (b) allow guidance に載っていない read-only クエリの許可、両方を LLM とシステムプロンプトに委ねている。どちらにも誤判定の余地あり。
+- **embedded default の特定ルールだけの部分削除は不可**: layer は list を **完全置換** (`allow: [...]`) するか **末尾追加** (`append_allow: [...]`) するかのどちらかで、1 件除外したい場合は残りを `allow:` / `deny:` に書き直す。
+- **jsonnet 側に runtime conditional logic なし**: jsonnet 評価は hook 発火ごとの config load 時に、 ccgate が `tool_input` を見る前に実行される。 `tool_input` / git working tree state に基づく runtime 分岐は書けない (分類は LLM の仕事)。 config 評価時の env 読み込みのみ `std.native('env')(name)` / `std.native('must_env')(name)` で可能。
 
 ## ドキュメント
 
-- [claude.md](claude.md) — Claude Code 固有、HookInput field リファレンス
-- [codex.md](codex.md) — Codex CLI 固有、HookInput field リファレンス
-- [configuration.md](configuration.md) — 設定 layering、fallthrough_strategy、metrics、既知の制約
-- [api-key-helper.md](api-key-helper.md) — `provider.auth` リファレンス (helper の契約、キャッシュ、401/403 挙動、復旧手順)
-- [English documentation (docs/)](../claude.md)
+- [providers.md](providers.md) — Provider 切替、 API キー、 base_url、 互換 proxy
+- [rule-tuning.md](rule-tuning.md) — ルールチューニングの入り口 (defaults 確認、 append vs 置換、 3 パターン例、 iteration workflow)
+- [configuration.md](configuration.md) — 設定 layering、 全フィールド reference、 fallthrough_strategy 詳細、 メトリクス出力
+- [api-key-helper.md](api-key-helper.md) — `provider.auth` リファレンス (helper の契約、 キャッシュ、 401/403 挙動、 復旧手順)
+- [claude.md](claude.md) — Claude Code 固有の HookInput
+- [codex.md](codex.md) — Codex CLI 固有の HookInput
+- [English README](../../README.md)
 
 ## CLI リファレンス
 
 ```
-ccgate                         stdin から HookInput JSON を読み込む (Claude Code hook)。
-                               'ccgate claude' と等価。**今後も維持されるデフォルト挙動** で、廃止予定はない。
-                               既存の ~/.claude/settings.json の "command": "ccgate" 設定はそのまま動作し続ける。
-ccgate claude                  bare ccgate と完全等価 (新規ユーザー向け推奨表記)
+ccgate                         stdin から HookInput JSON を読み込む (Claude Code hook)。`ccgate claude` と等価。
+ccgate claude                  bare ccgate と等価 (新規ユーザー向け推奨表記)
 ccgate claude init [-p|-o|-f]  Claude Code 用の埋込デフォルトを出力
 ccgate claude metrics [...]    Claude Code のメトリクス集計
-
 ccgate codex                   stdin から HookInput JSON を読み込む (Codex CLI hook)
 ccgate codex init [-o|-f]      Codex CLI 用の埋込デフォルトを出力
 ccgate codex metrics [...]     Codex CLI のメトリクス集計
 ```
 
-top-level の `ccgate init` / `ccgate metrics` は実 subcommand ではなく、per-target 形式への 1 行案内を出して exit `2` します。bare `ccgate` (hook 起動) は別経路で、上述の通り動作します。
+top-level の `ccgate init` / `ccgate metrics` は実 subcommand ではなく、 per-target 形式への 1 行案内を出して exit `2` します。
 
 ## 開発
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -43,12 +43,6 @@ aqua i
 
 [グローバル aqua 設定](https://aquaproj.github.io/docs/tutorial/global-config) に入れる場合は aqua 公式チュートリアルに従ってください。
 
-### Homebrew
-
-```bash
-brew install tak848/tap/ccgate
-```
-
 ### go install
 
 ```bash
@@ -58,6 +52,12 @@ go install github.com/tak848/ccgate@latest
 ### GitHub Releases
 
 [Releases](https://github.com/tak848/ccgate/releases) からバイナリをダウンロードし、PATH の通った場所に配置してください。
+
+### Homebrew
+
+```bash
+brew install tak848/tap/ccgate
+```
 
 ## クイックスタート — Claude Code
 
@@ -219,7 +219,13 @@ provider と hook の登録が済んでから、自分の `allow` / `deny` / `ap
 
 provider の切替手順、 モデル選定時の確認事項、 API キーの解決順、 互換 proxy 経由での利用は [docs/ja/providers.md](providers.md) にまとめてあります。
 
-**Refresh される credential** (AWS STS / Vertex ADC / OpenAI 互換 gateway の virtual key / 社内 key broker など、 静的 env では追従できないケース) を扱いたいときは `provider.auth` を設定します。 3 形式の discriminated union (`type=exec` / `type=file` / `type=profile`) で、 helper 契約・キャッシュ・401/403 挙動・復旧手順を含む完全な仕様は [docs/ja/api-key-helper.md](api-key-helper.md) を参照。
+**Refresh される credential** (AWS STS / Vertex ADC / OpenAI 互換 gateway の virtual key / 社内 key broker など、 静的 env では追従できないケース) を扱いたいときは `provider.auth` を設定します。 3 形式から選びます:
+
+- `type=exec` — ccgate が **credential helper** コマンドを実行し、 stdout を credential として使う (`expires_at` を keyed cache)。
+- `type=file` — 外部 rotator が書いた credential file を ccgate が読む。
+- `type=profile` — Anthropic 専用。 `ant auth login` の profile を SDK に渡し、 SDK の refresh-token loop が credential を保有する。
+
+helper 契約・キャッシュ・401/403 挙動・復旧手順を含む完全な仕様は [docs/ja/api-key-helper.md](api-key-helper.md) を参照。
 
 ## Fallthrough strategy
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -198,7 +198,7 @@ provider と hook の登録が済んでから、自分の `allow` / `deny` / `ap
 
 - **defaults を確認**: `ccgate claude init | less` / `ccgate codex init | less` (`-p` 付きで `.local.jsonnet` の雛形も出せる)。
 - **どこに書く**: グローバル `~/.<target>/ccgate.jsonnet`、プロジェクトローカル `<repo>/.<target>/ccgate.local.jsonnet` (Git 未追跡のみ)。
-- **置換 vs 追加**: 基本は `append_allow` / `append_deny` / `append_environment` (defaults を残して追加、upgrade 時に新 defaults を自動取り込み)。 `allow:` / `deny:` は完全置換で defaults を捨てる選択肢。
+- **置換 vs 追加**: 基本は `append_allow` / `append_deny` / `append_environment` (embedded defaults を残して自分のエントリを追加)。 `allow:` / `deny:` は完全置換 (defaults を捨てて自分の list だけが有効)。
 
 書き方の典型例 (Claude / Codex 別の append_allow / append_deny / 完全置換)、`deny_message:` ヒントの形式、`std.native('env')` / `must_env` で env を埋め込む方法、`ccgate <target> metrics --details N` を使った iteration workflow、`fallthrough_strategy` を含むその他の細部は [docs/rule-tuning.md](rule-tuning.md) に集約してあります。
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/tak848/ccgate/actions/workflows/ci.yml/badge.svg)](https://github.com/tak848/ccgate/actions/workflows/ci.yml)
 [![release](https://github.com/tak848/ccgate/actions/workflows/release.yml/badge.svg)](https://github.com/tak848/ccgate/releases)
 
-AI コーディングツール向けの **PermissionRequest** フックです。ツール実行の許可判定を LLM (Claude Haiku) に委任し、jsonnet 設定に書いたルールに基づいて allow / deny / fallthrough を返します。ルールは **LLM への自然言語 guidance** であって、jsonnet による条件分岐ポリシーコードではありません。「何を許可し何を拒否したいか」を散文で書き、実際のリクエストの分類は LLM に任せる、という運用です。
+AI コーディングツール向けの **PermissionRequest** フックです。ツール実行の許可判定を LLM (Claude Haiku) に委任し、jsonnet 設定に書いたルールに基づいて allow / deny / fallthrough を返します。
 
 ccgate は組み込みのデフォルトルールを持っているので、設定ファイルなしでも動きます。
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -32,8 +32,6 @@ ccgate をグローバルに登録せず一度だけ試したい場合 (`npx` / 
 mise exec aqua:tak848/ccgate -- ccgate --version
 ```
 
-そのまま hook としても no-install で使い続けたい場合は、設定の hook `command` を `mise exec aqua:tak848/ccgate -- ccgate claude` (または `... -- ccgate codex`) に書き換えてください。hook 呼び出しごとに launcher の起動コストが乗るため、常用するなら上の `mise use -g` の方を推奨します。
-
 ### aqua
 
 [aqua](https://aquaproj.github.io/) 標準 registry 経由 (registry `v4.498.0` 以降が必要)。aqua 管理下のプロジェクトで (`aqua.yaml` がない場合は `aqua init` を先に走らせる):
@@ -219,7 +217,7 @@ provider と hook の登録が済んでから、自分の `allow` / `deny` / `ap
 
 対応する API キーは [docs/ja/providers.md#api-キー](providers.md#api-キー) を参照して export してください。 キーが見つからない場合 ccgate は上流ツールの確認画面に fallthrough するので、 provider 切替で hook が壊れることはありません。
 
-provider の切替手順、 モデル選定 (reasoning model を避ける等)、 API キーの解決順、 互換 proxy 経由での利用は [docs/ja/providers.md](providers.md) にまとめてあります。
+provider の切替手順、 モデル選定時の確認事項、 API キーの解決順、 互換 proxy 経由での利用は [docs/ja/providers.md](providers.md) にまとめてあります。
 
 **Refresh される credential** (AWS STS / Vertex ADC / OpenAI 互換 gateway の virtual key / 社内 key broker など、 静的 env では追従できないケース) を扱いたいときは `provider.auth` を設定します。 3 形式の discriminated union (`type=exec` / `type=file` / `type=profile`) で、 helper 契約・キャッシュ・401/403 挙動・復旧手順を含む完全な仕様は [docs/ja/api-key-helper.md](api-key-helper.md) を参照。
 

--- a/docs/ja/api-key-helper.md
+++ b/docs/ja/api-key-helper.md
@@ -7,7 +7,7 @@ provider に渡す credential が静的な環境変数では追いつかない�
 `provider.auth` には 3 つのモードがあります。
 
 - **`type: 'exec'`**: ccgate がシェルコマンドを実行し、その stdout を credential として使う。
-- **`type: 'file'`**: 外部のローテーター (cron / launchd など) が書いたファイルを ccgate が読む。
+- **`type: 'file'`**: 外部のローテーターが書いたファイルを ccgate が読む。
 - **`type: 'profile'`**: Anthropic 専用。`ant auth login` の profile を anthropic-sdk-go に渡し、refresh は SDK 自身が担当する。[Profile ベース認証](#profile-ベース認証-anthropic-のみ) を参照。
 
 (`*_API_KEY` env var は `provider.auth` が省略されている場合の別経路。`auth` のモードではありません。)
@@ -78,7 +78,7 @@ helper は次を満たす必要があります。
 - 同じ `(shell, command, provider.name, base_url, cache_key)` の組に対して **決定論的** に振る舞う。同じ設定で 2 回呼んだら同じ意味の認証情報を返すこと。
 - **デーモン化しない**。process group の外に fork するとタイムアウト時の kill が効きません。
 - `auth.timeout_ms` 以内に終了する。
-- `auth.command` 文字列に **literal な秘密情報を直接書かない**。文字列は設定したシェル (`bash -c <command>`、または `auth.shell: 'powershell'` のときは `pwsh -Command <command>` / `powershell -Command <command>`) に渡されるため、`ps` / `/proc/<pid>/cmdline` / シェル履歴に残ります。秘密情報はファイルや keychain に置き、helper の中で読み出してください。
+- `auth.command` 文字列に **literal な秘密情報を直接書かない**。文字列は設定したシェル (`bash -c <command>`、または `auth.shell: 'powershell'` のときは `pwsh -Command <command>` / `powershell -Command <command>`) に渡されるため、 process listing やシェル履歴に残ります。秘密情報はファイルや keychain に置き、 helper の中で読み出してください。
 
 ccgate は helper の env に `CCGATE_API_KEY_RESOLUTION=1` を入れるので、helper が ccgate を再帰起動していないかを自分で検知できます。それ以外の環境変数 (`*_API_KEY` 含む) はそのまま継承します。stdin は閉じています (helper から親ターミナルの入力は読めません)。
 
@@ -106,11 +106,11 @@ ant auth login --profile ccgate         # ブラウザが開き ~/.config/anthro
 > [!IMPORTANT]
 > **`ant auth login` は profile 名に関わらず `<config_dir>/active_config` を書き換える** 仕様です。ant は `--profile <name>` 指定時はその `<name>` に、`--profile` 省略時は `default` に、`<config_dir>/active_config` を毎回書き換えます。Anthropic の profile 解決順は Claude Code / Claude Agent SDK と共有されるため、この書き換えで Claude Code の credential 経路が subscription から従量課金 API に移ることがあります。対応:
 >
-> - `default` 以外の名前 (例: `ccgate`) で profile を作成し、ccgate.jsonnet で明示宣言する。`ant auth login` を `--profile` 指定なしで実行すると `default` profile が作られて active profile を奪うので、それを避ける。
-> - `ant auth login` の後は active profile の参照先を戻す。2 つの選択肢:
+> - `default` 以外の名前 (例: `ccgate`) で profile を作成し、ccgate.jsonnet で明示宣言する。 `ant auth login` を `--profile` 指定なしで実行すると `default` profile が作られ、 既定の参照先として使われるため、 これを避ける。
+> - `ant auth login` の後は `<config_dir>/active_config` の参照先を戻す。 2 つの選択肢:
 >   - `rm <config_dir>/active_config` で参照先を完全に消す (SDK は `default` 解決に戻る)
 >   - 普段使う profile があれば `ant profile activate <previous-profile-name>`
-> - 同じ profile を別 org / workspace に紐づけ直したい場合: ant は既に紐づいた profile への再 login を拒否するので、`<config_dir>/configs/<name>.json` を削除して `ant auth login --profile <name>` を再実行する。
+> - 同じ profile を別 org / workspace に関連付け直す場合: ant は既に関連付け済みの profile への再 login を reject するので、 `<config_dir>/configs/<name>.json` を削除して `ant auth login --profile <name>` を再実行する。
 
 ## 例
 
@@ -139,10 +139,10 @@ plain string の出力はキャッシュされず、hook 起動のたびに help
 #!/bin/sh
 # ~/bin/ccgate-key-broker.sh
 # 出力: {"key": "...", "expires_at": "<RFC3339>"} の 1 行 JSON。
-# `<rfc3339-now-plus-50m>` は実行環境で利用できる RFC3339 フォーマッタに置き換えてください。
+# `my-broker-expiry-rfc3339` は「now + helper lifetime」を RFC3339 文字列で返す任意のコマンドに置き換えてください。
 set -eu
 TOKEN=$(my-key-broker --provider anthropic)
-EXP=<rfc3339-now-plus-50m>
+EXP=$(my-broker-expiry-rfc3339)
 jq -nc --arg key "$TOKEN" --arg expires_at "$EXP" '{key:$key, expires_at:$expires_at}'
 ```
 
@@ -203,7 +203,7 @@ cache fingerprint には **カレントディレクトリもホスト名も含�
 
 `auth.path` の読み取りも exec 経路と同じく `auth.timeout_ms` (default 30000) で上限が決まります — 応答しない mount では `reason=timeout` で fallthrough します (hook はブロックしません)。とはいえ NFS / SMB / FUSE / keychain mount に置くと毎 fire `timeout_ms` 分待つコストが発生するので、user 専用のローカル path を強く推奨します。
 
-`auth.path` か cache file が現在の user 以外でも読める / 所有者が違う場合、ccgate は `slog.Warn` を出します (拒否はしません)。これは security nudge であり policy enforcement ではなく、ファイルシステムから取得できる "world-readable" 指標だけを確認し、effective access の計算は行いません。推奨は user 専用に読めるファイルを user 専用に読めるディレクトリ配下に置く構成です (POSIX 系なら `0600` のファイルを `0700` の親ディレクトリの中に置く)。
+`auth.path` か cache file が現在の user 以外でも読める / 所有者が違う場合、ccgate は `slog.Warn` を出します (拒否はしません)。これは security nudge であり policy enforcement ではなく、ファイルシステムから取得できる "world-readable" 指標だけを確認し、effective access の計算は行いません。推奨は user 専用に読めるファイルを user 専用に読めるディレクトリ配下に置く構成です。
 
 ## provider が 401/403 を返した場合の挙動
 

--- a/docs/ja/api-key-helper.md
+++ b/docs/ja/api-key-helper.md
@@ -210,12 +210,12 @@ cache fingerprint には **カレントディレクトリもホスト名も含�
 
 provider が認証情報を拒否した場合、HTTP status のみで挙動が決まります。
 
-| HTTP status         | `auth.type=exec`                                  | `auth.type=file`                          | `auth.type=profile`                                                 | env var      |
-|---------------------|---------------------------------------------------|-------------------------------------------|---------------------------------------------------------------------|--------------|
-| 401 / 403           | `provider_auth`、**キャッシュ削除して fallthrough** | `provider_auth`、fallthrough のみ (cache 無し) | `provider_auth`、fallthrough (SDK の refresh-token loop が credential を保有、ccgate cache 無し) | **exit 1**   |
-| 5xx / 429 / network | exit 1 (従来通り)                                  | exit 1                                    | exit 1                                                              | exit 1       |
+| HTTP status         | `auth.type=exec`              | `auth.type=file`               | `auth.type=profile`            | env var |
+|---------------------|-------------------------------|--------------------------------|--------------------------------|---------|
+| 401 / 403           | cache を invalidate、 fallthrough | fallthrough (cache なし)        | fallthrough                    | exit 1  |
+| 5xx / 429 / network | exit 1                        | exit 1                         | exit 1                         | exit 1  |
 
-env 経路で 401 / 403 を exit 1 にしているのは、ccgate 側で env を rotate する手段がないためです。黙って飲み込むとユーザー側の設定ミスを隠してしまいます。
+`auth.type=profile` では SDK の refresh-token loop が credential を保有しているため、 ccgate に invalidate する cache はありません。 env 経路は 401 / 403 で exit 1 になります — ccgate 側で env を rotate する手段がなく、 黙って飲み込むとユーザー側の設定ミスを隠してしまうため。
 
 キャッシュさせたくない場合は `expires_at` を含めない JSON (または plain string) を返せば、helper は毎 fire 再実行されます。
 

--- a/docs/ja/api-key-helper.md
+++ b/docs/ja/api-key-helper.md
@@ -138,9 +138,11 @@ plain string の出力はキャッシュされず、hook 起動のたびに help
 ```sh
 #!/bin/sh
 # ~/bin/ccgate-key-broker.sh
+# 出力: {"key": "...", "expires_at": "<RFC3339>"} の 1 行 JSON。
+# `<rfc3339-now-plus-50m>` は実行環境で利用できる RFC3339 フォーマッタに置き換えてください。
 set -eu
 TOKEN=$(my-key-broker --provider anthropic)
-EXP=$(date -u -v+50M +%FT%TZ 2>/dev/null || date -u -d '+50 minutes' +%FT%TZ)
+EXP=<rfc3339-now-plus-50m>
 jq -nc --arg key "$TOKEN" --arg expires_at "$EXP" '{key:$key, expires_at:$expires_at}'
 ```
 
@@ -152,24 +154,11 @@ ccgate に渡す前に `~/bin/ccgate-key-broker.sh | jq .` 等で単体動作を
 
 ### 外部ローテーター (hook 経路で helper を回さない)
 
-hook の hot path で helper を回したくない場合は、cron / launchd / systemd-timer などの外部ローテーターから同じ JSON 形をファイルに atomic rename で書き出します。
-
-```sh
-#!/bin/sh
-set -eu
-TOKEN=$(my-key-broker --provider anthropic)
-EXP=$(date -u -v+1H +%FT%TZ 2>/dev/null || date -u -d '+1 hour' +%FT%TZ)
-TMP=$(mktemp ~/.config/my-broker/anthropic.json.XXXXXX)
-jq -nc --arg key "$TOKEN" --arg expires_at "$EXP" '{key:$key, expires_at:$expires_at}' > "$TMP"
-chmod 0600 "$TMP"
-mv "$TMP" ~/.config/my-broker/anthropic.json
-```
+hook の hot path で helper を回したくない場合は、外部ローテーターから同じ JSON 形を **atomic replace** (`tmp に書き込み` → `chmod 0600 tmp` → `rename tmp <auth.path>`) で `auth.path` に置きます。ローテートはローテーター側で担当し、 ccgate は hook 起動のたびに file を読むだけです。
 
 ```jsonnet
 auth: { type: 'file', path: '~/.config/my-broker/anthropic.json' }
 ```
-
-ローテートはローテーターが担い、ccgate は hook 起動のたびにファイルを読むだけです。
 
 ## キャッシュ
 

--- a/docs/ja/api-key-helper.md
+++ b/docs/ja/api-key-helper.md
@@ -214,7 +214,7 @@ cache fingerprint には **カレントディレクトリもホスト名も含�
 
 `auth.path` の読み取りも exec 経路と同じく `auth.timeout_ms` (default 30000) で上限が決まります — 応答しない mount では `reason=timeout` で fallthrough します (hook はブロックしません)。とはいえ NFS / SMB / FUSE / keychain mount に置くと毎 fire `timeout_ms` 分待つコストが発生するので、user 専用のローカル path を強く推奨します。
 
-`auth.path` か cache file が group/other に read 権を持っている / 現在の UID と所有者が違う (Unix)、または `Everyone` / `BuiltinUsers` SID に直接 read を許す ACE を持っている (Windows) 場合、ccgate は `slog.Warn` を出します (拒否はしません)。これらは security nudge であり policy enforcement ではありません: Windows DACL walk は当該 well-known SID への allow ACE のみを見ており、deny ACE・継承・effective access は評価しません。推奨は Unix で `chmod 0600` のファイルを `chmod 0700` の親ディレクトリに置く、Windows で当該 user のみ読める ACL に設定する、です。
+`auth.path` か cache file が現在の user 以外でも読める / 所有者が違う場合、ccgate は `slog.Warn` を出します (拒否はしません)。これは security nudge であり policy enforcement ではなく、ファイルシステムから取得できる "world-readable" 指標だけを確認し、effective access の計算は行いません。推奨は user 専用に読めるファイルを user 専用に読めるディレクトリ配下に置く構成です (POSIX 系なら `0600` のファイルを `0700` の親ディレクトリの中に置く)。
 
 ## provider が 401/403 を返した場合の挙動
 
@@ -227,13 +227,6 @@ provider が認証情報を拒否した場合、HTTP status のみで挙動が�
 
 env 経路で 401 / 403 を exit 1 にしているのは、ccgate 側で env を rotate する手段がないためです。黙って飲み込むとユーザー側の設定ミスを隠してしまいます。
 
-## AWS `credential_process` / kubectl exec plugin との関係
-
-`provider.auth` は同じ系列の credential helper を意識した形ですが、どれも drop-in 互換ではありません。
-
-- **AWS `credential_process`** は `{"Version":1, "AccessKeyId", "SecretAccessKey", "SessionToken", "Expiration"}` を SigV4 用に出力し、AWS CLI は呼び出しのたびに helper を再実行します。ccgate は Authorization header (Bearer) に乗せる用の `{"key", "expires_at"}` を出力し、ディスクにキャッシュします。AWS 形式の helper を流用する場合は、フィールドを抜き出して JSON を整える薄いラッパーが必要です。
-- **kubectl exec credential plugin** は `command` と `args` を分けて指定し、`ExecCredential` 形式を出力します。ccgate は ccgate が plug-in する Claude Code / Codex hook の慣習に揃えて、shell-form の `command` 1 本と上記 JSON 形式を採用しています。
-
 キャッシュさせたくない場合は `expires_at` を含めない JSON (または plain string) を返せば、helper は毎 fire 再実行されます。
 
 ## 障害時の復旧チェックリスト
@@ -242,7 +235,7 @@ env 経路で 401 / 403 を exit 1 にしているのは、ccgate 側で env を
 2. `ccgate <target> metrics` を実行し、**Credential failures** セクションで `(source, reason)` 別の集計を確認します。
 3. キャッシュ起因 (`cache_parse` / `cache_read` / `cache_write` の log warning) が疑わしい場合は `$XDG_CACHE_HOME/ccgate/<target>/api_key.*.json` を削除して再生成させます。隣接する `*.lock` は再利用するので残しておいてください。
 4. `expired` が出続ける場合は helper の `expires_at` と `date -u` を比較してください。helper 側の TTL ロジックや時計ズレが原因のことが多いです。
-5. 新しい環境で `command_exit` が出る場合は、まず `auth.shell` で指定したシェルが `$PATH` にあるかを確認してください。Linux / macOS の `bash` は標準で入ります。`powershell` は `pwsh` (優先) または `powershell` のどちらか一方が `$PATH` で解決できれば動きます。両方とも見つからない場合、`os/exec` の lookup エラーとして `command_exit` で現れます。
+5. 新しい環境で `command_exit` が出る場合は、まず `auth.shell` で指定したシェルが `$PATH` にあるかを確認してください。`auth.shell: 'bash'` なら `bash` が、`auth.shell: 'powershell'` なら `pwsh` (優先) または `powershell` のどちらか一方が `$PATH` で解決できる必要があります。両方とも見つからない場合、`os/exec` の lookup エラーとして `command_exit` で現れます。
 6. キャッシュを削除しても `provider_auth` が繰り返される場合は、helper 自体が provider に拒否される認証情報を生成しています。ccgate と同じシェルで手動実行してください — `bash -c "$your_command"`、`auth.shell: 'powershell'` の場合は `pwsh -Command "$your_command"` / `powershell -Command "$your_command"`。SDK に渡された stdout を直接確認します。
 7. `profile_load` (`auth.type=profile`) の場合、slog の `error_class` で原因を絞れます:
    - `profile_config_missing`: `ant auth login --profile <name>` で profile を作成。

--- a/docs/ja/api-key-helper.md
+++ b/docs/ja/api-key-helper.md
@@ -249,6 +249,6 @@ env 経路で 401 / 403 を exit 1 にしているのは、ccgate 側で env を
    - `profile_config_parse` / `profile_config_invalid`: `<config_dir>/configs/<name>.json` を mode `0644` に戻すか、削除して `ant auth login --profile <name>` で作り直す。
    - `credentials_missing`: `ant auth login --profile <name>` で credentials を発行。
    - `credentials_stat_failed`: credentials file または親 dir の `os.Stat` が "missing" 以外で失敗 (権限が典型)。`<config_dir>/credentials/` を mode 0700 に戻す。
-8. `ant auth login` の後は `ant auth status` で `<config_dir>/active_config` を確認してください。Claude Code が想定外の profile を使い始めたら `rm <config_dir>/active_config` で参照先を消すか、`ant profile activate <previous-profile>` で戻します。upstream PR [anthropics/anthropic-cli#45](https://github.com/anthropics/anthropic-cli/pull/45) (`--no-activate`) がマージされれば `ant auth login` が書き換えを回避できるようになります。
+8. `ant auth login` の後は `ant auth status` で `<config_dir>/active_config` を確認してください。Claude Code が想定外の profile を使い始めたら `rm <config_dir>/active_config` で参照先を消すか、`ant profile activate <previous-profile>` で戻します。
 
 reason の網羅は [configuration.md](configuration.md#credential_unavailable-の-reason-値) にあります。

--- a/docs/ja/api-key-helper.md
+++ b/docs/ja/api-key-helper.md
@@ -84,7 +84,7 @@ ccgate は helper の env に `CCGATE_API_KEY_RESOLUTION=1` を入れるので�
 
 ### 初回ブラウザ認証
 
-`gcloud auth print-access-token`、`aws sso login`、社内 SSO 経由の key broker など、初回起動時にブラウザが開いて OAuth / SAML 認証 → 完了後 stdout に認証情報を出すタイプの helper も使えます。2 回目以降はローカルにキャッシュされた refresh token が使われ、サイレントに完了します。
+`gcloud auth print-access-token`、 `aws sso login`、 社内 SSO 経由の key broker など、 初回起動時にブラウザが開いて OAuth / SAML 認証 → 完了後 stdout に認証情報を出すタイプの helper も使えます。 2 回目以降はローカルにキャッシュされた refresh token が使われ、 silent に完了します。
 
 既定の `auth.timeout_ms` (`30000`) は非対話的な helper の大半をカバーします。ブラウザでユーザーが同意画面を操作するタイプは `120000` 程度まで上げてください。一定時間アイドル後の最初の Permission Request がブラウザ操作の完了まで待つ形になりますが、`reason=timeout` で fallthrough しなくなります。
 
@@ -95,7 +95,8 @@ Anthropic provider 専用です。公式 `ant` CLI (`ant auth login` でブラ�
 ### Quick start
 
 ```sh
-mise use -g aqua:anthropics/anthropic-cli   # または `aqua g -i anthropics/anthropic-cli`。binary は `ant`
+# `ant` CLI を任意の方法で入れる (例: `mise use -g aqua:anthropics/anthropic-cli`、
+# `aqua g -i anthropics/anthropic-cli`、 upstream の release ページから直接 download など)。
 ant auth login --profile ccgate         # ブラウザが開き ~/.config/anthropic/credentials/ccgate.json を書き出す
 # ccgate.jsonnet に追記:
 #   provider: { ..., auth: { type: 'profile', profile: 'ccgate' } }
@@ -201,7 +202,7 @@ cache fingerprint には **カレントディレクトリもホスト名も含�
 
 ## ファイル経路の注意点
 
-`auth.path` の読み取りも exec 経路と同じく `auth.timeout_ms` (default 30000) で上限が決まります — 応答しない mount では `reason=timeout` で fallthrough します (hook はブロックしません)。とはいえ NFS / SMB / FUSE / keychain mount に置くと毎 fire `timeout_ms` 分待つコストが発生するので、user 専用のローカル path を強く推奨します。
+`auth.path` の読み取りも exec 経路と同じく `auth.timeout_ms` (default 30000) で上限が決まります — 応答しない file source では `reason=timeout` で fallthrough します (hook はブロックしません)。 ネットワーク経由や仮想 file source に置くと毎 fire `timeout_ms` 分待つコストが発生するので、 user 専用のローカル path を強く推奨します。
 
 `auth.path` か cache file が現在の user 以外でも読める / 所有者が違う場合、ccgate は `slog.Warn` を出します (拒否はしません)。これは security nudge であり policy enforcement ではなく、ファイルシステムから取得できる "world-readable" 指標だけを確認し、effective access の計算は行いません。推奨は user 専用に読めるファイルを user 専用に読めるディレクトリ配下に置く構成です。
 

--- a/docs/ja/api-key-helper.md
+++ b/docs/ja/api-key-helper.md
@@ -90,7 +90,7 @@ ccgate は helper の env に `CCGATE_API_KEY_RESOLUTION=1` を入れるので�
 
 ## Profile ベース認証 (Anthropic のみ)
 
-Anthropic provider 専用です。公式 `ant` CLI (`ant auth login` でブラウザ OAuth、`ant profile activate <name>` で active profile を切り替え) が `<config_dir>/credentials/<name>.json` (mode 0600) に credentials を書き出します。`<config_dir>` の既定は `~/.config/anthropic`。Anthropic の profile 解決順 (`$ANTHROPIC_PROFILE` → `<config_dir>/active_config` → `"default"`) は Go SDK / Claude Code / Claude Agent SDK で **共有** されます ([wif-reference doc](https://platform.claude.com/docs/en/api/authentication/wif-reference))。access token の refresh は SDK 自身が行うため、ccgate は credential 経路には立ち入りません — ただし SDK の static-credential 用 env autoload (`ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN`) は無効化するので、残っている env var が、宣言した profile を silent に上書きすることはありません。Workload Identity Federation は `authentication.type=oidc_federation` を含む profile config 経由のみ対応 (env だけで WIF を構成する経路は本リリースの範囲外)。
+Anthropic provider 専用です。公式 `ant` CLI (`ant auth login` でブラウザ OAuth、`ant profile activate <name>` で active profile を切り替え) が `<config_dir>/credentials/<name>.json` (mode 0600) に credentials を書き出します。`<config_dir>` の既定は `~/.config/anthropic`。Anthropic の profile 解決順 (`$ANTHROPIC_PROFILE` → `<config_dir>/active_config` → `"default"`) は Go SDK / Claude Code / Claude Agent SDK で **共有** されます ([wif-reference doc](https://platform.claude.com/docs/en/api/authentication/wif-reference))。access token の refresh は SDK 自身が行うため、ccgate は credential 経路には立ち入りません — ただし SDK の static-credential 用 env autoload (`ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN`) は無効化するので、残っている env var が、宣言した profile を silent に上書きすることはありません。Workload Identity Federation は `authentication.type=oidc_federation` を含む profile config 経由のみ対応。
 
 ### Quick start
 
@@ -110,7 +110,7 @@ ant auth login --profile ccgate         # ブラウザが開き ~/.config/anthro
 > - `ant auth login` の後は `<config_dir>/active_config` の参照先を戻す。 2 つの選択肢:
 >   - `rm <config_dir>/active_config` で参照先を完全に消す (SDK は `default` 解決に戻る)
 >   - 普段使う profile があれば `ant profile activate <previous-profile-name>`
-> - 同じ profile を別 org / workspace に関連付け直す場合: ant は既に関連付け済みの profile への再 login を reject するので、 `<config_dir>/configs/<name>.json` を削除して `ant auth login --profile <name>` を再実行する。
+> - 同じ profile を別 org / workspace に関連付け直す場合: ant は既に関連付け済みの profile への再 login を拒否するので、 `<config_dir>/configs/<name>.json` を削除して `ant auth login --profile <name>` を再実行する。
 
 ## 例
 

--- a/docs/ja/api-key-helper.md
+++ b/docs/ja/api-key-helper.md
@@ -1,15 +1,18 @@
-# 期限付き・自動更新される API キー
+# Refresh される credential
 
 [English version (docs/api-key-helper.md)](../api-key-helper.md)
 
-provider に渡す認証情報が静的な環境変数では追いつかない頻度で入れ替わる場合 (AWS STS セッション、Vertex ADC、OpenAI 互換 gateway の virtual key、社内 key broker など) は、`*_API_KEY` の代わりに `provider.auth` で取得します。
+provider に渡す credential が静的な環境変数では追いつかない頻度で入れ替わる場合 (AWS STS セッション、Vertex ADC、OpenAI 互換 gateway の virtual key、社内 key broker など) は、`*_API_KEY` の代わりに `provider.auth` で取得します。
 
-`provider.auth` には 2 つのモードがあります。
+`provider.auth` には 3 つのモードがあります。
 
-- **`type: 'exec'`**: ccgate がシェルコマンドを実行し、その stdout を認証情報として使います。
-- **`type: 'file'`**: 外部のローテーター (cron / launchd など) が書いたファイルを ccgate が読みます。
+- **`type: 'exec'`**: ccgate がシェルコマンドを実行し、その stdout を credential として使う。
+- **`type: 'file'`**: 外部のローテーター (cron / launchd など) が書いたファイルを ccgate が読む。
+- **`type: 'profile'`**: Anthropic 専用。`ant auth login` の profile を anthropic-sdk-go に渡し、refresh は SDK 自身が担当する。[Profile ベース認証](#profile-ベース認証-anthropic-のみ) を参照。
 
-Linux / macOS / *BSD / Windows に対応します。helper コマンドを動かすシェルは `auth.shell` で選択 (default `bash`)。bash が入っていない Windows では `shell: 'powershell'` を指定してください。
+(`*_API_KEY` env var は `provider.auth` が省略されている場合の別経路。`auth` のモードではありません。)
+
+`exec` の helper を動かすシェルは `auth.shell` で選択 (default `bash`)。詳細は [helper の契約](#helper-の契約) を参照。
 
 ## 設定
 
@@ -47,7 +50,7 @@ Linux / macOS / *BSD / Windows に対応します。helper コマンドを動か
 |---|---|---|---|
 | `auth.type` | `"exec"` / `"file"` / `"profile"` | (`auth` を書くなら必須) | 取得モード。`profile` は Anthropic 専用、[Profile ベース認証](#profile-ベース認証-anthropic-のみ) を参照 |
 | `auth.command` | string | `""` | (`exec` 専用、必須) シェルコマンド。stdout が認証情報 |
-| `auth.shell` | `"bash"` / `"powershell"` | `"bash"` | (`exec` 専用) `powershell` は `pwsh` を優先解決、無ければ `powershell` に fallback |
+| `auth.shell` | `"bash"` / `"powershell"` | `"bash"` | (`exec` 専用) `auth.command` を実行するシェル。`powershell` は `pwsh` を優先解決、無ければ `powershell` に fallback |
 | `auth.path` | string | `$XDG_STATE_HOME/ccgate/<target>/auth_key.json` | (`file` 専用) 認証情報ファイルのパス。省略でデフォルトを使用 |
 | `auth.profile` | string | `""` | (`profile` 専用) Anthropic profile 名 (`ant auth login --profile <name>` が `<config_dir>/credentials/<name>.json` に書く値)。空 / 省略時は SDK が `$ANTHROPIC_PROFILE` → `<config_dir>/active_config` → `"default"` を解決 |
 | `auth.refresh_margin_ms` | int (ms) | `60000` | `expires_at` の何 ms 前で期限切れ扱いにするか。`0` で無効。(`exec` / `file` 専用 — `profile` は SDK が refresh を担当するので無視) |
@@ -108,7 +111,6 @@ ant auth login --profile ccgate         # ブラウザが開き ~/.config/anthro
 >   - `rm <config_dir>/active_config` で参照先を完全に消す (SDK は `default` 解決に戻る)
 >   - 普段使う profile があれば `ant profile activate <previous-profile-name>`
 > - 同じ profile を別 org / workspace に紐づけ直したい場合: ant は既に紐づいた profile への再 login を拒否するので、`<config_dir>/configs/<name>.json` を削除して `ant auth login --profile <name>` を再実行する。
-> - upstream の `--no-activate` flag (upstream PR [anthropics/anthropic-cli#45](https://github.com/anthropics/anthropic-cli/pull/45)) がマージされれば、`ant auth login --profile <name> --no-activate` で書き換え自体を回避できるようになる。
 
 ## 例
 

--- a/docs/ja/claude.md
+++ b/docs/ja/claude.md
@@ -69,7 +69,7 @@ allow guidance は plan mode で write 操作を allow に promote しません�
 - ユーザーが直近の transcript で当該操作を明示的に依頼していた場合、`deny` より `allow` / `fallthrough` を優先せよ
 - ユーザーの明示依頼は `deny` を `fallthrough` に引き上げられるが、`allow` までは引き上げられない (deny guidance は依然として勝つ)
 
-これが LLM に「deny ルールに該当するが、ユーザーが明確に依頼してるので、refuse せず Claude Code の prompt に判断を委ねる」と言わせる唯一の signal です。Codex には現状 transcript field が無いので、この lever は Claude のみ。
+これが LLM に「deny ルールに該当するが、ユーザーが明確に依頼してるので、refuse せず Claude Code の prompt に判断を委ねる」と言わせる唯一の signal です。
 
 ## `settings.json` パターンが whitelist 要件ではない理由
 

--- a/docs/ja/claude.md
+++ b/docs/ja/claude.md
@@ -60,7 +60,7 @@ Claude Code は標準 PermissionRequest payload を流します ([upstream hooks
 
 allow guidance は plan mode で write 操作を allow に promote しません。deny guidance は依然として有効で、read-only 操作も override できます。
 
-完全に prompt-driven なので hard guarantee なし。[#37](https://github.com/tak848/ccgate/issues/37) で追跡。
+完全に prompt-driven なので hard guarantee なし。
 
 ## `recent_transcript` の使われ方
 
@@ -93,10 +93,8 @@ allow guidance は plan mode で write 操作を allow に promote しません�
 | State path                        | `$XDG_STATE_HOME/ccgate/claude/` (未設定なら `~/.local/state/ccgate/claude/`)                                                              |
 | Project-local config              | `{repo_root}/.claude/ccgate.local.jsonnet` (Git 未追跡のみ)                                                                                |
 
-Codex 側の同等項目は [codex.md](codex.md) を参照。
+## 制約
 
-## 既知の制約
-
-- **Plan mode はプロンプト依存** ([#37](https://github.com/tak848/ccgate/issues/37))
+- **Plan mode は prompt-only**: `permission_mode == "plan"` では (a) 実装系 write を拒絶する判定と (b) 明示的な allow guidance なしの read-only クエリ許可の両方を、LLM とシステムプロンプトの指示文に委ねている。どちらの方向にも誤判定の余地あり
 - **embedded default の特定ルールだけを部分削除する手段なし**: layer は list を **完全置換** (`allow: [...]`) するか **末尾追加** (`append_allow: [...]`) するかのどちらかで、embedded の中の 1 ルールだけ消したい場合は残り全部を `allow:` / `deny:` に書き直すしかない
-- **`settings.json` の deny パターンに対する deterministic short-circuit なし**: ccgate はすべての Claude Code PermissionRequest を LLM に通します。literal な `settings.json` deny match で ccgate を early exit する経路はありません
+- **`settings.json` の deny パターンに対する deterministic short-circuit なし**: ccgate はすべての Claude Code PermissionRequest を LLM に通す。literal な `settings.json` deny match で ccgate を early exit する経路はない

--- a/docs/ja/claude.md
+++ b/docs/ja/claude.md
@@ -41,9 +41,11 @@ ccgate は Claude Code の [PermissionRequest hook](https://code.claude.com/docs
 Claude Code は標準 PermissionRequest payload を流します ([upstream hooks reference](https://code.claude.com/docs/en/hooks))。ccgate が読むのは:
 
 - `tool_name`: ユーザー操作専用 tool (`ExitPlanMode`, `AskUserQuestion`) は早期に処理を終え、常に Claude Code の確認 prompt に委ねます。ccgate はこれらを判定しません
-- `tool_input`: LLM に転送。metrics 層は `command` / `file_path` / `path` / `pattern` のみ記録
+- `tool_input`: typed object として LLM に転送。metrics 層は `command` / `file_path` / `path` / `pattern` のみ記録
+- `tool_input_raw`: 元の `tool_input` JSON をそのまま LLM に渡します。typed view から漏れる field (ネストされた MCP 引数など) もここから読めます
+- `referenced_paths`: `tool_input` から best-effort で抽出した path のリスト。対象 tool は `Read` / `Write` / `Edit` / `MultiEdit` / `Glob` / `Grep` / `Bash` のみ。それ以外の tool (MCP / user-interaction tool) では空。LLM は `tool_input_raw` から raw payload を直接読めます
 - `permission_mode`: `"plan"` のとき system prompt を plan mode rule に切替。`"bypassPermissions"` / `"dontAsk"` は ccgate を fallthrough で短絡
-- `cwd`: git context builder (`gitutil.RepoRoot`, branch, worktree) に渡す
+- `cwd`: git context builder (`gitutil.RepoRoot`, branch, worktree) に渡す。working tree の dirty/clean は渡しません
 - `transcript_path`: recent-transcript loader が末尾 N 件を読み、ユーザー意図 context として LLM に渡す
 - `permission_suggestions`: LLM に背景情報として転送
 - `settings_permissions`: ccgate が `~/.claude/settings.json` を別途読み、ユーザー定義の static allow / deny / ask パターンを LLM に hint として渡す (whitelist 必須ではない、後述「settings.json パターンが whitelist 要件ではない理由」参照)
@@ -79,22 +81,22 @@ allow guidance は plan mode で write 操作を allow に promote しません�
 
 → `settings_permissions.allow` を whitelist 要件として扱うと hook の通常動作が壊れます。ccgate はあくまでユーザー嗜好のヒントとしてのみ使い、`settings_permissions.allow` に存在しないリクエストでも LLM が allow できる設計です。
 
-## Codex CLI との挙動差分
+## Claude 固有の HookInput / state リファレンス
 
-| 観点                                | Claude Code                                        | Codex CLI                                                                                  |
-|-------------------------------------|----------------------------------------------------|--------------------------------------------------------------------------------------------|
-| Tool surface                        | `Bash`, `Read`, `Write`, `Edit`, `Glob`, MCP, ...  | `Bash`, `apply_patch`, MCP, ...                                                             |
-| `permission_mode`                   | `default` / `acceptEdits` / `plan` / `bypassPermissions` / `dontAsk` | 現状 deliver されない                                                |
-| `recent_transcript`                 | LLM に転送                                          | deliver されない。LLM は `tool_name` + `tool_input` + `cwd` のみで判断                       |
-| `settings_permissions`              | 背景 hint として転送                                | 等価物なし。`~/.codex/config.toml` は取り込まない                                            |
-| `permission_suggestions`            | 転送                                                | deliver されない                                                                              |
-| State path                          | `$XDG_STATE_HOME/ccgate/claude/`                   | `$XDG_STATE_HOME/ccgate/codex/`                                                              |
-| Project-local config                | `{repo_root}/.claude/ccgate.local.jsonnet`         | `{repo_root}/.codex/ccgate.local.jsonnet`                                                    |
+| 観点                              | 値                                                                                                                                       |
+|-----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| Tool surface                      | `Bash`, `Read`, `Write`, `Edit`, `MultiEdit`, `Glob`, `Grep`, MCP, ユーザー操作 tool (`ExitPlanMode`, `AskUserQuestion`)                  |
+| `permission_mode` の値            | `default` / `acceptEdits` / `plan` / `bypassPermissions` / `dontAsk`。`plan` は system prompt を切替、`bypassPermissions` / `dontAsk` は fallthrough |
+| `recent_transcript`               | `transcript_path` から読み込み、ユーザー意図 context として LLM に渡す (上の「`recent_transcript` の使われ方」参照)                       |
+| `settings_permissions`            | hint として LLM に渡す (上の「`settings.json` パターンが whitelist 要件ではない理由」参照)                                                |
+| `permission_suggestions`          | そのまま LLM に転送                                                                                                                       |
+| State path                        | `$XDG_STATE_HOME/ccgate/claude/` (未設定なら `~/.local/state/ccgate/claude/`)                                                              |
+| Project-local config              | `{repo_root}/.claude/ccgate.local.jsonnet` (Git 未追跡のみ)                                                                                |
 
-Codex 側の詳細は [codex.md](codex.md) を参照。
+Codex 側の同等項目は [codex.md](codex.md) を参照。
 
 ## 既知の制約
 
 - **Plan mode はプロンプト依存** ([#37](https://github.com/tak848/ccgate/issues/37))
 - **embedded default の特定ルールだけを部分削除する手段なし**: layer は list を **完全置換** (`allow: [...]`) するか **末尾追加** (`append_allow: [...]`) するかのどちらかで、embedded の中の 1 ルールだけ消したい場合は残り全部を `allow:` / `deny:` に書き直すしかない
-- **`settings.json` の deny パターンに対する deterministic short-circuit なし**: ccgate は現状すべての Claude Code PermissionRequest を LLM に通します。literal な `settings.json` deny match で early exit する deterministic prefilter は将来の最適化候補で、現時点の挙動ではありません
+- **`settings.json` の deny パターンに対する deterministic short-circuit なし**: ccgate はすべての Claude Code PermissionRequest を LLM に通します。literal な `settings.json` deny match で ccgate を early exit する経路はありません

--- a/docs/ja/codex.md
+++ b/docs/ja/codex.md
@@ -6,8 +6,8 @@
 
 ## ステータス
 
-- **upstream schema を一次情報とする**: Codex hooks は `[features] codex_hooks = true` flag 配下にあります。OpenAI の [Codex hooks docs](https://developers.openai.com/codex/hooks) を authoritative として参照し、特定 field に依存する前に再確認してください
-- **Tool-agnostic**: Codex hooks は Bash、`apply_patch`、MCP tool 呼び出しなど複数の surface で発火します。ccgate は `tool_name` + `tool_input` JSON 全体で分類
+- Codex hooks は `[features] codex_hooks = true` の設定が必要です。 upstream の payload schema は [OpenAI Codex hooks docs](https://developers.openai.com/codex/hooks) を参照。
+- **Tool-agnostic**: Codex hooks は Bash、 `apply_patch`、 MCP tool 呼び出しなど複数の surface で発火します。 ccgate は `tool_name` + `tool_input` JSON 全体で分類。
 
 ## hook 登録
 
@@ -90,7 +90,7 @@ project-local の `<repo>/.codex/{hooks.json,config.toml}` は、project が tru
 
 ccgate は `tool_input` の JSON 全体をそのまま LLM に渡します。そのため、ccgate 側に専用フィールドのない MCP arguments や `apply_patch` の hunk metadata も判定対象に含まれます。metrics には parsed view (`command` / `description` / `file_path` / `path` / `pattern`) だけを書きますが、LLM に渡す内容から raw payload を削ることはありません。
 
-upstream Codex docs に記載があり ccgate が利用するフィールド:
+ccgate が Codex HookInput から読むフィールド:
 
 - `session_id`
 - `transcript_path` (path のみ; ccgate は transcript JSONL を parse しない)

--- a/docs/ja/codex.md
+++ b/docs/ja/codex.md
@@ -113,12 +113,6 @@ Codex 側の system prompt は LLM に `tool_name` + `tool_input` + `tool_input_
 | State path                | `$XDG_STATE_HOME/ccgate/codex/` (未設定なら `~/.local/state/ccgate/codex/`)                       |
 | Project-local config      | `{repo_root}/.codex/ccgate.local.jsonnet` (Git 未追跡のみ、project trust が必要)                 |
 
-## デフォルトスナップショット
+## 埋込デフォルト
 
-埋込 Codex defaults (`internal/cmd/codex/defaults.jsonnet`) は Codex の tool surface に合わせた allow / deny / environment guidance を持ちます。主要エントリ:
-
-- `allow`: 読み取り専用の Bash 検査、workspace 内の write (`apply_patch` の cwd / repo_root 配下の hunk、AI が現在編集しているプロジェクトファイル)、project script による build / test、リポジトリ内に閉じたパッケージインストール、feature branch 上の git 操作、ユーザーが信頼した MCP server で、影響範囲がユーザーの許可した範囲に収まる MCP tool
-- `deny`: remote content の pipe-to-shell、one-shot remote package execution (`npx` / `pnpx` / `bunx` で unfamiliar package)、`sudo`、workspace 外への `rm -rf` / `mv` / `apply_patch` hunks、protected branch への破壊的 git、無制限 network out (`nc` / `ssh` / `scp` / `ftp` の非 allowlist 先)、destructive side effect を advertise する MCP tool で per-rule allow なし
-- `environment`: heterogeneous tool surface、trusted-repo 境界、path scope ルール。ccgate は upstream の承認 prompt を置き換えるため、guidance が適用できるときは allow / deny を返し、fallthrough は真に曖昧なケースに留めます。Codex hooks には `recent_transcript` が deliver されないため、system prompt は LLM にその context を仮定しないよう伝えます
-
-workspace 内 `apply_patch` を `allow` に置いているのは、ユーザーが ccgate を入れた目的が repo 内編集の prompt を省略することだからです。workspace 外への apply_patch hunk は既存の deny rule でブロックされます。より保守的にしたい場合は、project-local rule で apply_patch の allow scope を狭めてください (specific subtree のみ等)。
+`ccgate codex init | less` で binary に同梱された allow / deny / environment guidance の中身を読めます。 拡張・置換の方法は [docs/ja/rule-tuning.md](rule-tuning.md) を参照。

--- a/docs/ja/codex.md
+++ b/docs/ja/codex.md
@@ -6,7 +6,7 @@
 
 ## ステータス
 
-- **hook schema は変わる可能性あり**: Codex hooks 自体が upstream で進化中で、`features.codex_hooks = true` flag 配下にあります。OpenAI の [Codex hooks docs](https://developers.openai.com/codex/hooks) を一次情報として参照し、特定 field に依存する前に再確認してください
+- **upstream schema を一次情報とする**: Codex hooks は `[features] codex_hooks = true` flag 配下にあります。OpenAI の [Codex hooks docs](https://developers.openai.com/codex/hooks) を authoritative として参照し、特定 field に依存する前に再確認してください
 - **Tool-agnostic**: Codex hooks は Bash、`apply_patch`、MCP tool 呼び出しなど複数の surface で発火します。ccgate は `tool_name` + `tool_input` JSON 全体で分類
 
 ## hook 登録
@@ -49,7 +49,7 @@ Codex 設定全体を 1 ファイルにまとめたい場合:
 
 ```toml
 [features]
-codex_hooks = true   # 必須: Codex hooks はこの feature flag 配下に置かれている
+codex_hooks = true   # Codex hooks はこの feature flag 配下にあるため、互換性のため明示しておく
 
 [[hooks.PermissionRequest]]
 matcher = ""
@@ -99,21 +99,26 @@ upstream Codex docs に記載があり ccgate が利用するフィールド:
 - `model` (AI 側のモデル、例: `gpt-5`)
 - `turn_id`
 - `tool_name` (`Bash`, `apply_patch`, `mcp__<server>__<tool>`, ...)
-- `tool_input` (typed view + raw forward)
+- `tool_input` (typed view)
+- `tool_input_raw` (元の JSON payload をそのまま LLM に転送 — `apply_patch` の hunk や MCP 引数を見るときの主経路)
+- `referenced_paths` (`tool_input` から best-effort で抽出した path リスト。Codex では `Bash` のみ対応。`apply_patch` と MCP は `tool_input_raw` を LLM が直接読む)
 
-Codex は Claude の `permission_mode` / `permission_suggestions` / `recent_transcript` / `settings_permissions` を deliver しません。system prompt は LLM に「ここに recent_transcript は無い -- `tool_name` + `tool_input` + `cwd` のみで判断せよ」と明示的に伝え、存在しない context を捏造しないようにしています。
+Codex は Claude の `permission_mode` / `permission_suggestions` / `recent_transcript` / `settings_permissions` を deliver しません。system prompt は LLM に `tool_name` + `tool_input` + `tool_input_raw` + `cwd` のみで判断するよう指示し、存在しない context を捏造しないようにしています。
+
+## Codex 固有の state リファレンス
+
+| 観点                      | 値                                                                                                |
+|---------------------------|---------------------------------------------------------------------------------------------------|
+| Tool surface              | `Bash`, `apply_patch`, MCP (`mcp__<server>__<tool>`)。Codex hooks は tool 種別に関わらず全 PermissionRequest で発火 |
+| State path                | `$XDG_STATE_HOME/ccgate/codex/` (未設定なら `~/.local/state/ccgate/codex/`)                       |
+| Project-local config      | `{repo_root}/.codex/ccgate.local.jsonnet` (Git 未追跡のみ、project trust が必要)                 |
 
 ## デフォルトスナップショット
 
-ccgate は埋込 Codex defaults (`internal/cmd/codex/defaults.jsonnet`) を持ち、Claude 側と同じ allow + deny + environment 構造です。Codex 固有の主要エントリ:
+埋込 Codex defaults (`internal/cmd/codex/defaults.jsonnet`) は Codex の tool surface に合わせた allow / deny / environment guidance を持ちます。主要エントリ:
 
-- `allow`: 読み取り専用の Bash 検査、workspace 内の write (`apply_patch` の cwd / repo_root 配下のハンク、AI が現在編集しているプロジェクトファイル)、project script による build / test、リポジトリ内に閉じたパッケージインストール、feature branch 上の git 操作、ユーザーが信頼した MCP server で、影響範囲がユーザーの許可した範囲に収まる MCP tool
+- `allow`: 読み取り専用の Bash 検査、workspace 内の write (`apply_patch` の cwd / repo_root 配下の hunk、AI が現在編集しているプロジェクトファイル)、project script による build / test、リポジトリ内に閉じたパッケージインストール、feature branch 上の git 操作、ユーザーが信頼した MCP server で、影響範囲がユーザーの許可した範囲に収まる MCP tool
 - `deny`: remote content の pipe-to-shell、one-shot remote package execution (`npx` / `pnpx` / `bunx` で unfamiliar package)、`sudo`、workspace 外への `rm -rf` / `mv` / `apply_patch` hunks、protected branch への破壊的 git、無制限 network out (`nc` / `ssh` / `scp` / `ftp` の非 allowlist 先)、destructive side effect を advertise する MCP tool で per-rule allow なし
-- `environment`: heterogeneous tool surface、trusted-repo 境界、path scope ルール、**ccgate は upstream prompt の代替** -- 真に曖昧なときだけ fallthrough、それ以外は allow / deny を返す、`recent_transcript` は不在
+- `environment`: heterogeneous tool surface、trusted-repo 境界、path scope ルール。ccgate は upstream の承認 prompt を置き換えるため、guidance が適用できるときは allow / deny を返し、fallthrough は真に曖昧なケースに留めます。Codex hooks には `recent_transcript` が deliver されないため、system prompt は LLM にその context を仮定しないよう伝えます
 
-workspace 内 `apply_patch` は意図的に `allow` に**含めています**: Claude Code の Edit/Write が ccgate を通る際と同じ bar で、ユーザーが ccgate を入れた目的はまさに repo 内編集の prompt を省略することだからです。workspace 外への apply_patch hunk は既存の deny rule でブロックされます。より保守的にしたい場合は、project-local rule で apply_patch の allow scope を狭めてください (specific subtree のみ等)。
-
-## Claude Code との挙動差分
-
-完全な表は [claude.md](claude.md) を参照。
-
+workspace 内 `apply_patch` を `allow` に置いているのは、ユーザーが ccgate を入れた目的が repo 内編集の prompt を省略することだからです。workspace 外への apply_patch hunk は既存の deny rule でブロックされます。より保守的にしたい場合は、project-local rule で apply_patch の allow scope を狭めてください (specific subtree のみ等)。

--- a/docs/ja/codex.md
+++ b/docs/ja/codex.md
@@ -4,7 +4,7 @@
 
 `ccgate codex` フック専用のドキュメント。
 
-## ステータス
+## 前提
 
 - Codex hooks は `[features] codex_hooks = true` の設定が必要です。 upstream の payload schema は [OpenAI Codex hooks docs](https://developers.openai.com/codex/hooks) を参照。
 - **Tool-agnostic**: Codex hooks は Bash、 `apply_patch`、 MCP tool 呼び出しなど複数の surface で発火します。 ccgate は `tool_name` + `tool_input` JSON 全体で分類。

--- a/docs/ja/codex.md
+++ b/docs/ja/codex.md
@@ -103,7 +103,7 @@ upstream Codex docs に記載があり ccgate が利用するフィールド:
 - `tool_input_raw` (元の JSON payload をそのまま LLM に転送 — `apply_patch` の hunk や MCP 引数を見るときの主経路)
 - `referenced_paths` (`tool_input` から best-effort で抽出した path リスト。Codex では `Bash` のみ対応。`apply_patch` と MCP は `tool_input_raw` を LLM が直接読む)
 
-Codex は Claude の `permission_mode` / `permission_suggestions` / `recent_transcript` / `settings_permissions` を deliver しません。system prompt は LLM に `tool_name` + `tool_input` + `tool_input_raw` + `cwd` のみで判断するよう指示し、存在しない context を捏造しないようにしています。
+Codex 側の system prompt は LLM に `tool_name` + `tool_input` + `tool_input_raw` + `cwd` で判断するよう指示し、 HookInput に存在しない context を捏造しないようにしています。
 
 ## Codex 固有の state リファレンス
 

--- a/docs/ja/configuration.md
+++ b/docs/ja/configuration.md
@@ -37,8 +37,6 @@ ccgate は target ごとに以下の層を順に読み込みます。各層は�
 
 `allow` と `append_allow` (他 list も同じ) は同じ layer に共存可能 — 先に置換、その結果に対して append が積まれる。embedded の list を厳選版に **差し替えつつ** プロジェクト固有のルールを **追加** したいときに使います: `{ allow: ['only this base'], append_allow: ['plus this project rule'] }`。
 
-> v0.6 以前の ccgate はグローバル設定が存在すると埋込デフォルトをスキップしていました (グローバル層が「置換」していた)。v0.6 では embedded を常にベースとして適用しつつ、明示的な opt-in 拡張として `append_*` を導入しています。詳細は [#38](https://github.com/tak848/ccgate/issues/38) を参照。v0.6 以前のグローバル設定 (もともと `allow:` / `deny:` で完全置換していた) は無編集で同じ挙動になります。v0.6 以前のプロジェクトローカル設定で `allow:` / `deny:` / `environment:` を **追加** 目的で使っていた人だけ、`append_allow:` / `append_deny:` / `append_environment:` への rename が必要です (そのままだと累積 list を完全置換してしまいます)。
-
 ### tracked file が無視される理由
 
 プロジェクトローカル設定は意図的に **git で tracked されていない場合のみ load** します。これは「個人 contributor が共有ベースラインの上に自分の制限を重ねる」用途を想定しているためで、ローカル設定経由でチーム全体ポリシーを repo に密かに混入させない狙いです。
@@ -197,5 +195,5 @@ cache 層の失敗は fallthrough せずに自動回復するので、`slog.Warn
 
 - **Plan mode (Claude のみ) はプロンプト依存**: `permission_mode == "plan"` では (a) 実装系 write を拒絶する判定と (b) 明示的な allow guidance なしの read-only クエリ許可 を、LLM とシステムプロンプトの指示文に委ねています。どちらの方向にも誤判定の余地あり。[#37](https://github.com/tak848/ccgate/issues/37) で追跡
 - **embedded default の特定ルールだけを部分削除する手段なし**: layer は list を **完全置換** (`allow: [...]`) するか **末尾追加** (`append_allow: [...]`) するかのどちらかで、embedded の中の 1 ルールだけ消したい場合は残り全部を `allow:` / `deny:` に書き直すしかない
-- **Codex hook の schema は変わる可能性あり**: Codex hooks 自体が upstream の `features.codex_hooks = true` flag 配下にあり、まだ進化中です
-- **Codex `~/.codex/config.toml` 取り込み未実装** (`approval_policy`, `sandbox_mode`, `prefix_rules`): ccgate は hook payload + ccgate config だけで判定するため、Codex 自身の設定が拒絶するはずだった操作のシグナルは LLM に届かない (現状)
+- **Codex hook の schema は upstream-driven**: Codex hooks は upstream の `[features] codex_hooks = true` flag 配下にあり、[OpenAI Codex hooks docs](https://developers.openai.com/codex/hooks) を一次情報として扱う
+- **Codex `~/.codex/config.toml` 取り込みは未対応** (`approval_policy`, `sandbox_mode`, `prefix_rules`): ccgate は hook payload + ccgate config だけで判定するため、Codex 自身の設定が拒絶するはずだった操作のシグナルは LLM に届かない

--- a/docs/ja/configuration.md
+++ b/docs/ja/configuration.md
@@ -33,7 +33,7 @@ ccgate は target ごとに以下の層を順に読み込みます。各層は�
 | list: `allow` / `deny` / `environment` | 値を設定した layer が前の layer から引き継いだ list を **置き換える** (`[]` でも置換)。設定していない layer は前の値を保持 | embedded `allow: ["A","B"]` + global `allow: ["X"]` → 最終 `allow: ["X"]` |
 | list: `append_allow` / `append_deny` / `append_environment` | 値を設定した layer が前の layer の累積 list の **末尾に追加** | embedded `deny: ["A"]` + project `append_deny: ["P"]` → 最終 `deny: ["A","P"]` |
 | スカラー: `log_*` / `metrics_*` / `fallthrough_strategy` | 各 layer が値を設定していれば per-field で **overwrite**、設定していなければ前の値を保持 | embedded `log_max_size: 5MB` + global `log_max_size: 10MB` → 最終 `log_max_size: 10MB` |
-| ブロック: `provider` (`provider.*` の全 field — `name` / `model` / `base_url` / `auth` / `timeout_ms`) | `provider` を書いた layer は **block 全体を置換**、書かなかった layer はそのまま継承。per-field merge にすると、下位 layer の proxy 用 `base_url` や helper 用 `auth.command` が `name` を切り替えただけの上位 layer に残る等の不整合が起きるため | embedded `provider: {name: anthropic, model: haiku}` + global `provider: {name: openai, model: gpt-5.4-nano-2026-03-17}` → 最終 `provider: {name: openai, model: gpt-5.4-nano-2026-03-17}`。model だけ変えたい場合は `provider: {name: anthropic, model: claude-sonnet-4-6}` のように block 全体を書き直す。global で `auth` を設定している場合、project-local 側で `provider` を上書きするときも `auth` ブロック全体を忘れずに書き写すこと (書き漏らすと当該プロジェクトで helper 設定が静かに消える) |
+| ブロック: `provider` (`provider.*` の全 field — `name` / `model` / `base_url` / `auth` / `timeout_ms`) | `provider` を書いた layer は **block 全体を置換**、書かなかった layer はそのまま継承。per-field merge にすると、下位 layer の proxy 用 `base_url` や helper 用 `auth.command` が `name` を切り替えただけの上位 layer に残る等の不整合が起きるため | embedded `provider: {name: anthropic, model: claude-haiku-4-5}` + global `provider: {name: openai, model: gpt-4o-mini}` → 最終 `provider: {name: openai, model: gpt-4o-mini}`。model だけ変えたい場合は `provider: {name: anthropic, model: claude-sonnet-4-6}` のように block 全体を書き直す。global で `auth` を設定している場合、project-local 側で `provider` を上書きするときも `auth` ブロック全体を忘れずに書き写すこと (書き漏らすと当該プロジェクトで helper 設定が静かに消える) |
 
 `allow` と `append_allow` (他 list も同じ) は同じ layer に共存可能 — 先に置換、その結果に対して append が積まれる。embedded の list を厳選版に **差し替えつつ** プロジェクト固有のルールを **追加** したいときに使います: `{ allow: ['only this base'], append_allow: ['plus this project rule'] }`。
 
@@ -219,7 +219,6 @@ cache 層の失敗は fallthrough せずに自動回復するので、`slog.Warn
 
 ## 既知の制約
 
-- **Plan mode (Claude のみ) はプロンプト依存**: `permission_mode == "plan"` では (a) 実装系 write を拒絶する判定と (b) 明示的な allow guidance なしの read-only クエリ許可 を、LLM とシステムプロンプトの指示文に委ねています。どちらの方向にも誤判定の余地あり。[#37](https://github.com/tak848/ccgate/issues/37) で追跡
+- **Plan mode (Claude のみ) はプロンプト依存**: `permission_mode == "plan"` では (a) 実装系 write を拒絶する判定と (b) 明示的な allow guidance なしの read-only クエリ許可 を、LLM とシステムプロンプトの指示文に委ねています。どちらの方向にも誤判定の余地あり
 - **embedded default の特定ルールだけを部分削除する手段なし**: layer は list を **完全置換** (`allow: [...]`) するか **末尾追加** (`append_allow: [...]`) するかのどちらかで、embedded の中の 1 ルールだけ消したい場合は残り全部を `allow:` / `deny:` に書き直すしかない
-- **Codex hook の schema は upstream-driven**: Codex hooks は upstream の `[features] codex_hooks = true` flag 配下にあり、[OpenAI Codex hooks docs](https://developers.openai.com/codex/hooks) を一次情報として扱う
-- **Codex `~/.codex/config.toml` 取り込みは out of scope** (`approval_policy`, `sandbox_mode`, `prefix_rules`): ccgate は hook payload + ccgate config だけで判定するため、Codex 自身の設定が拒絶する操作のシグナルは LLM に届かない
+- ccgate は hook payload と ccgate の設定からのみ判定する。Codex hooks は `[features] codex_hooks = true` flag が必要 (schema 詳細は [OpenAI Codex hooks docs](https://developers.openai.com/codex/hooks) を参照)。 ccgate は Codex の `~/.codex/config.toml` (`approval_policy`, `sandbox_mode`, `prefix_rules`) を読まない

--- a/docs/ja/configuration.md
+++ b/docs/ja/configuration.md
@@ -129,7 +129,7 @@ ccgate codex  metrics --days 7         # codex 側も同 shape
 
 `ft_kind` は LLM (またはランタイム) が fallthrough を返したときに埋まり、どの fallback path が発火したかを示します (`llm`, `api_unusable`, `no_apikey`, `credential_unavailable`, `unknown_provider`, `bypass`, `dontask`, `user_interaction`)。`forced=true` は `fallthrough_strategy` が LLM `fallthrough` を `decision` に promote したことを意味します。
 
-`credential_source` は `ft_kind=credential_unavailable` のときだけ埋まります。credential 解決のどの段階で起きた / 失敗したかを示し、現状は `exec` / `file` / `cache` / `lock` (keystore 経由の `auth.type=exec` / `auth.type=file`) に加え `profile` (Anthropic 専用 `auth.type=profile`、解決は anthropic-sdk-go に委譲し keystore は通らない) を取ります。値の集合は open: 将来 Windows ネイティブ backend など新しい credential 経路が増えると値も増えうるので、この field を parse する側は固定 enum で validation せず、未知の短い文字列を許容してください。
+`credential_source` は `ft_kind=credential_unavailable` のときだけ埋まります。credential 解決のどの段階で起きた / 失敗したかを示し、現状は `exec` / `file` / `cache` / `lock` (keystore 経由の `auth.type=exec` / `auth.type=file`) に加え `profile` (Anthropic 専用 `auth.type=profile`、解決は anthropic-sdk-go に委譲し keystore は通らない) を取ります。値の集合は open: 新しい credential 経路が追加されれば値も増えうるので、この field を parse する側は固定 enum で validation せず、未知の短い文字列を許容してください。
 
 `reason` の意味は `ft_kind` で文脈が変わります:
 

--- a/docs/ja/configuration.md
+++ b/docs/ja/configuration.md
@@ -2,7 +2,7 @@
 
 [English version (docs/configuration.md)](../configuration.md)
 
-本ページは layering ルール、fallthrough の決定木、メトリクス出力スキーマを扱います。field 一覧とクイックスタートは [README](README.md) にあります。
+target 横断の設定リファレンス: layering ルール、全フィールド表、fallthrough_strategy、メトリクス出力スキーマ。 quick start は [README](README.md) を参照。
 
 ## ccgate が config を探す場所
 
@@ -42,6 +42,32 @@ ccgate は target ごとに以下の層を順に読み込みます。各層は�
 プロジェクトローカル設定は意図的に **git で tracked されていない場合のみ load** します。これは「個人 contributor が共有ベースラインの上に自分の制限を重ねる」用途を想定しているためで、ローカル設定経由でチーム全体ポリシーを repo に密かに混入させない狙いです。
 
 repo 全体に効くポリシーが必要なら、自前 fork の埋込デフォルトに含める / チームで `~/.claude/ccgate.jsonnet` を dotfiles bootstrap で配布する / 個別に各 contributor が `.local.jsonnet` を作る、いずれかを選んでください。
+
+## 設定フィールド
+
+| フィールド               | 型                                | デフォルト                                                                       | 説明                                                                                                       |
+|--------------------------|-----------------------------------|---------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
+| `provider.name`          | string                            | `"anthropic"`                                                                   | プロバイダー名。`"anthropic"` / `"openai"` / `"gemini"`。詳細は [docs/ja/providers.md](providers.md)。      |
+| `provider.model`         | string                            | `"claude-haiku-4-5"`                                                            | モデル名。選定指針は [docs/ja/providers.md](providers.md#モデル選択) を参照。                              |
+| `provider.base_url`      | string                            | `""`                                                                            | API base URL の上書き。空文字列 (default) で SDK の既定 endpoint を使用。詳細は [docs/ja/providers.md#base_url-と互換-proxy](providers.md#base_url-と互換-proxy)。 |
+| `provider.auth`          | object (`{type, ...}`)            | (省略時は env var)                                                              | refresh される credential を扱う discriminated union。`type=exec` / `type=file` / `type=profile`。詳細は [docs/ja/api-key-helper.md](api-key-helper.md)。 |
+| `provider.timeout_ms`    | int                               | `20000`                                                                         | API タイムアウト (ms)。`0` = タイムアウトなし。                                                            |
+| `log_path`               | string                            | `$XDG_STATE_HOME/ccgate/<target>/ccgate.log`                                    | ログファイルパス。`~` でホームディレクトリ展開。                                                           |
+| `log_disabled`           | bool                              | `false`                                                                         | ログ出力を完全に無効化。                                                                                   |
+| `log_max_size`           | int                               | `5242880`                                                                       | ローテーション閾値 (bytes, デフォルト 5MB)。`0` = ローテーションなし。                                     |
+| `metrics_path`           | string                            | `$XDG_STATE_HOME/ccgate/<target>/metrics.jsonl`                                 | メトリクス JSONL のパス。                                                                                  |
+| `metrics_disabled`       | bool                              | `false`                                                                         | メトリクス収集を完全に無効化。                                                                             |
+| `metrics_max_size`       | int                               | `2097152`                                                                       | ローテーション閾値 (bytes, デフォルト 2MB)。`0` = ローテーションなし。                                     |
+| `fallthrough_strategy`   | `"ask"` / `"allow"` / `"deny"`    | `"ask"`                                                                         | LLM が判定に迷った (`fallthrough`) 際の扱い。[fallthrough_strategy](#fallthrough_strategy----llm-判定迷い時の挙動) 参照。 |
+| `disable_load_main_worktree_local_config` | bool | `false`                                                                         | linked git worktree で main worktree 側の `ccgate.local.jsonnet` を読むのをスキップ。[ccgate が config を探す場所](#ccgate-が-config-を探す場所) 参照。 |
+| `allow`                  | string[]                          | `[]`                                                                            | 許可ルール。設定すると前の layer から引き継いだ list を **完全置換**。                                     |
+| `deny`                   | string[]                          | `[]`                                                                            | 拒否ルール (mandatory)。`deny_message:` ヒント対応。`allow` と同じく置換。                                 |
+| `environment`            | string[]                          | `[]`                                                                            | LLM に渡すコンテキスト (信頼レベル、ポリシー等)。`allow` と同じく置換。                                     |
+| `append_allow`           | string[]                          | `[]`                                                                            | 引き継いだ list の末尾に **追加**。[docs/ja/rule-tuning.md](rule-tuning.md) を参照。                       |
+| `append_deny`            | string[]                          | `[]`                                                                            | 引き継いだ deny list の末尾に追加。                                                                        |
+| `append_environment`     | string[]                          | `[]`                                                                            | 引き継いだ environment list の末尾に追加。                                                                 |
+
+`<target>` は Claude / Codex どちらの hook が呼ばれたかで `claude` / `codex` になります。`XDG_STATE_HOME` が未設定の場合は `~/.local/state/ccgate/<target>/...` が fallback として使われます。
 
 ## `fallthrough_strategy` -- LLM 判定迷い時の挙動
 
@@ -129,7 +155,7 @@ ccgate codex  metrics --days 7         # codex 側も同 shape
 
 `ft_kind` は LLM (またはランタイム) が fallthrough を返したときに埋まり、どの fallback path が発火したかを示します (`llm`, `api_unusable`, `no_apikey`, `credential_unavailable`, `unknown_provider`, `bypass`, `dontask`, `user_interaction`)。`forced=true` は `fallthrough_strategy` が LLM `fallthrough` を `decision` に promote したことを意味します。
 
-`credential_source` は `ft_kind=credential_unavailable` のときだけ埋まります。credential 解決のどの段階で起きた / 失敗したかを示し、現状は `exec` / `file` / `cache` / `lock` (keystore 経由の `auth.type=exec` / `auth.type=file`) に加え `profile` (Anthropic 専用 `auth.type=profile`、解決は anthropic-sdk-go に委譲し keystore は通らない) を取ります。値の集合は open: 新しい credential 経路が追加されれば値も増えうるので、この field を parse する側は固定 enum で validation せず、未知の短い文字列を許容してください。
+`credential_source` は `ft_kind=credential_unavailable` のときだけ埋まります。credential 解決のどの段階で起きた / 失敗したかを示し、 `exec` / `file` / `cache` / `lock` (keystore 経由の `auth.type=exec` / `auth.type=file`)、 `profile` (Anthropic 専用 `auth.type=profile`、解決は anthropic-sdk-go に委譲し keystore は通らない) を取ります。値の集合は open で、この field を parse する側は固定 enum で validation せず、未知の短い文字列を許容してください。
 
 `reason` の意味は `ft_kind` で文脈が変わります:
 
@@ -196,4 +222,4 @@ cache 層の失敗は fallthrough せずに自動回復するので、`slog.Warn
 - **Plan mode (Claude のみ) はプロンプト依存**: `permission_mode == "plan"` では (a) 実装系 write を拒絶する判定と (b) 明示的な allow guidance なしの read-only クエリ許可 を、LLM とシステムプロンプトの指示文に委ねています。どちらの方向にも誤判定の余地あり。[#37](https://github.com/tak848/ccgate/issues/37) で追跡
 - **embedded default の特定ルールだけを部分削除する手段なし**: layer は list を **完全置換** (`allow: [...]`) するか **末尾追加** (`append_allow: [...]`) するかのどちらかで、embedded の中の 1 ルールだけ消したい場合は残り全部を `allow:` / `deny:` に書き直すしかない
 - **Codex hook の schema は upstream-driven**: Codex hooks は upstream の `[features] codex_hooks = true` flag 配下にあり、[OpenAI Codex hooks docs](https://developers.openai.com/codex/hooks) を一次情報として扱う
-- **Codex `~/.codex/config.toml` 取り込みは未対応** (`approval_policy`, `sandbox_mode`, `prefix_rules`): ccgate は hook payload + ccgate config だけで判定するため、Codex 自身の設定が拒絶するはずだった操作のシグナルは LLM に届かない
+- **Codex `~/.codex/config.toml` 取り込みは out of scope** (`approval_policy`, `sandbox_mode`, `prefix_rules`): ccgate は hook payload + ccgate config だけで判定するため、Codex 自身の設定が拒絶する操作のシグナルは LLM に届かない

--- a/docs/ja/configuration.md
+++ b/docs/ja/configuration.md
@@ -33,7 +33,9 @@ ccgate は target ごとに以下の層を順に読み込みます。各層は�
 | list: `allow` / `deny` / `environment` | 値を設定した layer が前の layer から引き継いだ list を **置き換える** (`[]` でも置換)。設定していない layer は前の値を保持 | embedded `allow: ["A","B"]` + global `allow: ["X"]` → 最終 `allow: ["X"]` |
 | list: `append_allow` / `append_deny` / `append_environment` | 値を設定した layer が前の layer の累積 list の **末尾に追加** | embedded `deny: ["A"]` + project `append_deny: ["P"]` → 最終 `deny: ["A","P"]` |
 | スカラー: `log_*` / `metrics_*` / `fallthrough_strategy` | 各 layer が値を設定していれば per-field で **overwrite**、設定していなければ前の値を保持 | embedded `log_max_size: 5MB` + global `log_max_size: 10MB` → 最終 `log_max_size: 10MB` |
-| ブロック: `provider` (`provider.*` の全 field — `name` / `model` / `base_url` / `auth` / `timeout_ms`) | `provider` を書いた layer は **block 全体を置換**、書かなかった layer はそのまま継承。per-field merge にすると、下位 layer の proxy 用 `base_url` や helper 用 `auth.command` が `name` を切り替えただけの上位 layer に残る等の不整合が起きるため | embedded `provider: {name: anthropic, model: claude-haiku-4-5}` + global `provider: {name: openai, model: gpt-4o-mini}` → 最終 `provider: {name: openai, model: gpt-4o-mini}`。model だけ変えたい場合は `provider: {name: anthropic, model: claude-sonnet-4-6}` のように block 全体を書き直す。global で `auth` を設定している場合、project-local 側で `provider` を上書きするときも `auth` ブロック全体を忘れずに書き写すこと (書き漏らすと当該プロジェクトで helper 設定が静かに消える) |
+| ブロック: `provider` (`name` / `model` / `base_url` / `auth` / `timeout_ms`) | `provider` を書いた layer は **block 全体を置換**。 | embedded `provider: {name: anthropic, model: claude-haiku-4-5}` + global `provider: {name: openai, model: gpt-4o-mini}` → 最終 `provider: {name: openai, model: gpt-4o-mini}`。 |
+
+`provider` を block 全体で置換するのは、 下位 layer の proxy 用 `base_url` や helper 用 `auth.command` が `name` を切り替えただけの上位 layer に残らないようにするためです。 model だけ変えたい場合は `provider: {name: anthropic, model: claude-sonnet-4-6}` のように block 全体を書き直してください。 global で `auth` を設定している場合、 project-local 側で `provider` を上書きするときも `auth` ブロック全体を書き写す必要があります (書き漏らすと当該プロジェクトで helper 設定が silent に消えます)。
 
 `allow` と `append_allow` (他 list も同じ) は同じ layer に共存可能 — 先に置換、その結果に対して append が積まれる。embedded の list を厳選版に **差し替えつつ** プロジェクト固有のルールを **追加** したいときに使います: `{ allow: ['only this base'], append_allow: ['plus this project rule'] }`。
 
@@ -178,11 +180,15 @@ ccgate codex  metrics --days 7         # codex 側も同 shape
 | `output_too_large`      | helper の stdout が 64 KiB 上限超過                                                                  |
 | `lock_timeout`          | flock retry budget 切れ (peer が refresh 中)                                                         |
 | `lock_error`            | flock syscall が EWOULDBLOCK 以外で失敗 (lock 系が壊れている → helper exec はスキップ)               |
-| `cache_unavailable`     | cache dir を作成 / `chmod` できない。隣接 lock file も作れず concurrent helper の race を防げないため fail-fast (helper exec せずに fallthrough) |
-| `provider_auth`         | provider が **HTTP 401 または 403** で credential を拒否。`auth.type=exec` は cache を invalidate して次回 hook 発火時に helper を再実行、`auth.type=file` は内部 cache がないため fallthrough のみ、`auth.type=profile` も fallthrough (SDK の refresh-token loop が credential を保有)、env var 経路は **意図的にこの経路に乗せず exit 1** (ccgate からは rotate できず、握り潰すと user 側の設定ミスを隠してしまうため) |
-| `profile_load`          | `auth.type=profile` で credential を SDK に渡す前に失敗 (profile config 不在 / parse error / profile 名不正、credentials file の preflight 失敗 = 不在 / 読めない)。slog の `error_class` で具体的な分類が得られる。詳細は [docs/ja/api-key-helper.md の障害時の復旧チェックリスト](api-key-helper.md#障害時の復旧チェックリスト) を参照 |
+| `cache_unavailable`     | cache dir を作成 / `chmod` できない。 fail-fast (helper exec せずに fallthrough)。 |
+| `provider_auth`         | provider が HTTP 401 または 403 で credential を拒否。 |
+| `profile_load`          | `auth.type=profile` で credential を SDK に渡す前に失敗。 |
 
-`credential_unavailable` は単に「credential 解決に失敗した」だけでなく、「provider が credential を受け取った上で拒否した」(401 / 403) ケースも含みます。
+`cache_unavailable` が fail-fast なのは、 隣接 lock file も作れず concurrent helper の race を防げないためです。
+
+`provider_auth` の `auth.type` 別挙動: `exec` は cache を invalidate して次回 hook 発火時に helper を再実行、 `file` は内部 cache がないため fallthrough のみ、 `profile` も fallthrough (SDK の refresh-token loop が credential を保有)。 env var 経路は意図的にこの経路に乗せず exit 1 (ccgate からは rotate できず、 握り潰すと user 側の設定ミスを隠してしまうため)。 したがって `credential_unavailable` は「credential 解決に失敗した」だけでなく「provider が credential を受け取った上で拒否した」 (401 / 403) ケースも含みます。
+
+`profile_load` の具体的な原因は slog の `error_class` で narrow できます (profile config 不在 / parse error / profile 名不正、 credentials file の preflight 失敗 = 不在 / 読めない、 など)。 完全なラベルと triage 手順は [docs/ja/api-key-helper.md の障害時の復旧チェックリスト](api-key-helper.md#障害時の復旧チェックリスト) を参照。
 
 #### log のみで出る credential 警告 (metrics には乗らない)
 
@@ -221,4 +227,4 @@ cache 層の失敗は fallthrough せずに自動回復するので、`slog.Warn
 
 - **Plan mode (Claude のみ) はプロンプト依存**: `permission_mode == "plan"` では (a) 実装系 write を拒絶する判定と (b) 明示的な allow guidance なしの read-only クエリ許可 を、LLM とシステムプロンプトの指示文に委ねています。どちらの方向にも誤判定の余地あり
 - **embedded default の特定ルールだけを部分削除する手段なし**: layer は list を **完全置換** (`allow: [...]`) するか **末尾追加** (`append_allow: [...]`) するかのどちらかで、embedded の中の 1 ルールだけ消したい場合は残り全部を `allow:` / `deny:` に書き直すしかない
-- ccgate は hook payload と ccgate の設定からのみ判定する。Codex hooks は `[features] codex_hooks = true` flag が必要 (schema 詳細は [OpenAI Codex hooks docs](https://developers.openai.com/codex/hooks) を参照)。 ccgate は Codex の `~/.codex/config.toml` (`approval_policy`, `sandbox_mode`, `prefix_rules`) を読まない
+- ccgate は hook payload と ccgate の設定からのみ判定する。 Codex 側は `[features] codex_hooks = true` の設定が必要 (schema 詳細は [OpenAI Codex hooks docs](https://developers.openai.com/codex/hooks) を参照)。

--- a/docs/ja/configuration.md
+++ b/docs/ja/configuration.md
@@ -60,9 +60,9 @@ repo 全体に効くポリシーが必要なら、自前 fork の埋込デフォ
 | `metrics_max_size`       | int                               | `2097152`                                                                       | ローテーション閾値 (bytes, デフォルト 2MB)。`0` = ローテーションなし。                                     |
 | `fallthrough_strategy`   | `"ask"` / `"allow"` / `"deny"`    | `"ask"`                                                                         | LLM が判定に迷った (`fallthrough`) 際の扱い。[fallthrough_strategy](#fallthrough_strategy----llm-判定迷い時の挙動) 参照。 |
 | `disable_load_main_worktree_local_config` | bool | `false`                                                                         | linked git worktree で main worktree 側の `ccgate.local.jsonnet` を読むのをスキップ。[ccgate が config を探す場所](#ccgate-が-config-を探す場所) 参照。 |
-| `allow`                  | string[]                          | `[]`                                                                            | 許可ルール。設定すると前の layer から引き継いだ list を **完全置換**。                                     |
-| `deny`                   | string[]                          | `[]`                                                                            | 拒否ルール (mandatory)。`deny_message:` ヒント対応。`allow` と同じく置換。                                 |
-| `environment`            | string[]                          | `[]`                                                                            | LLM に渡すコンテキスト (信頼レベル、ポリシー等)。`allow` と同じく置換。                                     |
+| `allow`                  | string[]                          | embedded list (`ccgate <target> init` で確認)                                    | 許可ルール。設定すると前の layer から引き継いだ list を **完全置換**。                                     |
+| `deny`                   | string[]                          | embedded list (`ccgate <target> init` で確認)                                    | 拒否ルール (mandatory)。`deny_message:` ヒント対応。`allow` と同じく置換。                                 |
+| `environment`            | string[]                          | embedded list (`ccgate <target> init` で確認)                                    | LLM に渡すコンテキスト (信頼レベル、ポリシー等)。`allow` と同じく置換。                                     |
 | `append_allow`           | string[]                          | `[]`                                                                            | 引き継いだ list の末尾に **追加**。[docs/ja/rule-tuning.md](rule-tuning.md) を参照。                       |
 | `append_deny`            | string[]                          | `[]`                                                                            | 引き継いだ deny list の末尾に追加。                                                                        |
 | `append_environment`     | string[]                          | `[]`                                                                            | 引き継いだ environment list の末尾に追加。                                                                 |
@@ -81,7 +81,7 @@ LLM は `allow` / `deny` / `fallthrough` のいずれかを返します。`fallt
 | `deny`    | 自動拒否。deny メッセージが「user に聞くな、別コマンドで回避するな」と AI に指示する                    | 無人実行で「許可待ちで止まる」より「失敗で抜ける」を選びたいとき                    |
 | `allow`   | 自動許可                                                                                              | 完全自律実行で「LLM が迷ったケースも進めたい」リスクを受容できるとき                |
 
-**`allow` は見た目より危険です**。Claude Code / Codex とも、hook 仕様上 `decision.message` は `behavior=deny` のときしか AI に届きません。強制 allow のメッセージは silent に drop されるので、AI には「ccgate が auto approve した、注意して進めて」のような警告が見えません。このトレードオフを理解した上で選択してください。
+**`allow` は見た目より危険です**。 hook 仕様上 `decision.message` は `behavior=deny` のときしか AI に届きません。 強制 allow のメッセージは silent に drop されるので、 AI には「ccgate が auto approve した、 注意して進めて」のような警告が見えません。 このトレードオフを理解した上で選択してください。
 
 ### `fallthrough_strategy` の対象**外**
 
@@ -196,7 +196,7 @@ cache 層の失敗は fallthrough せずに自動回復するので、`slog.Warn
 
 `ccgate <target> metrics` はデフォルトで 3 つのセクションを追加します:
 
-- **Top fallthrough commands**: LLM が判断に迷った頻度上位の操作。プロジェクトローカルで allow / deny ルールを追加すれば LLM 往復を省略できる候補
+- **Top fallthrough commands**: LLM が判断に迷った頻度上位の操作。プロジェクトローカルで allow / deny ルールを追加すれば、 LLM が明確な判定に寄りやすくなり上流 prompt への fallthrough を減らせる候補
 - **Top deny commands**: LLM が deny した頻度上位の操作。同じブロックされた操作を自動 job が繰り返してる場合、AI 側のプラン形を変えるべきサインであることが多い
 - **Credential failures**: `ft_kind=credential_unavailable` を `(source, reason)` で集計。tool input は意図的に無視 (credential 障害中は同じ source/reason が全 tool で出るため)。cache 層 warning はここには出ないので `ccgate.log` で確認
 

--- a/docs/ja/providers.md
+++ b/docs/ja/providers.md
@@ -1,0 +1,102 @@
+# ccgate -- Providers
+
+[English version (docs/providers.md)](../providers.md)
+
+ccgate は各 PermissionRequest を provider LLM (default: Claude Haiku) に投げて分類します。本ページは、対応 provider・切り替え方・API キーの解決順・互換 proxy 経由での利用を扱います。Refresh される credential (`provider.auth`) については [docs/ja/api-key-helper.md](api-key-helper.md) を参照。
+
+## 対応 provider
+
+| `provider.name` | underlying SDK | 既定モデル                          |
+|-----------------|----------------|-------------------------------------|
+| `anthropic`     | `anthropic-sdk-go` | `claude-haiku-4-5`               |
+| `openai`        | `openai-go`        | (`provider.model` で明示指定が必要) |
+| `gemini`        | Gemini の OpenAI 互換 endpoint 経由で `openai-go` | (同じく明示指定が必要) |
+
+## Provider の切り替え
+
+任意の layer で `provider.name` (必要なら `provider.model` も) を書き換えます:
+
+```jsonnet
+{
+  provider: {
+    name: 'openai',
+    model: 'gpt-4o-mini',
+  },
+}
+```
+
+対応する API キー (下の [API キー](#api-キー) 参照) を export してください。キーが見つからない場合 ccgate は上流ツールの確認画面に fallthrough するので、 provider 切替で hook が壊れることはありません。
+
+## API キー
+
+`CCGATE_*_API_KEY` が優先され bare 変数を上書きします。 AI ツール本体の API キーと ccgate 用キーを分けられます。
+
+| `provider.name` | 優先                       | フォールバック        | API キー発行ページ |
+|-----------------|----------------------------|-----------------------|--------------------|
+| `anthropic`     | `CCGATE_ANTHROPIC_API_KEY` | `ANTHROPIC_API_KEY`   | <https://platform.claude.com/settings/keys> |
+| `openai`        | `CCGATE_OPENAI_API_KEY`    | `OPENAI_API_KEY`      | <https://platform.openai.com/api-keys>      |
+| `gemini`        | `CCGATE_GEMINI_API_KEY`    | `GEMINI_API_KEY`      | <https://aistudio.google.com/app/api-keys>  |
+
+全体の解決順: `provider.auth` (設定済み) → `CCGATE_*_API_KEY` → `*_API_KEY`。`provider.auth` を設定した状態で失敗しても env var に silent に fallback はせず、 `kind=credential_unavailable` で fallthrough します。 helper の契約と復旧手順は [docs/ja/api-key-helper.md](api-key-helper.md) を参照。
+
+## モデル選択
+
+ccgate は structured output と `temperature=0` (決定論的な分類) でリクエストを送ります。どちらにも対応するモデルを選んでください。
+
+> [!WARNING]
+> reasoning model は `temperature=0` を拒否するため全リクエストが失敗し、分類タスクには不要な chain-of-thought に数秒かかります。現時点で該当することが知られているのは OpenAI の `gpt-5` reasoning 系列 (`gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-chat`) と `o1*` / `o3*` / `o4-mini` 系。同じファミリーの chat 系モデルを使ってください。
+
+各 provider のモデル一覧は提供側で頻繁に更新されるので、選定時に確認:
+
+- Anthropic: <https://docs.anthropic.com/en/docs/about-claude/models/overview>
+- OpenAI: <https://platform.openai.com/docs/models>
+- Gemini: <https://ai.google.dev/gemini-api/docs/models>
+
+## `base_url` と互換 proxy
+
+ccgate は各 provider SDK の標準 chat / messages エンドポイントを使うので、**OpenAI 互換 / Anthropic 互換** の任意の endpoint — [LiteLLM proxy](https://docs.litellm.ai/docs/proxy/quick_start) / Azure OpenAI / オンプレ gateway / 地域別 endpoint など — に `provider.base_url` を向ければ動きます。
+
+`provider.base_url` は underlying SDK の `WithBaseURL` にそのまま渡されるので、書く path は **その SDK の慣習** に従います (ccgate 側で正規化しません):
+
+| `provider.name` | SDK default base URL                                       | `base_url` に書く形                                    |
+|-----------------|------------------------------------------------------------|--------------------------------------------------------|
+| `openai`        | `https://api.openai.com/v1/`                               | host **+ `/v1`** (SDK が `chat/completions` を追加)    |
+| `anthropic`     | `https://api.anthropic.com/`                               | host root のみ (SDK が `/v1/messages` を追加)          |
+| `gemini`        | `https://generativelanguage.googleapis.com/v1beta/openai/` | override するなら host **+ `/v1beta/openai`**          |
+
+### OpenAI 互換 endpoint
+
+`/v1/chat/completions` を expose する proxy (LiteLLM proxy / Azure OpenAI の OpenAI 互換モード 等):
+
+```jsonnet
+{
+  provider: {
+    name: 'openai',
+    model: 'anthropic/claude-haiku-4-5', // proxy が公開している名前
+    base_url: 'https://your-proxy.example/v1',
+  },
+}
+```
+
+proxy の API キーを `CCGATE_OPENAI_API_KEY` で export。OpenAI SDK は base URL に `/chat/completions` を直接 append するので、末尾の `/v1` が必要。
+
+### Anthropic 互換 endpoint
+
+`/v1/messages` を expose する proxy:
+
+```jsonnet
+{
+  provider: {
+    name: 'anthropic',
+    model: 'claude-haiku-4-5',
+    base_url: 'https://your-proxy.example',
+  },
+}
+```
+
+proxy の API キーを `CCGATE_ANTHROPIC_API_KEY` で export。 Anthropic SDK が `/v1/messages` を自分で append するので、base URL は host root で止めます。
+
+## 関連
+
+- [docs/ja/api-key-helper.md](api-key-helper.md) — `provider.auth` (refresh される credential、 helper 契約、 401/403 挙動、 障害復旧)
+- [docs/ja/configuration.md](configuration.md) — 設定 layering、 全フィールドリファレンス、 fallthrough_strategy、 metrics

--- a/docs/ja/providers.md
+++ b/docs/ja/providers.md
@@ -43,10 +43,7 @@ ccgate は各 PermissionRequest を provider LLM (default: Claude Haiku) に投�
 
 ccgate は structured output と `temperature=0` (決定論的な分類) でリクエストを送ります。どちらにも対応するモデルを選んでください。
 
-> [!WARNING]
-> reasoning model は `temperature=0` を拒否するため全リクエストが失敗し、分類タスクには不要な chain-of-thought に数秒かかります。現時点で該当することが知られているのは OpenAI の `gpt-5` reasoning 系列 (`gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-chat`) と `o1*` / `o3*` / `o4-mini` 系。同じファミリーの chat 系モデルを使ってください。
-
-各 provider のモデル一覧は提供側で頻繁に更新されるので、選定時に確認:
+reasoning 系のモデルは別のパラメータ shape を要求することが多く、 分類タスクには不要な chain-of-thought 遅延が乗ります。 `temperature=0` や structured output を拒否するモデルでは ccgate は loop せず上流ツールの確認画面に fallthrough しますが、 同じモデルで判定が成立することはありません。 特定モデルを採用する前に provider のモデル一覧で `temperature=0` + structured output 対応を確認してください。 provider モデル一覧:
 
 - Anthropic: <https://docs.anthropic.com/en/docs/about-claude/models/overview>
 - OpenAI: <https://platform.openai.com/docs/models>

--- a/docs/ja/rule-tuning.md
+++ b/docs/ja/rule-tuning.md
@@ -81,7 +81,7 @@ Codex (`apply_patch` の hunk target を `tool_input_raw` から LLM が読む):
 
 ```jsonnet
 {
-  // embedded defaults を採用せず自分で list を書く形 (defaults は effect しない)。
+  // embedded defaults を採用せず自分で list を書く形 (embedded defaults は有効にならない)。
   allow: [
     'Read-only filesystem inspection inside the repository.',
     'Local development commands using project scripts (build, test, lint).',

--- a/docs/ja/rule-tuning.md
+++ b/docs/ja/rule-tuning.md
@@ -1,0 +1,115 @@
+# ccgate -- ルールチューニング
+
+[English version (docs/rule-tuning.md)](../rule-tuning.md)
+
+provider と hook の登録が済んだら、ここから先は「`allow` / `deny` / `append_*` をどう書くか」が中心です。1 ページで完結するよう、 defaults の確認から iteration までを順に説明します。
+
+## 1. 組み込み defaults を確認する
+
+```bash
+ccgate claude init | less                                # Claude embedded defaults を読む
+ccgate codex  init | less                                # Codex も同じ
+ccgate claude init -p > .claude/ccgate.local.jsonnet     # プロジェクトローカルのスケルトン (空雛形)
+ccgate codex  init -p > .codex/ccgate.local.jsonnet      # Codex も同じ
+```
+
+`-p` で吐ける雛形には provider 設定や `fallthrough_strategy` のコメントアウト例が入っているので、空ファイルから書き始めるより楽です。
+
+## 2. どこに書くか
+
+- グローバル: `~/.claude/ccgate.jsonnet` / `~/.codex/ccgate.jsonnet`
+- プロジェクトローカル: `<repo>/.claude/ccgate.local.jsonnet` / `<repo>/.codex/ccgate.local.jsonnet` (Git 未追跡のみ)
+
+layer の合成順は [設定リファレンス](configuration.md#ccgate-が-config-を探す場所) 参照。 ざっくり: embedded defaults → グローバル → main worktree project-local → current worktree project-local の順で上書きされていきます。
+
+## 3. 置換 vs 追加 (= コピペするかしないか)
+
+| 書き方 | defaults との関係 | 新 defaults リリース時 | 用途 |
+|--------|--------------------|------------------------|------|
+| `append_allow` / `append_deny` / `append_environment` | 残す + 追加 | upgrade 時に自動取り込み | 基本はこちら |
+| `allow:` / `deny:` / `environment:` | 完全置換 (defaults を採用しない) | 自分で `init` 出力と diff を取り、必要なら手で取り込み | 一部 default を消したい、独自方針を全部書きたい等、特別な事情のとき |
+
+「default を 1 件だけ消したい」を append で実現する経路はありません (append は **足す** だけ)。1 件除外したい場合は `allow:` / `deny:` で残り全部を書き直すしかありません。
+
+## 4. ルールの書き方
+
+1 ルール 1 行の自然言語で対象操作を書きます。末尾に `deny_message:` を付けると、deny 時にその文字列が AI へのヒントとして渡ります。
+
+判定は LLM が行うので、LLM が `tool_input` / `tool_input_raw` / `branch_name` / 各種 path / コマンド文字列から判断できる粒度で書くのが要点です。LLM に渡らない情報 (例: working tree の dirty/clean) を guidance に書いても効きません。LLM に渡る代表項目は README の [§ Concepts](../../README.md#concepts) 参照。
+
+書く field によって挙動が変わるので、3 パターンに分けて例を示します。
+
+### 追加で広げる (`append_allow`)
+
+Claude:
+
+```jsonnet
+{
+  ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/schemas/claude.schema.json',
+  append_allow: [
+    // target path は tool_input.file_path / referenced_paths から LLM が判定可能
+    'Edit / Write / MultiEdit で repo_root/docs/ 配下の Markdown を target にするものは allow (内容レビューは別途)。',
+  ],
+}
+```
+
+Codex (`apply_patch` の hunk target を `tool_input_raw` から LLM が読む):
+
+```jsonnet
+{
+  ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/schemas/codex.schema.json',
+  append_allow: [
+    'apply_patch の全 hunk が repo_root/docs/ 配下の *.md を target にしている場合は allow (内容レビューは別途)。',
+  ],
+}
+```
+
+### 追加で狭める (`append_deny`)
+
+```jsonnet
+{
+  append_deny: [
+    'Production database access: any psql / mysql connection to a *.prod.* host. deny_message: production access is gated behind the runbook.',
+    'Setting production environment variables in the running session. deny_message: configure production via the deployment system, not via shell exports.',
+  ],
+}
+```
+
+### 完全置換で絞る (`allow:` / `deny:`)
+
+```jsonnet
+{
+  // 引き継いだ defaults を全部捨てて自分で list を書く。新 defaults は自動で流れ込まない。
+  allow: [
+    'Read-only filesystem inspection inside the repository.',
+    'Local development commands using project scripts (build, test, lint).',
+  ],
+  deny: [
+    'Downloading and executing remote code (curl | bash, eval $(curl ...), etc.). deny_message: vet the script first; install it via a package manager or a checked-in script.',
+  ],
+}
+```
+
+`$schema` 行はどの形でもエディタ補完を有効にします。
+
+### 動的な値を埋め込む
+
+ルール文字列にホスト名やアカウント ID など環境依存の値を入れたいときは jsonnet helper を使います:
+
+- `std.native('env')(name)` — 未定義は空文字
+- `std.native('must_env')(name)` — 未定義なら config-load エラー
+
+評価は **hook 発火ごとの config load 時** に 1 回だけ行われます (= ccgate が `tool_input` を見る前)。`tool_input` や git state に基づいて runtime に分岐する仕組みではないので注意してください。 runtime の分類は LLM の仕事です。
+
+## 5. iteration workflow
+
+1-2 日 ccgate を実利用したら `ccgate <target> metrics --details N` を回します。「Top fallthrough commands」「Top deny commands」のドリルダウンで、ルール追加で削減できる操作が分かります。`append_deny` (もしくは `append_allow`) を 1 件足して metrics を再確認する、を繰り返すのが基本サイクルです。
+
+metrics の列の意味、JSON 出力の schema、credential failure の集計は [設定リファレンスのメトリクス出力](configuration.md#メトリクス出力) を参照。
+
+## 関連
+
+- [設定リファレンス (configuration.md)](configuration.md) — Layer / merge / 設定全フィールド / metrics / Fallthrough strategy
+- [Refresh される credential (api-key-helper.md)](api-key-helper.md) — `provider.auth` の helper 契約、 401/403 挙動、復旧手順
+- [Claude Code 固有 (claude.md)](claude.md) — Claude Code の HookInput
+- [Codex CLI 固有 (codex.md)](codex.md) — Codex CLI の HookInput

--- a/docs/ja/rule-tuning.md
+++ b/docs/ja/rule-tuning.md
@@ -24,10 +24,12 @@ layer の合成順は [設定リファレンス](configuration.md#ccgate-が-con
 
 ## 3. 置換 vs 追加 (= コピペするかしないか)
 
-| 書き方 | defaults との関係 | 新 defaults リリース時 | 用途 |
-|--------|--------------------|------------------------|------|
-| `append_allow` / `append_deny` / `append_environment` | 残す + 追加 | upgrade 時に自動取り込み | 基本はこちら |
-| `allow:` / `deny:` / `environment:` | 完全置換 (defaults を採用しない) | 自分で `init` 出力と diff を取り、必要なら手で取り込み | 一部 default を消したい、独自方針を全部書きたい等、特別な事情のとき |
+| 書き方 | 実行中の binary の embedded defaults との関係 |
+|--------|--------------------------------------------|
+| `append_allow` / `append_deny` / `append_environment` | embedded defaults を残し、 自分のエントリを末尾に追加 |
+| `allow:` / `deny:` / `environment:` | embedded defaults を捨てて、 自分の list だけが有効になる |
+
+完全置換側を使っている場合は、 別の ccgate build に切り替えるたびに `ccgate <target> init` で当時の embedded list を確認し、 手で反映してください。
 
 「default を 1 件だけ消したい」を append で実現する経路はありません (append は **足す** だけ)。1 件除外したい場合は `allow:` / `deny:` で残り全部を書き直すしかありません。
 

--- a/docs/ja/rule-tuning.md
+++ b/docs/ja/rule-tuning.md
@@ -29,7 +29,7 @@ layer の合成順は [設定リファレンス](configuration.md#ccgate-が-con
 | `append_allow` / `append_deny` / `append_environment` | embedded defaults を残し、 自分のエントリを末尾に追加 |
 | `allow:` / `deny:` / `environment:` | embedded defaults を捨てて、 自分の list だけが有効になる |
 
-完全置換側を使っている場合は、 別の ccgate build に切り替えるたびに `ccgate <target> init` で当時の embedded list を確認し、 手で反映してください。
+完全置換側を使っている場合は、 `ccgate <target> init` を現時点の embedded list の参照源として使い、 手で反映してください。
 
 「default を 1 件だけ消したい」を append で実現する経路はありません (append は **足す** だけ)。1 件除外したい場合は `allow:` / `deny:` で残り全部を書き直すしかありません。
 
@@ -81,7 +81,7 @@ Codex (`apply_patch` の hunk target を `tool_input_raw` から LLM が読む):
 
 ```jsonnet
 {
-  // 引き継いだ defaults を全部捨てて自分で list を書く。新 defaults は自動で流れ込まない。
+  // embedded defaults を採用せず自分で list を書く形 (defaults は effect しない)。
   allow: [
     'Read-only filesystem inspection inside the repository.',
     'Local development commands using project scripts (build, test, lint).',

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,102 @@
+# ccgate -- Providers
+
+[日本語版 (docs/ja/providers.md)](ja/providers.md)
+
+ccgate calls a provider LLM (default: Claude Haiku) to classify each PermissionRequest. This page covers which providers ccgate supports, how to switch between them, where the API keys come from, and how to route through a compatible proxy. For refreshable / rotating credentials (`provider.auth`), see [docs/api-key-helper.md](api-key-helper.md).
+
+## Supported providers
+
+| `provider.name` | Underlying SDK | Default model        |
+|-----------------|----------------|----------------------|
+| `anthropic`     | `anthropic-sdk-go` | `claude-haiku-4-5` |
+| `openai`        | `openai-go`        | (set explicitly via `provider.model`) |
+| `gemini`        | `openai-go` against Gemini's OpenAI-compat endpoint | (set explicitly) |
+
+## Switching providers
+
+Set `provider.name` (and `provider.model` when needed) in any layer:
+
+```jsonnet
+{
+  provider: {
+    name: 'openai',
+    model: 'gpt-4o-mini',
+  },
+}
+```
+
+Export the matching API key (see [API keys](#api-keys) below). If the key is missing, ccgate falls through to the upstream tool's permission prompt, so a wrong provider name cannot break the hook.
+
+## API keys
+
+`CCGATE_*_API_KEY` is the preferred name and overrides the bare variant, so ccgate's key can stay separate from the AI tool's own key.
+
+| `provider.name` | Preferred                  | Fallback             | Issue page |
+|-----------------|----------------------------|----------------------|------------|
+| `anthropic`     | `CCGATE_ANTHROPIC_API_KEY` | `ANTHROPIC_API_KEY`  | <https://platform.claude.com/settings/keys> |
+| `openai`        | `CCGATE_OPENAI_API_KEY`    | `OPENAI_API_KEY`     | <https://platform.openai.com/api-keys>      |
+| `gemini`        | `CCGATE_GEMINI_API_KEY`    | `GEMINI_API_KEY`     | <https://aistudio.google.com/app/api-keys>  |
+
+Resolution order overall: `provider.auth` (when set) → `CCGATE_*_API_KEY` → `*_API_KEY`. When `provider.auth` is set and fails, ccgate does **not** silently fall back to env vars — the hook falls through with `kind=credential_unavailable`. See [docs/api-key-helper.md](api-key-helper.md) for the helper contract and recovery.
+
+## Model selection
+
+ccgate sends each request with structured output and `temperature=0` (deterministic classification). Pick a model that supports both.
+
+> [!WARNING]
+> Reasoning models reject `temperature=0` (every request fails) and add seconds of chain-of-thought that the classification does not need. The known affected families today are the OpenAI `gpt-5` reasoning lineup (`gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-chat`) and the `o1*` / `o3*` / `o4-mini` lines. Use a chat-tier model from the same family instead.
+
+Concrete model picks change over time; check each provider's current model list when choosing one:
+
+- Anthropic: <https://docs.anthropic.com/en/docs/about-claude/models/overview>
+- OpenAI: <https://platform.openai.com/docs/models>
+- Gemini: <https://ai.google.dev/gemini-api/docs/models>
+
+## `base_url` and compatible proxies
+
+ccgate uses each provider SDK's standard chat / messages endpoint. That means any **OpenAI-compatible** or **Anthropic-compatible** endpoint — [LiteLLM proxy](https://docs.litellm.ai/docs/proxy/quick_start), Azure OpenAI, on-prem gateways, regional endpoints — works once you point `provider.base_url` at it.
+
+`provider.base_url` is passed verbatim to the underlying SDK's `WithBaseURL`. The path follows each SDK's convention; ccgate does not normalise it:
+
+| `provider.name` | SDK default base URL                                       | What to put in `base_url`                              |
+|-----------------|------------------------------------------------------------|--------------------------------------------------------|
+| `openai`        | `https://api.openai.com/v1/`                               | host **+ `/v1`** (SDK appends `chat/completions`)      |
+| `anthropic`     | `https://api.anthropic.com/`                               | host root only (SDK appends `/v1/messages`)            |
+| `gemini`        | `https://generativelanguage.googleapis.com/v1beta/openai/` | host **+ `/v1beta/openai`** when overriding            |
+
+### OpenAI-compatible endpoint
+
+For a proxy that exposes `/v1/chat/completions` (LiteLLM proxy, Azure OpenAI in OpenAI-compat mode, ...):
+
+```jsonnet
+{
+  provider: {
+    name: 'openai',
+    model: 'anthropic/claude-haiku-4-5', // whatever the proxy exposes
+    base_url: 'https://your-proxy.example/v1',
+  },
+}
+```
+
+Export the proxy's API key as `CCGATE_OPENAI_API_KEY`. The trailing `/v1` is required because the OpenAI SDK appends `/chat/completions` directly to the base URL.
+
+### Anthropic-compatible endpoint
+
+For a proxy that exposes `/v1/messages`:
+
+```jsonnet
+{
+  provider: {
+    name: 'anthropic',
+    model: 'claude-haiku-4-5',
+    base_url: 'https://your-proxy.example',
+  },
+}
+```
+
+Export the proxy's API key as `CCGATE_ANTHROPIC_API_KEY`. The Anthropic SDK appends `/v1/messages` itself, so the base URL stops at the host root.
+
+## See also
+
+- [docs/api-key-helper.md](api-key-helper.md) — `provider.auth` (refreshable credentials, helper contract, 401/403 behaviour, recovery checklist)
+- [docs/configuration.md](configuration.md) — config layering, full field reference, fallthrough_strategy, metrics

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -31,7 +31,7 @@ Export the matching API key (see [API keys](#api-keys) below). If the key is mis
 
 `CCGATE_*_API_KEY` is the preferred name and overrides the bare variant, so ccgate's key can stay separate from the AI tool's own key.
 
-| `provider.name` | Preferred                  | Fallback             | Issue page |
+| `provider.name` | Preferred                  | Fallback             | Get a key |
 |-----------------|----------------------------|----------------------|------------|
 | `anthropic`     | `CCGATE_ANTHROPIC_API_KEY` | `ANTHROPIC_API_KEY`  | <https://platform.claude.com/settings/keys> |
 | `openai`        | `CCGATE_OPENAI_API_KEY`    | `OPENAI_API_KEY`     | <https://platform.openai.com/api-keys>      |
@@ -43,10 +43,7 @@ Resolution order overall: `provider.auth` (when set) → `CCGATE_*_API_KEY` → 
 
 ccgate sends each request with structured output and `temperature=0` (deterministic classification). Pick a model that supports both.
 
-> [!WARNING]
-> Reasoning models reject `temperature=0` (every request fails) and add seconds of chain-of-thought that the classification does not need. The known affected families today are the OpenAI `gpt-5` reasoning lineup (`gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-chat`) and the `o1*` / `o3*` / `o4-mini` lines. Use a chat-tier model from the same family instead.
-
-Concrete model picks change over time; check each provider's current model list when choosing one:
+Reasoning-tier models often require a different parameter shape and add chain-of-thought latency that ccgate's classification does not need. If a model rejects `temperature=0` or otherwise refuses structured output, ccgate falls through to the upstream tool's prompt instead of looping — but the same model will never produce a verdict. Confirm `temperature=0` + structured output support against the provider's model docs before relying on a specific model. Provider model lists:
 
 - Anthropic: <https://docs.anthropic.com/en/docs/about-claude/models/overview>
 - OpenAI: <https://platform.openai.com/docs/models>

--- a/docs/rule-tuning.md
+++ b/docs/rule-tuning.md
@@ -24,10 +24,12 @@ For layer composition see [docs/configuration.md](configuration.md#where-ccgate-
 
 ## 3. Replace vs append (i.e. copy-paste or not)
 
-| Field shape | Relationship to defaults | When ccgate ships new defaults | When to use it |
-|-------------|--------------------------|--------------------------------|----------------|
-| `append_allow` / `append_deny` / `append_environment` | Keep + append | Updates flow in on upgrade automatically | Default choice |
-| `allow:` / `deny:` / `environment:` | Replace wholesale (defaults are dropped) | Diff `ccgate <target> init` output yourself and copy what you want | Special cases: dropping a specific default, fully curated lists, etc. |
+| Field shape | Relationship to embedded defaults |
+|-------------|-----------------------------------|
+| `append_allow` / `append_deny` / `append_environment` | Embedded defaults from the running binary are kept; your entries are appended. |
+| `allow:` / `deny:` / `environment:` | Embedded defaults from the running binary are dropped; only your list is in effect. |
+
+If you replace wholesale, run `ccgate <target> init` whenever you bring in a different ccgate build to see the current embedded list, and reconcile manually.
 
 There is no surgical "remove one specific embedded rule" path. `append_*` only adds; to omit one embedded entry, restate the whole list under `allow:` / `deny:` minus that one entry.
 

--- a/docs/rule-tuning.md
+++ b/docs/rule-tuning.md
@@ -29,7 +29,7 @@ For layer composition see [docs/configuration.md](configuration.md#where-ccgate-
 | `append_allow` / `append_deny` / `append_environment` | Embedded defaults from the running binary are kept; your entries are appended. |
 | `allow:` / `deny:` / `environment:` | Embedded defaults from the running binary are dropped; only your list is in effect. |
 
-If you replace wholesale, run `ccgate <target> init` whenever you bring in a different ccgate build to see the current embedded list, and reconcile manually.
+If you replace wholesale, use `ccgate <target> init` as the current embedded-list reference and reconcile manually.
 
 There is no surgical "remove one specific embedded rule" path. `append_*` only adds; to omit one embedded entry, restate the whole list under `allow:` / `deny:` minus that one entry.
 
@@ -81,7 +81,7 @@ Codex (the LLM reads `apply_patch` hunk targets from `tool_input_raw`):
 
 ```jsonnet
 {
-  // You take ownership of the full lists; new embedded defaults will not flow in automatically.
+  // You own the full lists; the embedded defaults are not in effect.
   allow: [
     'Read-only filesystem inspection inside the repository.',
     'Local development commands using project scripts (build, test, lint).',

--- a/docs/rule-tuning.md
+++ b/docs/rule-tuning.md
@@ -1,0 +1,115 @@
+# ccgate -- Rule tuning
+
+[日本語版 (docs/ja/rule-tuning.md)](ja/rule-tuning.md)
+
+Once provider setup and hook registration are done, the next thing to learn is how to write your own `allow` / `deny` / `append_*` guidance. This page walks through that flow end to end so you do not have to cross-reference other files mid-task.
+
+## 1. Inspect the embedded defaults
+
+```bash
+ccgate claude init | less                                # Read the embedded Claude defaults.
+ccgate codex  init | less                                # Same for Codex.
+ccgate claude init -p > .claude/ccgate.local.jsonnet     # Project-local skeleton you can extend.
+ccgate codex  init -p > .codex/ccgate.local.jsonnet      # Same for Codex.
+```
+
+The `-p` skeleton ships with commented-out provider and `fallthrough_strategy` examples, so it is easier to start from than an empty file.
+
+## 2. Where to put the file
+
+- Global: `~/.claude/ccgate.jsonnet` or `~/.codex/ccgate.jsonnet`.
+- Project-local: `<repo>/.claude/ccgate.local.jsonnet` or `<repo>/.codex/ccgate.local.jsonnet`, untracked-only.
+
+For layer composition see [docs/configuration.md](configuration.md#where-ccgate-looks-for-config). At a glance: embedded defaults → global → main-worktree project-local → current-worktree project-local, with later layers stacked on top.
+
+## 3. Replace vs append (i.e. copy-paste or not)
+
+| Field shape | Relationship to defaults | When ccgate ships new defaults | When to use it |
+|-------------|--------------------------|--------------------------------|----------------|
+| `append_allow` / `append_deny` / `append_environment` | Keep + append | Updates flow in on upgrade automatically | Default choice |
+| `allow:` / `deny:` / `environment:` | Replace wholesale (defaults are dropped) | Diff `ccgate <target> init` output yourself and copy what you want | Special cases: dropping a specific default, fully curated lists, etc. |
+
+There is no surgical "remove one specific embedded rule" path. `append_*` only adds; to omit one embedded entry, restate the whole list under `allow:` / `deny:` minus that one entry.
+
+## 4. Writing rules
+
+A rule is one line of natural-language guidance describing the operation. Add a `deny_message:` at the end and that string is shown to the AI when the rule fires.
+
+The LLM does the actual classification, so write at a granularity the LLM can judge from `tool_input` / `tool_input_raw` / `branch_name` / paths / command strings. Information that ccgate never delivers to the LLM (e.g. the working-tree dirty/clean flag) cannot be used in guidance. The representative input list is in the README's [Concepts](../README.md#concepts) section.
+
+Three patterns, by which field you write the rule in:
+
+### Add to allow (`append_allow`)
+
+Claude:
+
+```jsonnet
+{
+  ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/schemas/claude.schema.json',
+  append_allow: [
+    // The LLM can read target_path from tool_input.file_path / referenced_paths.
+    'Edit / Write / MultiEdit targeting a Markdown file under repo_root/docs/ is fine; the content review happens elsewhere.',
+  ],
+}
+```
+
+Codex (the LLM reads `apply_patch` hunk targets from `tool_input_raw`):
+
+```jsonnet
+{
+  ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/schemas/codex.schema.json',
+  append_allow: [
+    'apply_patch whose hunks all target *.md files under repo_root/docs/ is fine; the content review happens elsewhere.',
+  ],
+}
+```
+
+### Add to deny (`append_deny`)
+
+```jsonnet
+{
+  append_deny: [
+    'Production database access: any psql / mysql connection to a *.prod.* host. deny_message: production access is gated behind the runbook.',
+    'Setting production environment variables in the running session. deny_message: configure production via the deployment system, not via shell exports.',
+  ],
+}
+```
+
+### Replace wholesale (`allow:` / `deny:`)
+
+```jsonnet
+{
+  // You take ownership of the full lists; new embedded defaults will not flow in automatically.
+  allow: [
+    'Read-only filesystem inspection inside the repository.',
+    'Local development commands using project scripts (build, test, lint).',
+  ],
+  deny: [
+    'Downloading and executing remote code (curl | bash, eval $(curl ...), etc.). deny_message: vet the script first; install it via a package manager or a checked-in script.',
+  ],
+}
+```
+
+The `$schema` line enables editor autocompletion for either shape.
+
+### Embedding env-derived values
+
+When a rule string needs to embed a host name, an account ID, or any other environment-derived value, use the jsonnet native helpers:
+
+- `std.native('env')(name)` — returns `""` when unset.
+- `std.native('must_env')(name)` — raises a config-load error when unset.
+
+These run **once per hook invocation, at config-load time**, before ccgate sees `tool_input`. There is no runtime branch-on-`tool_input` mechanism — the LLM does the runtime classification.
+
+## 5. Iteration workflow
+
+After a day or two of real use, run `ccgate <target> metrics --details N`. The "Top fallthrough commands" / "Top deny commands" drill-downs surface operations a rule could handle. Add one `append_deny` (or `append_allow`) entry, ship it, and re-check the metrics next round.
+
+Metrics column meanings, the JSON output schema, and the credential-failure aggregation live in [docs/configuration.md#metrics-output](configuration.md#metrics-output).
+
+## See also
+
+- [docs/configuration.md](configuration.md) — Layer / merge rules / full field reference / metrics / fallthrough_strategy details
+- [docs/api-key-helper.md](api-key-helper.md) — `provider.auth` (refreshable credentials, helper contract, 401/403 behaviour, recovery checklist)
+- [docs/claude.md](claude.md) — Claude Code-specific HookInput fields
+- [docs/codex.md](codex.md) — Codex CLI-specific HookInput fields

--- a/internal/cmd/claude/defaults.jsonnet
+++ b/internal/cmd/claude/defaults.jsonnet
@@ -2,14 +2,16 @@
   ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/schemas/claude.schema.json',
 
   // Default safety rules for ccgate.
-  // Inspired by Claude Code Auto Mode defaults.
+  // These rules are natural-language guidance for the LLM, not deterministic matchers.
+  // The LLM is the primary judge; allow/deny lists shape its decision boundary.
+  //
   // To customize, write either:
   //   - ~/.claude/ccgate.jsonnet (global), or
   //   - <repo>/.claude/ccgate.local.jsonnet (project-local, untracked-only)
   // and at either layer use append_* to add on top of what's
   // inherited (picks up future ccgate quality updates automatically),
   // or allow / deny / environment to replace the inherited list
-  // wholesale. See the README "Setup -- Claude Code" for examples.
+  // wholesale. See the README "Rule tuning" section for examples.
 
   provider: {
     name: 'anthropic',

--- a/internal/cmd/claude/defaults.jsonnet
+++ b/internal/cmd/claude/defaults.jsonnet
@@ -11,7 +11,7 @@
   // and at either layer use append_* to add on top of what's
   // inherited (picks up future ccgate quality updates automatically),
   // or allow / deny / environment to replace the inherited list
-  // wholesale. See the README "Rule tuning" section for examples.
+  // wholesale. See https://github.com/tak848/ccgate#rule-tuning for examples.
 
   provider: {
     name: 'anthropic',
@@ -20,7 +20,7 @@
     //   name: 'openai',  model: 'gpt-4o-mini',        (env: OPENAI_API_KEY)
     //   name: 'gemini',  model: 'gemini-2.0-flash',    (env: GEMINI_API_KEY)
     // base_url:  route through an OpenAI-/Anthropic-compatible proxy.
-    //            See README "Routing through a compatible proxy".
+    //            See https://github.com/tak848/ccgate#routing-through-a-compatible-proxy.
     // timeout_ms: API timeout in ms, default 20000.
     // auth: short-lived / rotating credentials. Discriminated
     //   by auth.type:
@@ -29,8 +29,8 @@
     //     auth: { type: 'profile', profile: 'ccgate' }                           // anthropic-only; reads `ant auth login --profile ccgate` credentials, SDK refreshes
     //   The provider block is replaced atomically across config layers,
     //   so a project-local config that restates `provider` must repeat
-    //   the auth block. See docs/api-key-helper.md for the full helper
-    //   contract, examples, and recovery checklist.
+    //   the auth block. See https://github.com/tak848/ccgate/blob/main/docs/api-key-helper.md
+    //   for the full helper contract, examples, and recovery checklist.
   },
 
   // What to do when the LLM is uncertain (returns "fallthrough"):

--- a/internal/cmd/claude/defaults.jsonnet
+++ b/internal/cmd/claude/defaults.jsonnet
@@ -8,9 +8,8 @@
   // To customize, write either:
   //   - ~/.claude/ccgate.jsonnet (global), or
   //   - <repo>/.claude/ccgate.local.jsonnet (project-local, untracked-only)
-  // and at either layer use append_* to add on top of what's
-  // inherited (picks up future ccgate quality updates automatically),
-  // or allow / deny / environment to replace the inherited list
+  // and at either layer use append_* to add entries on top of the
+  // embedded list, or allow / deny / environment to replace the list
   // wholesale. See https://github.com/tak848/ccgate#rule-tuning for examples.
 
   provider: {

--- a/internal/cmd/claude/defaults.jsonnet
+++ b/internal/cmd/claude/defaults.jsonnet
@@ -19,7 +19,7 @@
     //   name: 'openai',  model: 'gpt-4o-mini',        (env: OPENAI_API_KEY)
     //   name: 'gemini',  model: 'gemini-2.0-flash',    (env: GEMINI_API_KEY)
     // base_url:  route through an OpenAI-/Anthropic-compatible proxy.
-    //            See https://github.com/tak848/ccgate#routing-through-a-compatible-proxy.
+    //            See https://github.com/tak848/ccgate/blob/main/docs/providers.md#base_url-and-compatible-proxies
     // timeout_ms: API timeout in ms, default 20000.
     // auth: short-lived / rotating credentials. Discriminated
     //   by auth.type:

--- a/internal/cmd/codex/defaults.jsonnet
+++ b/internal/cmd/codex/defaults.jsonnet
@@ -17,8 +17,8 @@
 //   - <repo>/.codex/ccgate.local.jsonnet (project-local, untracked-only)
 // and at either layer use append_* to add on top of what's inherited
 // (picks up future ccgate quality updates automatically), or allow /
-// deny / environment to replace the inherited list wholesale. See the
-// README "Rule tuning" section for examples.
+// deny / environment to replace the inherited list wholesale.
+// See https://github.com/tak848/ccgate#rule-tuning for examples.
 
 {
   ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/schemas/codex.schema.json',
@@ -30,7 +30,7 @@
     //   name: 'openai',  model: 'gpt-4o-mini',        (env: OPENAI_API_KEY)
     //   name: 'gemini',  model: 'gemini-2.0-flash',    (env: GEMINI_API_KEY)
     // base_url:  route through an OpenAI-/Anthropic-compatible proxy.
-    //            See README "Routing through a compatible proxy".
+    //            See https://github.com/tak848/ccgate#routing-through-a-compatible-proxy.
     // timeout_ms: API timeout in ms, default 20000.
     // auth: short-lived / rotating credentials. Discriminated
     //   by auth.type:
@@ -39,8 +39,8 @@
     //     auth: { type: 'profile', profile: 'ccgate' }                           // anthropic-only; reads `ant auth login --profile ccgate` credentials, SDK refreshes
     //   The provider block is replaced atomically across config layers,
     //   so a project-local config that restates `provider` must repeat
-    //   the auth block. See docs/api-key-helper.md for the full helper
-    //   contract, examples, and recovery checklist.
+    //   the auth block. See https://github.com/tak848/ccgate/blob/main/docs/api-key-helper.md
+    //   for the full helper contract, examples, and recovery checklist.
   },
 
   // What to do when the LLM is uncertain (returns "fallthrough"):

--- a/internal/cmd/codex/defaults.jsonnet
+++ b/internal/cmd/codex/defaults.jsonnet
@@ -1,10 +1,10 @@
 // ccgate defaults for the OpenAI Codex CLI PermissionRequest hook.
 //
-// Same shape and philosophy as the Claude Code defaults: the LLM is the
-// primary judge; the allow/deny rules below are guidance, not strict
-// matchers. Fall through to Codex's own approval prompt when uncertain
-// (set fallthrough_strategy=allow|deny in your overrides for fully
-// unattended runs -- at your own risk).
+// These rules are natural-language guidance for the LLM, not deterministic matchers.
+// The LLM is the primary judge; allow/deny lists shape its decision boundary.
+// Fall through to Codex's own approval prompt when uncertain (set
+// fallthrough_strategy=allow|deny in your overrides for fully unattended
+// runs -- at your own risk).
 //
 // Codex hooks fire for Bash, apply_patch, MCP tool calls, and any other
 // surface Codex exposes via PermissionRequest. The rules below are
@@ -18,7 +18,7 @@
 // and at either layer use append_* to add on top of what's inherited
 // (picks up future ccgate quality updates automatically), or allow /
 // deny / environment to replace the inherited list wholesale. See the
-// README "Setup -- Codex CLI" for examples.
+// README "Rule tuning" section for examples.
 
 {
   ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/schemas/codex.schema.json',
@@ -60,7 +60,7 @@
 
   allow: [
     'Read-only operations: Bash inspection commands (ls, cat, head, tail, less, file, stat, find/grep without -exec/--delete, git status/log/diff/show/branch/remote -v), or any tool whose tool_input shape implies pure read (no writes, no network calls with side effects).',
-    'Local writes inside the workspace: apply_patch hunks whose target paths are all under cwd / repo_root, edits to project files for editing/refactoring/scaffolding the AI is currently doing. Same bar as Claude Code Edit/Write through ccgate.',
+    'Local writes inside the workspace: apply_patch hunks whose target paths are all under cwd / repo_root, edits to project files for editing/refactoring/scaffolding the AI is currently doing. Workspace-internal writes for the active coding task are in scope; writes that escape cwd / repo_root or that match a deny rule are not.',
     'Local build/test against project-defined scripts: make, just, mise run, pnpm test, go test, cargo test, etc.',
     'Package install confined to this repo: pnpm/cargo/go install with no global flags.',
     'Git feature-branch operations on non-protected branches.',
@@ -81,7 +81,7 @@
     'Tool surface: Codex hooks fire for Bash, apply_patch, MCP tool calls, and other tool kinds. Classify by tool_name + tool_input shape rather than assuming a single surface.',
     'Trusted repo: assume the repo is the trust boundary; treat anything outside it (other directories, remote endpoints, MCP servers not explicitly trusted) as untrusted.',
     'Path scope: when a tool_input targets paths outside cwd (e.g. /etc/, /usr/, ~/.ssh/), treat as out-of-repo and lean toward deny unless clearly read-only and benign.',
-    'You are replacing the upstream Codex approval prompt. Codex hooks fire only when Codex would otherwise stop and ask the user, which is exactly the prompt the user installed ccgate to skip. Returning fallthrough sends them that prompt anyway, so reserve fallthrough for cases that are genuinely ambiguous (suspect intent, malformed payload, mismatch between description and tool_input, or upstream surface ccgate has no rule for). Default to allow / deny instead -- same bar Claude Code parity asks for.',
+    'You are replacing the upstream Codex approval prompt. Codex hooks fire only when Codex would otherwise stop and ask the user, which is exactly the prompt the user installed ccgate to skip. Returning fallthrough sends them that prompt anyway, so reserve fallthrough for cases that are genuinely ambiguous (suspect intent, malformed payload, mismatch between description and tool_input, or upstream surface ccgate has no rule for). Default to allow / deny when guidance clearly applies; reserve fallthrough for genuinely ambiguous cases.',
     'Codex has no recent_transcript field today. Decide from tool_name + tool_input + cwd alone; if intent is ambiguous, return fallthrough (do NOT invent transcript context).',
   ],
 }

--- a/internal/cmd/codex/defaults.jsonnet
+++ b/internal/cmd/codex/defaults.jsonnet
@@ -81,7 +81,7 @@
     'Tool surface: Codex hooks fire for Bash, apply_patch, MCP tool calls, and other tool kinds. Classify by tool_name + tool_input shape rather than assuming a single surface.',
     'Trusted repo: assume the repo is the trust boundary; treat anything outside it (other directories, remote endpoints, MCP servers not explicitly trusted) as untrusted.',
     'Path scope: when a tool_input targets paths outside cwd (e.g. /etc/, /usr/, ~/.ssh/), treat as out-of-repo and lean toward deny unless clearly read-only and benign.',
-    'You are replacing the upstream Codex approval prompt. Codex hooks fire only when Codex would otherwise stop and ask the user, which is exactly the prompt the user installed ccgate to skip. Returning fallthrough sends them that prompt anyway, so reserve fallthrough for cases that are genuinely ambiguous (suspect intent, malformed payload, mismatch between description and tool_input, or upstream surface ccgate has no rule for). Default to allow / deny when guidance clearly applies; reserve fallthrough for genuinely ambiguous cases.',
-    'Codex has no recent_transcript field today. Decide from tool_name + tool_input + cwd alone; if intent is ambiguous, return fallthrough (do NOT invent transcript context).',
+    'Codex hooks fire only when Codex would otherwise stop and ask the user, which is the prompt the user installed ccgate to skip. Returning fallthrough sends them that prompt anyway, so reserve fallthrough for cases that are genuinely ambiguous (suspect intent, malformed payload, mismatch between description and tool_input, or a tool surface ccgate has no rule for). Default to allow / deny when guidance clearly applies.',
+    'Codex HookInput does not carry a recent_transcript field. Decide from tool_name + tool_input + cwd; if intent is ambiguous, return fallthrough (do NOT invent transcript context).',
   ],
 }

--- a/internal/cmd/codex/defaults.jsonnet
+++ b/internal/cmd/codex/defaults.jsonnet
@@ -15,10 +15,9 @@
 // To customize, write either:
 //   - ~/.codex/ccgate.jsonnet (global), or
 //   - <repo>/.codex/ccgate.local.jsonnet (project-local, untracked-only)
-// and at either layer use append_* to add on top of what's inherited
-// (picks up future ccgate quality updates automatically), or allow /
-// deny / environment to replace the inherited list wholesale.
-// See https://github.com/tak848/ccgate#rule-tuning for examples.
+// and at either layer use append_* to add entries on top of the
+// embedded list, or allow / deny / environment to replace the list
+// wholesale. See https://github.com/tak848/ccgate#rule-tuning for examples.
 
 {
   ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/schemas/codex.schema.json',

--- a/internal/cmd/codex/defaults.jsonnet
+++ b/internal/cmd/codex/defaults.jsonnet
@@ -29,7 +29,7 @@
     //   name: 'openai',  model: 'gpt-4o-mini',        (env: OPENAI_API_KEY)
     //   name: 'gemini',  model: 'gemini-2.0-flash',    (env: GEMINI_API_KEY)
     // base_url:  route through an OpenAI-/Anthropic-compatible proxy.
-    //            See https://github.com/tak848/ccgate#routing-through-a-compatible-proxy.
+    //            See https://github.com/tak848/ccgate/blob/main/docs/providers.md#base_url-and-compatible-proxies
     // timeout_ms: API timeout in ms, default 20000.
     // auth: short-lived / rotating credentials. Discriminated
     //   by auth.type:


### PR DESCRIPTION
## Why

Before this PR, ccgate's manuals had three problems that fed into each other:

- Someone who had finished provider setup could not find a single entry point for rule tuning. `allow / deny / append_* / defaults / ccgate <target> init` material was spread across the README's "Setup", "Configuration", and "Default Rules" sections plus `docs/configuration.md`.
- The README was carrying full reference tables, multi-paragraph examples, and provider / credential / proxy details inline. There was no clear "basics here, deep dive there" shape — the OSS conventional split most users expect.
- context7 / fragment retrievals on the docs picked up parity statements (`Claude<->Codex same bar`, `AWS credential_process` comparisons), `Tracked in #37` / `out of scope today` / `upstream is the source of truth` hedges, OS carve-outs (`/proc`, `POSIX-style`, `cron / launchd`, `NFS / SMB / FUSE`), and forever-promise wording (`will keep working forever`). `ccgate <target> init` output included parity wording in both comments and rule strings, and pointed back at the README with `See README "Section name"` rather than URLs.

This PR is a whole-manual cleanup. The README becomes a Quick-start hub, the detail moves into per-topic docs/* files, and the docs / cross-links / embedded defaults / retrieval surface are all aligned on the same docs policy.

## What

### Docs file layout

| File | Scope |
|------|-------|
| `README.md` / `docs/ja/README.md` | Overview, Install, Quick start (Claude + Codex), Concepts, 1–3 paragraph summary + link per topic, Known limitations, CLI reference |
| `docs/providers.md` (new) | Provider switching, API keys table, model selection constraints, `base_url` + compatible-proxy recipes |
| `docs/rule-tuning.md` (new) | Entry point for someone who finished provider setup: inspect defaults, replace vs append, three rule-writing patterns (Claude `Edit/Write/MultiEdit`, Codex `apply_patch`, wholesale replace), iteration workflow with `ccgate <target> metrics --details N` |
| `docs/configuration.md` (refactored) | Layer order, merge semantics, full Config fields reference (moved out of the README), fallthrough_strategy details, metrics output schema |
| `docs/api-key-helper.md` (refactored) | `provider.auth` reference (`type=exec` / `type=file` / `type=profile`), helper contract, caching, 401/403 behaviour matrix, recovery checklist |
| `docs/claude.md` / `docs/codex.md` | Per-target HookInput field reference (each closes on its own surface; no cross-target comparison tables) |

### README structure (en + ja, identical chapter order)

Overview → Install → Quick start (Claude) → Quick start (Codex) → Concepts → Configuration (1-page summary + link) → Rule tuning (1-page summary + link) → Providers and credentials → Fallthrough strategy → Logging and metrics → Known limitations → Documentation → CLI reference → Development → License.

The Quick starts close on `That's it — ccgate is now running with its embedded defaults` and link directly into `docs/rule-tuning.md`, so a reader who only needs the embedded defaults stops there and a reader who wants to tune is one hop away from the full guide.

### Embedded defaults (`internal/cmd/{claude,codex}/defaults.jsonnet`)

`ccgate <target> init` output is part of the docs surface (it is read via `less` and indexed by retrieval).

- Comments and rule strings no longer carry parity / self-reference wording (`Same shape as Claude Code defaults`, `Inspired by Claude Code Auto Mode defaults`, `Same bar as Claude Code Edit/Write through ccgate`, `same bar Claude Code parity asks for`). The intent (workspace-internal writes are in scope but cannot escape `cwd / repo_root`, default to allow/deny when guidance clearly applies, reserve fallthrough for genuinely ambiguous cases) is preserved in target-neutral wording.
- `See README "Section"` and `See docs/api-key-helper.md` references are replaced with absolute GitHub URLs into the new docs structure, so `ccgate <target> init | less` is followable in isolation.

### Removed throughout

- Parity / target-comparison wording (the Claude<->Codex differences table, `AWS credential_process and kubectl exec credential plugins` comparison section, `Codex does not deliver Claude's...`, etc.).
- History / TODO / forever / future / upgrade-cadence wording (`Tracked in #37`, `out of scope today`, `Earlier releases`, `ccgate's first registered version`, `will keep working forever`, `upgrade time に新 defaults が自動取り込み`, `picks up future ccgate quality updates automatically`, `upstream PR ... will let X once it lands`).
- OS carve-outs (`Linux / macOS / *BSD / Windows`, `/proc/<pid>/cmdline`, `POSIX-style filesystems`, `cron / launchd / systemd-timer`, `NFS / SMB / FUSE / keychain mounts`).
- Multi-paragraph table cells (`docs/configuration.md` provider-merge cell, `credential_unavailable` table, `docs/api-key-helper.md` 401/403 matrix) collapsed to one short verdict each; reasoning and edge cases moved to paragraphs below the table.
- README poetic titles (`Setup` → `Quick start`, `Unattended automation` → `Fallthrough strategy`, `Short-lived / rotating API keys` → `Refreshable credentials`).

### Factual corrections inside the same PR

- `docs/api-key-helper.md` (en + ja): the intro said `provider.auth has two modes`. Actual implementation is three: `type=exec` / `type=file` / `type=profile`. Fixed.
- `README.md` and `docs/ja/README.md` CLI reference: previous text was `ccgate codex init [-o|-f]`. Actual usage banner (`internal/cli/cli.go`) is `ccgate <target> init [-p] [-o FILE] [-f]` — `-p` was missing and the `[-p|-o|-f]` form read as an exclusive group. Fixed in both targets.
- `docs/configuration.md` Config fields: the defaults for `allow` / `deny` / `environment` were listed as `[]`. They are actually the embedded list shipped in `defaults.jsonnet`. Listed as `embedded list (inspect with ccgate <target> init)`.
- `docs/configuration.md` Drill-down sections: a Top-fallthrough-commands bullet claimed that adding a rule lets ccgate "skip the LLM round-trip entirely". ccgate routes every PermissionRequest through the LLM by design; corrected to "nudges the LLM toward a clear verdict".

### Out of scope (intentionally)

- Codex `[features].codex_hooks` → `[features].hooks` flag rename: OpenAI's Codex hooks docs and config-basic page still list `codex_hooks` as Default true / Stable with no deprecation notice. Kept as-is.
- Go behaviour changes: no `internal/...` code changes other than the cosmetic comment / rule-string updates in `defaults.jsonnet`. No schema regeneration. The `defaults.jsonnet` rule-string edits preserve the original LLM-guidance intent (workspace write threshold, fallthrough scoping).

## Test plan

- [ ] `mise run vet`
- [ ] `mise run test`
- [ ] `mise run build`, then `./bin/ccgate <target> init` for each target and confirm the output renders cleanly via `less`
- [ ] Render `README.md` and `docs/ja/README.md` on the PR page and spot-check the chapter order, anchor links, and "Documentation" index
- [ ] Render `docs/providers.md` / `docs/rule-tuning.md` / `docs/configuration.md` / `docs/api-key-helper.md` and spot-check cross-links between them