### PR TITLE
docs: rename target docs to avoid Claude Code CLAUDE.md collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ That's it — ccgate is now running with its embedded defaults. To customize wha
 ## Quick start — Codex CLI
 
 > [!NOTE]
-> Codex hooks require `[features] codex_hooks = true` in `~/.codex/config.toml`. See [docs/codex.md](docs/codex.md) for details.
+> Codex hooks require `[features] codex_hooks = true` in `~/.codex/config.toml`. See [docs/codex-cli.md](docs/codex-cli.md) for details.
 
 ### 1. Register as a Codex hook
 
@@ -138,7 +138,7 @@ command = "ccgate codex"
 statusMessage = "ccgate evaluating request"
 ```
 
-See [docs/codex.md](docs/codex.md) for the full lookup order, project-local overlays, and a `go run` recipe for in-tree dev builds.
+See [docs/codex-cli.md](docs/codex-cli.md) for the full lookup order, project-local overlays, and a `go run` recipe for in-tree dev builds.
 
 ### 2. API key
 
@@ -174,7 +174,7 @@ What ccgate puts in front of the LLM (representative fields):
 - `referenced_paths` — paths extracted from `tool_input` on a best-effort basis. Supported tools: `Read`, `Write`, `Edit`, `MultiEdit`, `Glob`, `Grep`, `Bash`. For `apply_patch` (Codex) and MCP tools, `referenced_paths` is empty; the LLM reads `tool_input_raw` directly to see hunk targets or call arguments.
 - Claude-only: `permission_mode` (switches the prompt to plan-mode rules when `"plan"`), `permission_suggestions`, `recent_transcript`, and `settings_permissions` (treated as a hint, not a whitelist).
 
-For the complete input list per target, see [docs/claude.md](docs/claude.md) and [docs/codex.md](docs/codex.md).
+For the complete input list per target, see [docs/claude-code.md](docs/claude-code.md) and [docs/codex-cli.md](docs/codex-cli.md).
 
 ## Configuration
 
@@ -268,8 +268,8 @@ Column meanings, the JSON entry schema, and the credential-failure aggregation a
 - [docs/rule-tuning.md](docs/rule-tuning.md) — Rule tuning entry point (defaults inspection, append vs replace, three example patterns, iteration workflow)
 - [docs/configuration.md](docs/configuration.md) — Config layering, full field reference, fallthrough_strategy details, metrics output
 - [docs/api-key-helper.md](docs/api-key-helper.md) — `provider.auth` reference (helper contract, caching, 401/403 behaviour, recovery checklist)
-- [docs/claude.md](docs/claude.md) — Claude Code-specific HookInput
-- [docs/codex.md](docs/codex.md) — Codex CLI-specific HookInput
+- [docs/claude-code.md](docs/claude-code.md) — Claude Code-specific HookInput
+- [docs/codex-cli.md](docs/codex-cli.md) — Codex CLI-specific HookInput
 - [日本語ドキュメント (docs/ja/)](docs/ja/README.md)
 
 ## CLI reference

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -1,6 +1,6 @@
 # ccgate -- Claude Code
 
-[日本語版 (docs/ja/claude.md)](ja/claude.md)
+[日本語版 (docs/ja/claude-code.md)](ja/claude-code.md)
 
 Claude-Code-specific notes for the `ccgate claude` hook.
 

--- a/docs/codex-cli.md
+++ b/docs/codex-cli.md
@@ -1,6 +1,6 @@
 # ccgate -- OpenAI Codex CLI
 
-[日本語版 (docs/ja/codex.md)](ja/codex.md)
+[日本語版 (docs/ja/codex-cli.md)](ja/codex-cli.md)
 
 Codex-CLI-specific notes for the `ccgate codex` hook.
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -96,7 +96,7 @@ ccgate は default で Anthropic の Claude Haiku を呼びます。 `CCGATE_ANT
 ## クイックスタート — Codex CLI
 
 > [!NOTE]
-> Codex hooks は `~/.codex/config.toml` に `[features] codex_hooks = true` の設定が必要です。詳細は [docs/codex.md](codex.md) を参照。
+> Codex hooks は `~/.codex/config.toml` に `[features] codex_hooks = true` の設定が必要です。詳細は [docs/codex-cli.md](codex-cli.md) を参照。
 
 ### 1. Codex hook として登録
 
@@ -138,7 +138,7 @@ command = "ccgate codex"
 statusMessage = "ccgate evaluating request"
 ```
 
-lookup 順序、 project-local overlay、 in-tree dev build 用の `go run` レシピは [docs/codex.md](codex.md) を参照。
+lookup 順序、 project-local overlay、 in-tree dev build 用の `go run` レシピは [docs/codex-cli.md](codex-cli.md) を参照。
 
 ### 2. API キー
 
@@ -174,7 +174,7 @@ ccgate が LLM に渡す情報 (代表項目):
 - `referenced_paths` — `tool_input` から best-effort で抽出した path リスト。対象 tool は `Read` / `Write` / `Edit` / `MultiEdit` / `Glob` / `Grep` / `Bash` のみ。`apply_patch` (Codex) や MCP tool では空で、LLM は `tool_input_raw` の hunk / args を直接読む。
 - Claude のみ: `permission_mode` (`"plan"` で system prompt が plan mode rule に切替), `permission_suggestions`, `recent_transcript`, `settings_permissions` hint (whitelist ではなく hint 扱い)。
 
-target ごとの完全な入力一覧は [docs/claude.md](claude.md) / [docs/codex.md](codex.md) を参照してください。
+target ごとの完全な入力一覧は [docs/claude-code.md](claude-code.md) / [docs/codex-cli.md](codex-cli.md) を参照してください。
 
 ## 設定
 
@@ -266,8 +266,8 @@ ccgate codex  metrics --json          # JSON 出力 (機械可読)
 - [rule-tuning.md](rule-tuning.md) — ルールチューニングの入り口 (defaults 確認、 append vs 置換、 3 パターン例、 iteration workflow)
 - [configuration.md](configuration.md) — 設定 layering、 全フィールド reference、 fallthrough_strategy 詳細、 メトリクス出力
 - [api-key-helper.md](api-key-helper.md) — `provider.auth` リファレンス (helper の契約、 キャッシュ、 401/403 挙動、 復旧手順)
-- [claude.md](claude.md) — Claude Code 固有の HookInput
-- [codex.md](codex.md) — Codex CLI 固有の HookInput
+- [claude-code.md](claude-code.md) — Claude Code 固有の HookInput
+- [codex-cli.md](codex-cli.md) — Codex CLI 固有の HookInput
 - [English README](../../README.md)
 
 ## CLI リファレンス

--- a/docs/ja/claude-code.md
+++ b/docs/ja/claude-code.md
@@ -1,6 +1,6 @@
 # ccgate -- Claude Code
 
-[English version (docs/claude.md)](../claude.md)
+[English version (docs/claude-code.md)](../claude-code.md)
 
 `ccgate claude` フック専用のドキュメント。
 

--- a/docs/ja/codex-cli.md
+++ b/docs/ja/codex-cli.md
@@ -1,6 +1,6 @@
 # ccgate -- OpenAI Codex CLI
 
-[English version (docs/codex.md)](../codex.md)
+[English version (docs/codex-cli.md)](../codex-cli.md)
 
 `ccgate codex` フック専用のドキュメント。
 

--- a/docs/ja/rule-tuning.md
+++ b/docs/ja/rule-tuning.md
@@ -113,5 +113,5 @@ metrics の列の意味、JSON 出力の schema、credential failure の集計�
 
 - [設定リファレンス (configuration.md)](configuration.md) — Layer / merge / 設定全フィールド / metrics / Fallthrough strategy
 - [Refresh される credential (api-key-helper.md)](api-key-helper.md) — `provider.auth` の helper 契約、 401/403 挙動、復旧手順
-- [Claude Code 固有 (claude.md)](claude.md) — Claude Code の HookInput
-- [Codex CLI 固有 (codex.md)](codex.md) — Codex CLI の HookInput
+- [Claude Code 固有 (claude-code.md)](claude-code.md) — Claude Code の HookInput
+- [Codex CLI 固有 (codex-cli.md)](codex-cli.md) — Codex CLI の HookInput

--- a/docs/rule-tuning.md
+++ b/docs/rule-tuning.md
@@ -113,5 +113,5 @@ Metrics column meanings, the JSON output schema, and the credential-failure aggr
 
 - [docs/configuration.md](configuration.md) — Layer / merge rules / full field reference / metrics / fallthrough_strategy details
 - [docs/api-key-helper.md](api-key-helper.md) — `provider.auth` (refreshable credentials, helper contract, 401/403 behaviour, recovery checklist)
-- [docs/claude.md](claude.md) — Claude Code-specific HookInput fields
-- [docs/codex.md](codex.md) — Codex CLI-specific HookInput fields
+- [docs/claude-code.md](claude-code.md) — Claude Code-specific HookInput fields
+- [docs/codex-cli.md](codex-cli.md) — Codex CLI-specific HookInput fields


### PR DESCRIPTION
## Why

`docs/claude.md` collides with the Claude Code agent's `CLAUDE.md` project-instructions file on case-insensitive filesystems (macOS default). The agent ends up auto-loading `docs/claude.md` into the conversation as if it were project instructions, which it is not — `docs/claude.md` is reference docs for the `ccgate claude` hook.

This was caught when the existing PR landed on main and the agent immediately started pulling `docs/claude.md` into context every turn.

## What

- `docs/claude.md` → `docs/claude-code.md`
- `docs/ja/claude.md` → `docs/ja/claude-code.md`
- `docs/codex.md` → `docs/codex-cli.md` (no collision today, but renamed together for consistent target-docs naming)
- `docs/ja/codex.md` → `docs/ja/codex-cli.md`

Updated cross-references in `README.md`, `docs/ja/README.md`, `docs/rule-tuning.md`, `docs/ja/rule-tuning.md`, and the language-switch links at the top of each renamed file. No content changes inside the target docs themselves.

## Test plan

- [ ] `mise run vet`
- [ ] `mise run test`
- [ ] `rg -nP '\b(claude|codex)\.md\b' README.md docs/ internal/` → empty
- [ ] Render `README.md` and `docs/ja/README.md` on the PR page and confirm the Documentation index links resolve to the renamed files