### PR TITLE
fix: print usage when `ccgate claude` / `ccgate codex` runs on a tty

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -89,16 +89,20 @@ func Run(version string, args []string, stdin io.Reader, stdout, stderr io.Write
 		return 2
 	}
 
-	return dispatch(kctx, &cli, stdin, stdout, stderr)
+	return dispatch(kctx, &cli, version, stdin, stdout, stderr)
 }
 
 // kongExit unwinds back to Run so we can translate kong's process-level
 // exit semantics into the int the caller already returns.
 type kongExit struct{ code int }
 
-func dispatch(kctx *kong.Context, cli *CLI, stdin io.Reader, stdout, stderr io.Writer) int {
+func dispatch(kctx *kong.Context, cli *CLI, version string, stdin io.Reader, stdout, stderr io.Writer) int {
 	switch kctx.Command() {
 	case "claude", "claude hook":
+		if isTerminal(stdin) {
+			printUsage(stderr, version)
+			return 0
+		}
 		return claude.Run(stdin, stdout)
 	case "claude init":
 		return claude.Init(stdout, stderr, claude.InitOptions{
@@ -117,6 +121,10 @@ func dispatch(kctx *kong.Context, cli *CLI, stdin io.Reader, stdout, stderr io.W
 			DetailsTop: cli.Claude.Metrics.Details,
 		})
 	case "codex", "codex hook":
+		if isTerminal(stdin) {
+			printUsage(stderr, version)
+			return 0
+		}
 		return codex.Run(stdin, stdout)
 	case "codex init":
 		return codex.Init(stdout, stderr, codex.InitOptions{


### PR DESCRIPTION
## Why

Running `ccgate codex` (or `ccgate claude`) directly in an interactive
terminal blocked on stdin while trying to JSON-decode it as a
PermissionRequest hook payload. Any keystrokes the user typed —
`Ctrl-C`, `Ctrl-\`, escape sequences — leaked into the decoder and
produced cryptic errors like:

```
❯ ccgate codex
^A^C^C^[[165;5u
... ERROR failed to decode stdin error="invalid character '\x1b' looking for beginning of value"
```

Bare `ccgate` already handled this case: tty stdin → print usage,
piped stdin → run the hook. The explicit `claude` / `codex` forms
skipped that guard and went straight into the decoder.

Fixes #80

## What

- Apply the same `isTerminal(stdin)` check to the `claude` and
  `codex` dispatch branches.
- Thread `version` through `dispatch` so it can call `printUsage`.