### PR TITLE
feat: add Claude Code plugin (setup / tune / debug / doctor skills)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "tak848-ccgate",
+  "owner": { "name": "tak848" },
+  "metadata": {
+    "description": "Claude Code plugin for ccgate — setup / tune / debug / doctor skills."
+  },
+  "plugins": [
+    {
+      "name": "ccgate",
+      "description": "AI-assisted setup, rule tuning, deny / 401 debug, and health check for ccgate.",
+      "version": "0.9.1",
+      "source": "./",
+      "category": "development"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "ccgate",
+  "description": "AI-assisted setup, rule tuning, deny / 401 debug, and health check for ccgate.",
+  "version": "0.9.1",
+  "author": { "name": "tak848" }
+}

--- a/README.md
+++ b/README.md
@@ -262,6 +262,29 @@ Column meanings, the JSON entry schema, and the credential-failure aggregation a
 - **No surgical reset for a single embedded default rule.** A layer can either **replace** a list wholesale (`allow: [...]`) or **append** to it (`append_allow: [...]`). Removing one specific embedded `allow` / `deny` rule while keeping the rest requires re-stating the whole list minus that one entry.
 - **No runtime conditional logic in jsonnet.** jsonnet evaluation happens once per hook invocation, at config-load time, **before ccgate sees `tool_input`**. Rules cannot branch on `tool_input` / git working-tree state / external command output. Runtime classification is the LLM's job. Config-time env reads via `std.native('env')(name)` / `std.native('must_env')(name)` are available for things like embedding a host name into a rule string.
 
+## Claude Code plugin
+
+ccgate ships a Claude Code plugin in this repo so the docs above can drive AI-assisted workflows directly from Claude Code.
+
+Install:
+
+```text
+/plugin marketplace add tak848/ccgate
+/plugin install ccgate@tak848-ccgate
+```
+
+Skills (auto-dispatched by Claude, also invocable manually):
+
+| Skill | What it does |
+|---|---|
+| `/ccgate:setup`  | Walks first-time install, PermissionRequest hook registration, and provider configuration. |
+| `/ccgate:tune`   | Drives `append_allow` / `append_deny` edits from recent `ccgate <target> metrics --details N`. |
+| `/ccgate:debug`  | Explains why ccgate produced a specific decision (deny / fallthrough / 401 / plan-mode). |
+| `/ccgate:doctor` | Read-only audit of binary, version, hook registration, config layers, and provider sanity. |
+
+> [!NOTE]
+> Skills that edit dotfiles (`setup`, `tune`) stop at a diff while Claude Code is in plan mode. Apply the writes after leaving plan mode.
+
 ## Documentation
 
 - [docs/providers.md](docs/providers.md) — Provider switching, API keys, base_url, compatible proxies

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -260,6 +260,29 @@ ccgate codex  metrics --json          # JSON 出力 (機械可読)
 - **embedded default の特定ルールだけの部分削除は不可**: layer は list を **完全置換** (`allow: [...]`) するか **末尾追加** (`append_allow: [...]`) するかのどちらかで、1 件除外したい場合は残りを `allow:` / `deny:` に書き直す。
 - **jsonnet 側に runtime conditional logic なし**: jsonnet 評価は hook 発火ごとの config load 時に、 ccgate が `tool_input` を見る前に実行される。 `tool_input` / git working tree state に基づく runtime 分岐は書けない (分類は LLM の仕事)。 config 評価時の env 読み込みのみ `std.native('env')(name)` / `std.native('must_env')(name)` で可能。
 
+## Claude Code plugin
+
+ccgate は本リポジトリに Claude Code plugin を同梱しています。上のドキュメントを背景に、 Claude Code から AI に作業を任せられます。
+
+インストール:
+
+```text
+/plugin marketplace add tak848/ccgate
+/plugin install ccgate@tak848-ccgate
+```
+
+Skills (Claude が auto-dispatch する。 manual invocation も可):
+
+| Skill | 役割 |
+|---|---|
+| `/ccgate:setup`  | 初回 install、 PermissionRequest hook 登録、 provider 設定の対話的ガイド。 |
+| `/ccgate:tune`   | 直近の `ccgate <target> metrics --details N` から `append_allow` / `append_deny` 編集を提案。 |
+| `/ccgate:debug`  | ccgate の判定 (deny / fallthrough / 401 / plan-mode) の root cause を説明。 |
+| `/ccgate:doctor` | binary、 version、 hook 登録、 config layer、 provider 設定の read-only audit。 |
+
+> [!NOTE]
+> dotfile を編集する skill (`setup`、 `tune`) は Claude Code が plan mode の間は diff の提示までで停止します。 plan mode を抜けてから write を実行してください。
+
 ## ドキュメント
 
 - [providers.md](providers.md) — Provider 切替、 API キー、 base_url、 互換 proxy

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: debug
+description: Explain why ccgate produced a specific decision (deny / fallthrough / 401).
+when_to_use: |
+  - User asks "why did ccgate deny this" / "why did ccgate fall through".
+  - Provider auth is failing with 401 / 403 and the user wants to know which credential stage broke.
+  - A specific command is consistently denied and the user wants the reason before changing rules.
+  - User wonders whether plan mode / bypassPermissions / dontAsk affected the decision.
+---
+
+# ccgate decision debug
+
+Help the user understand **why** ccgate emitted a specific decision. This skill explains and proposes — it does not edit `ccgate.jsonnet`. Once the user wants a concrete edit, hand off to `/ccgate:tune`.
+
+## 1. Pull the relevant metrics entries
+
+Start from the aggregated metrics. Default `<target>` is `claude`; ask if both targets are in play:
+
+```bash
+ccgate <target> metrics --json --details 10
+```
+
+The JSON has top fallthrough / top deny commands. If the user has a specific timestamp, tool, or command in mind, drop into the raw entries:
+
+```bash
+tail -n 200 "$XDG_STATE_HOME/ccgate/<target>/metrics.jsonl"
+```
+
+(`$XDG_STATE_HOME` falls back to `~/.local/state` when unset.) If the user redirected `metrics_path` in their config, `ccgate <target> metrics --json` is the only safe way to find it — the raw file may not be at the default path. The file may also be rotated (`metrics_max_size`); the most recent N lines are still in `metrics.jsonl`.
+
+Each entry has the shape documented in `${CLAUDE_PLUGIN_ROOT}/docs/configuration.md` "JSON entry schema" ([configuration#metrics-output](../../docs/configuration.md#metrics-output)). Key fields:
+
+- `decision` — `allow` / `deny` / `fallthrough`
+- `ft_kind` — `""` / `llm` / `api_unusable` / `no_apikey` / `credential_unavailable` / `unknown_provider` / `bypass` / `dontask` / `user_interaction`
+- `forced` — `true` when `fallthrough_strategy` promoted an LLM `fallthrough` into the final `decision`
+- `reason` — free-form text from the LLM (or a classifier when `ft_kind=credential_unavailable`)
+- `credential_source` — set only when `ft_kind=credential_unavailable`
+- `perm_mode` — Claude target only
+
+## 2. Branch by the user's complaint
+
+### "It denied something I asked for"
+
+1. Find the entry. Surface `decision`, `reason`, `tool_input.command` (or `file_path` / `path` / `pattern`), and `perm_mode`.
+2. Read the user's `ccgate.jsonnet` deny list (global + project-local) and identify which guidance line the LLM was likely matching against. If it is an embedded default, point at `ccgate <target> init` output.
+3. If the user wants to change the outcome, hand off to `/ccgate:tune` (add to `append_allow`, or rewrite the matching `append_deny`).
+
+### "It fell through to the upstream prompt"
+
+Look at `ft_kind`:
+
+| `ft_kind` | What it means | Where to send the user |
+|---|---|---|
+| `llm` | LLM was unsure. `reason` carries the LLM's justification. | `/ccgate:tune` to add an `append_allow` or `append_deny` that disambiguates the case. |
+| `credential_unavailable` | Credential resolution failed. `credential_source` (`exec` / `file` / `cache` / `lock` / `profile`) plus `reason` (`command_exit` / `json_parse` / `expired` / `file_missing` / `provider_auth` / etc.) identifies the stage. | `${CLAUDE_PLUGIN_ROOT}/docs/api-key-helper.md` "Recovery checklist" ([api-key-helper#recovery-checklist](../../docs/api-key-helper.md#recovery-checklist)). |
+| `no_apikey` | The provider's API key env var is unset. | `${CLAUDE_PLUGIN_ROOT}/docs/providers.md` "API keys" ([providers#api-keys](../../docs/providers.md#api-keys)). |
+| `unknown_provider` | `provider.name` is not `anthropic` / `openai` / `gemini`. | Have the user re-check the `provider.name` in their `ccgate.jsonnet`. |
+| `api_unusable` | Provider API returned a truncated / refused response. | Common causes: wrong `provider.base_url`, model that does not accept structured output or `temperature=0`, transient provider outage. See `${CLAUDE_PLUGIN_ROOT}/docs/providers.md` "Model selection" ([providers#model-selection](../../docs/providers.md#model-selection)). |
+| `bypass` | Claude `permission_mode == "bypassPermissions"`. ccgate intentionally does not decide here. | This is expected behaviour. Explain and stop. |
+| `dontask` | Claude `permission_mode == "dontAsk"`. Same as `bypass`. | Same. |
+| `user_interaction` | Claude `tool_name` is `ExitPlanMode` or `AskUserQuestion`. ccgate never decides for these. | Same. |
+
+When `forced=true`, the entry's final `decision` was promoted from an LLM `fallthrough` by `fallthrough_strategy`. If the user does not want that to happen on uncertainty, point at `${CLAUDE_PLUGIN_ROOT}/docs/configuration.md` "fallthrough_strategy" ([configuration#fallthrough_strategy](../../docs/configuration.md#fallthrough_strategy----choosing-what-to-do-on-llm-uncertainty)).
+
+### "I'm seeing 401 / 403 from the provider"
+
+This shows up as `ft_kind=credential_unavailable` with `reason=provider_auth`. Reaction differs by `auth.type`:
+
+- `exec` — ccgate invalidates the cache; the next invocation re-runs the helper.
+- `file` — ccgate falls through; the external rotator must rewrite the credential file.
+- `profile` — ccgate falls through; the SDK refresh-token loop owns the credential.
+
+If the user is on a static env-var key, ccgate cannot rotate it for them — they have to update the env. Reference: `${CLAUDE_PLUGIN_ROOT}/docs/api-key-helper.md` ([api-key-helper](../../docs/api-key-helper.md)).
+
+### "Plan mode is behaving differently than I expected"
+
+Look at `perm_mode` on the entry:
+
+- `plan` — ccgate switches its system prompt to plan-mode rules. Write operations should be denied; read-only queries should be allowed without an explicit allow-guidance match. This is **prompt-only**, with no hard guarantee — either side can misfire.
+- `bypassPermissions` / `dontAsk` — ccgate short-circuits to fallthrough; the upstream tool is in charge.
+
+Reference: `${CLAUDE_PLUGIN_ROOT}/docs/claude-code.md` "Plan mode" ([claude-code#plan-mode](../../docs/claude-code.md#plan-mode)).
+
+## 3. Hand off to tune (if the user wants an edit)
+
+Once the root cause is clear and the fix is a guidance change, summarise the proposed change in one line and invoke `/ccgate:tune` with that summary. Do not write the edit yourself in this skill.
+
+## What this skill does not do
+
+- It does not register the PermissionRequest hook — that is `/ccgate:setup`.
+- It does not write `append_allow` / `append_deny` edits — that is `/ccgate:tune`.
+- It does not audit the broader environment (binary / version / hook / layer) — that is `/ccgate:doctor`.

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: doctor
+description: Read-only audit of the ccgate environment (binary, version, hook, config layers, provider).
+when_to_use: |
+  - User wants to verify their ccgate setup end-to-end.
+  - "Is ccgate even running?" / "Which config layers are being read?"
+  - Checking whether the installed ccgate version is current.
+  - Diagnosing worktree config layering confusion (which `.local.jsonnet` is loaded).
+  - Verifying Codex hook feature flag and project trust state.
+---
+
+# ccgate environment doctor
+
+Read-only audit of the user's ccgate environment. Report findings as a table. **Do not edit any file.** When something needs to be fixed, name the file and the change, and hand the user to `/ccgate:setup` or `/ccgate:tune` for the actual write.
+
+## Checks (run them all, then summarise)
+
+### 1. Binary
+
+- Run `ccgate --version`. Record: not installed / on `PATH` / requires `mise exec` / absolute path.
+- If `ccgate --version` fails entirely, the rest of the checks still run on filesystems but skip anything that calls the binary.
+
+### 2. Version freshness
+
+Compare installed version against the latest release.
+
+Try in this order:
+
+1. `WebFetch https://api.github.com/repos/tak848/ccgate/releases/latest` and extract `tag_name`.
+2. On 403 or other failure (unauthenticated GitHub API is rate-limited to 60 req/hour/IP), `git ls-remote --tags --refs https://github.com/tak848/ccgate | tail -n 30` and pick the highest semver tag.
+3. If both fail, report "latest version unverified" and continue.
+
+Normalisation rules before comparing:
+
+- Strip a leading `v` from both sides (git tags use `v0.9.1`, `plugin.json` and `ccgate --version` may not).
+- Treat `dev` / `(devel)` / anything non-semver from `ccgate --version` as "development build" — do not classify as outdated, just report the literal version.
+- A trailing pre-release or build suffix on either side disables the "outdated" verdict; report both versions verbatim.
+
+### 3. Hook registration
+
+#### Claude Code
+
+Read `~/.claude/settings.json` and check `hooks.PermissionRequest`. Confirm at least one entry has a `command` that resolves to ccgate (`ccgate`, `ccgate claude`, an absolute path, or a `mise exec` wrapper).
+
+If no entry exists, report "ccgate is not registered as a Claude Code PermissionRequest hook" and point at `/ccgate:setup`.
+
+#### Codex CLI
+
+Two pieces both have to be in place:
+
+1. `[features] codex_hooks = true` in `~/.codex/config.toml`. Without this flag, Codex ignores the hook.
+2. A `hooks.PermissionRequest` entry in either `~/.codex/hooks.json` or `~/.codex/config.toml` that resolves to ccgate (`ccgate codex` or equivalent).
+
+Project trust: ccgate inherits Codex's project trust state. If the current project is not trusted, hooks may not fire on operations originating from it. Note this in the report when relevant. Reference: `${CLAUDE_PLUGIN_ROOT}/docs/codex-cli.md` ([codex-cli](../../docs/codex-cli.md)).
+
+### 4. Config layer candidates
+
+For each `<target>` the user uses, walk every candidate and report:
+
+| Path | Loaded as | Exists | Tracked by git | Effective? |
+|---|---|---|---|---|
+
+Paths:
+
+- `~/.<target>/ccgate.jsonnet` — global (layer 2)
+- `{main_worktree}/.<target>/ccgate.local.jsonnet` — main-worktree project-local (layer 3, **linked-worktree-only**, **untracked-only**)
+- `{repo_root}/.<target>/ccgate.local.jsonnet` — current-worktree project-local (layer 4, **untracked-only**)
+
+How to fill the table:
+
+- `Exists` — `stat` the path.
+- `Tracked by git` — `git ls-files --error-unmatch <path>` from the appropriate repo root. Tracked files are intentionally ignored by ccgate.
+- `Effective` — `Exists && !Tracked` for layer 3 / 4. For layer 3, also confirm the current cwd is a linked worktree (not the main one) and `disable_load_main_worktree_local_config: true` is **not** set in layer 1 or 2.
+
+> [!NOTE]
+> `ccgate <target> init` prints the **embedded defaults** only; it is not a merged-config inspector. There is no read-only API for "the config that would actually be evaluated at runtime", so doctor reports candidates and effective layers, not the merged result.
+
+Reference: `${CLAUDE_PLUGIN_ROOT}/docs/configuration.md` "Where ccgate looks for config" ([configuration#where-ccgate-looks-for-config](../../docs/configuration.md#where-ccgate-looks-for-config)).
+
+### 5. Provider sanity (per layer)
+
+For each effective layer file from §4, `Read` it (do **not** evaluate the jsonnet — this is a syntactic hint, not a merged inspect). Look for a `provider` block; if present, sanity-check:
+
+- `name` is one of `anthropic` / `openai` / `gemini` (anything else falls through with `ft_kind=unknown_provider` at runtime).
+- `model` is non-empty.
+- `base_url`, if set, looks like a URL.
+- `auth`, if set, has `type` in `exec` / `file` / `profile` and the matching required fields.
+
+> [!IMPORTANT]
+> The `provider` block is replaced **atomically** across layers — a higher layer that sets `provider` drops every field from lower layers. When doctor sees a `provider` block that lacks fields the user expects (e.g. `auth` is missing on a layer that overrides a global helper), call it out.
+
+Reference: `${CLAUDE_PLUGIN_ROOT}/docs/configuration.md` "How layers compose" ([configuration](../../docs/configuration.md)), `${CLAUDE_PLUGIN_ROOT}/docs/api-key-helper.md` ([api-key-helper](../../docs/api-key-helper.md)).
+
+### 6. Metrics / log presence
+
+`ccgate <target> metrics --json` resolves the configured `metrics_path` (which may be customised away from the default). Use it to find out whether metrics are being written.
+
+Default paths (only consulted when `ccgate metrics` is unavailable or fails):
+
+- Logs: `$XDG_STATE_HOME/ccgate/<target>/ccgate.log` (or `~/.local/state/ccgate/<target>/`)
+- Metrics: `$XDG_STATE_HOME/ccgate/<target>/metrics.jsonl`
+
+Report: file exists / last modified / empty or not.
+
+### 7. Embedded defaults sanity
+
+Run `ccgate <target> init | head -5`. If output is empty or errors, the binary is broken or the wrong target was passed. (This does **not** validate the user's config; it only checks the embedded defaults are intact.)
+
+## Report shape
+
+Present the report as one summary table plus a follow-up list:
+
+- Each row: one check, one of `OK` / `WARN` / `FAIL` / `INFO`, one-sentence note.
+- Below the table: list any concrete next steps with the target skill (e.g. "no Claude hook registered → run `/ccgate:setup`", "OpenAI provider block has no `model` → run `/ccgate:tune` and add the model field").
+
+## What this skill does not do
+
+- It does not edit any file. Every fix is described, not applied.
+- It does not draft `append_allow` / `append_deny` rules — that is `/ccgate:tune`.
+- It does not explain individual decisions — that is `/ccgate:debug`.
+- It does not register the hook from scratch — that is `/ccgate:setup`.

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: setup
+description: Set up ccgate as a PermissionRequest hook for Claude Code or Codex CLI.
+when_to_use: |
+  - First-time install of ccgate.
+  - User asks to register ccgate as a PermissionRequest hook.
+  - settings.json / hooks.json has no ccgate entry yet, and the user wants to add one.
+  - Switching ccgate to a different provider (Anthropic / OpenAI / Gemini) for the first time.
+---
+
+# ccgate setup
+
+Guide the user through installing ccgate and wiring it into Claude Code or Codex CLI as a PermissionRequest hook.
+
+> [!IMPORTANT]
+> When the surrounding Claude Code session is in plan mode, stop at the diff stage for every dotfile change. Do not write to `~/.claude/settings.json`, `~/.codex/hooks.json`, `~/.codex/config.toml`, `~/.claude/ccgate.jsonnet`, or `~/.codex/ccgate.jsonnet`. The user runs the writes after leaving plan mode.
+
+## 1. Inspect current state
+
+Before asking anything, gather the facts:
+
+- `ccgate --version` (PATH / absolute path / not installed)
+- `~/.claude/settings.json` for an existing `hooks.PermissionRequest` entry
+- `~/.codex/hooks.json` and `~/.codex/config.toml` for the same on the Codex side
+- `~/.claude/ccgate.jsonnet` / `~/.codex/ccgate.jsonnet` for a custom provider block
+
+If the user already has ccgate wired up, the right next step is usually `/ccgate:doctor`, not a fresh setup. Confirm with the user before overwriting anything.
+
+## 2. Ask three questions
+
+Use `AskUserQuestion` once with these three questions, in order:
+
+1. **target** — Claude Code / Codex CLI / both.
+2. **install method** — `mise` / `aqua` / `go install` / Homebrew / "already on `PATH`". Do not assume the user's shell or version manager.
+3. **provider** — Anthropic (Haiku, default) / OpenAI / Gemini / external credential helper.
+
+If the user picked "external credential helper", jump to [§6 External credential helpers](#6-external-credential-helpers) after the install step.
+
+## 3. Install ccgate
+
+For each install method, point at the canonical command from the README and let the user run it. Do not invent flags. Reference: `${CLAUDE_PLUGIN_ROOT}/README.md` (Install section). After install, run `ccgate --version` to confirm.
+
+## 4. Register the PermissionRequest hook
+
+For each target chosen in §2, produce a diff against the current settings/hooks file and show it to the user. Only write after the user accepts the diff. Plan-mode reminder: stop at the diff in plan mode.
+
+### Claude Code
+
+Add to `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PermissionRequest": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ccgate claude"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+If `ccgate` is not on `PATH` (e.g. only available through `mise exec`), use the equivalent invocation or an absolute path.
+
+Reference: `${CLAUDE_PLUGIN_ROOT}/docs/claude-code.md` ([claude-code](../../docs/claude-code.md)).
+
+### Codex CLI
+
+Codex hooks live behind `[features] codex_hooks = true` in `~/.codex/config.toml`. Add both pieces:
+
+```toml
+[features]
+codex_hooks = true
+
+[[hooks.PermissionRequest]]
+matcher = ""
+
+[[hooks.PermissionRequest.hooks]]
+type    = "command"
+command = "ccgate codex"
+statusMessage = "ccgate evaluating request"
+```
+
+Reference: `${CLAUDE_PLUGIN_ROOT}/docs/codex-cli.md` ([codex-cli](../../docs/codex-cli.md)).
+
+## 5. Provider configuration (if not the default Anthropic Haiku)
+
+If the user chose a non-default provider in §2, write a global `ccgate.jsonnet` (`~/.claude/ccgate.jsonnet` for Claude, `~/.codex/ccgate.jsonnet` for Codex).
+
+> [!IMPORTANT]
+> The `provider` block is replaced **atomically** across config layers — there is no per-field merge (see `${CLAUDE_PLUGIN_ROOT}/docs/configuration.md` "How layers compose", section [configuration.md](../../docs/configuration.md)). Always write the full `provider` block: `name`, `model`, `base_url` (if needed), `auth` (if needed), `timeout_ms` (if needed). Writing just one field silently drops every other field from lower layers.
+
+OpenAI example:
+
+```jsonnet
+{
+  ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/schemas/claude.schema.json',
+  provider: {
+    name: 'openai',
+    model: '<openai model name — see docs/providers.md#model-selection>',
+  },
+}
+```
+
+Reference: `${CLAUDE_PLUGIN_ROOT}/docs/providers.md` ([providers](../../docs/providers.md)).
+
+## 6. External credential helpers
+
+If the user picked "external credential helper" in §2, ccgate exposes `provider.auth.type = exec` / `file` / `profile` for refreshable credentials.
+
+This skill does **not** install or configure any specific helper. Instead:
+
+1. Point the user at `${CLAUDE_PLUGIN_ROOT}/docs/api-key-helper.md` ([api-key-helper](../../docs/api-key-helper.md)) for the helper contract.
+2. Tell them to follow the docs of whichever helper their organization ships, then come back with the `provider` block that helper produces.
+3. When they bring back a partial block, remind them again about atomic replacement (§5) — every field needs to be restated.
+
+## 7. API key setup
+
+For the chosen provider, set the matching environment variable. Reference: `${CLAUDE_PLUGIN_ROOT}/docs/providers.md` "API keys" ([providers#api-keys](../../docs/providers.md#api-keys)).
+
+Do not prescribe how to persist the env var. The user picks `direnv` / `mise` / their shell rc / a per-session export — list these as options if they ask, but do not assume any of them.
+
+If the key is missing, ccgate falls through to the upstream tool's permission prompt. Flipping providers cannot break the hook, but the hook will stop deciding until the key is in place.
+
+## 8. End-to-end verification
+
+There is no `ccgate test` command. To verify the hook is wired up:
+
+1. Open Claude Code (or Codex CLI) in any project.
+2. Trigger an operation that hits a PermissionRequest (e.g. ask the assistant to `ls` the repo).
+3. Check that a line appears in:
+   - Logs: `$XDG_STATE_HOME/ccgate/<target>/ccgate.log` (falls back to `~/.local/state/ccgate/<target>/`)
+   - Metrics: `$XDG_STATE_HOME/ccgate/<target>/metrics.jsonl`
+4. Run `ccgate <target> metrics` and confirm a row for today appears.
+
+If nothing shows up, hand off to `/ccgate:doctor` for a deeper environment audit.
+
+## What this skill does not do
+
+- It does not maintain `allow` / `deny` rules — that is `/ccgate:tune`.
+- It does not diagnose denies, fallthroughs, or 401s — that is `/ccgate:debug`.
+- It does not run a general health check — that is `/ccgate:doctor`.
+- It does not install organization-specific credential helpers — those ship separately and their docs are the source of truth.

--- a/skills/tune/SKILL.md
+++ b/skills/tune/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: tune
+description: Refine ccgate allow / deny rules from recent metrics.
+when_to_use: |
+  - User wants to add or adjust allow / deny rules in ccgate.jsonnet.
+  - "ccgate falls through too much" / "ccgate keeps denying the same command" type complaints.
+  - User reviewed `ccgate <target> metrics --details N` and wants a concrete edit proposal.
+  - User wants to add a `deny_message:` hint to an existing deny rule.
+---
+
+# ccgate rule tuning
+
+Refine the user's ccgate guidance lists (`allow` / `deny` / `environment`, or their `append_*` siblings) using the last N days of metrics as the signal.
+
+> [!IMPORTANT]
+> When the surrounding Claude Code session is in plan mode, stop at the diff stage. Do not write to any `ccgate.jsonnet` / `ccgate.local.jsonnet` until plan mode is off.
+
+## 1. Pull recent metrics
+
+```bash
+ccgate <target> metrics --json --details 5
+```
+
+`<target>` is `claude` or `codex`. The output has top fallthrough commands and top deny commands aggregated over the configured window (default 7 days).
+
+If the JSON output is empty or the user reports a custom `metrics_path`, ask them which `<target>` they want tuned — do not silently assume `claude`.
+
+## 2. Read the top entries
+
+For each top entry, extract:
+
+- `tool` (`Bash` / `Edit` / `Read` / MCP tool / `apply_patch` / etc.)
+- representative `command` / `file_path` / `pattern`
+- count of fallthrough / deny in the window
+
+Use these to decide whether the right move is:
+
+- `append_allow` — recurring fallthrough on a safe operation the LLM is unsure about.
+- `append_deny` (with `deny_message`) — recurring user requests for something that should be refused and the LLM keeps falling through.
+- Rewrite an existing rule — current `allow` / `deny` guidance is too vague or too sharp.
+
+## 3. Decide the edit target layer
+
+Inspect the candidate layer paths, in load order:
+
+| Order | Claude target | Codex target |
+|------:|---------------|--------------|
+| 2 | `~/.claude/ccgate.jsonnet` (global) | `~/.codex/ccgate.jsonnet` |
+| 3 | `{main_worktree}/.claude/ccgate.local.jsonnet` (linked worktree only, untracked-only) | `{main_worktree}/.codex/ccgate.local.jsonnet` |
+| 4 | `{repo_root}/.claude/ccgate.local.jsonnet` (untracked-only) | `{repo_root}/.codex/ccgate.local.jsonnet` |
+
+For each candidate the user names, check:
+
+- Does the file exist?
+- Is the path git-tracked (`git ls-files --error-unmatch <path>` succeeds)?
+
+> [!WARNING]
+> Project-local `ccgate.local.jsonnet` files are loaded **only when not tracked by git**. If the chosen layer is tracked, the edit will not take effect. Surface the warning and ask the user whether to switch to a global layer or move the file to untracked.
+
+Reference: `${CLAUDE_PLUGIN_ROOT}/docs/configuration.md` "Where ccgate looks for config" ([configuration](../../docs/configuration.md)).
+
+## 4. Read the existing config
+
+Once the layer is decided, read it. Note whether it currently uses replace-style fields (`allow:` / `deny:`) or append-style (`append_allow:` / `append_deny:`). The two have different semantics:
+
+- `allow:` / `deny:` replace the entire list from earlier layers (including embedded defaults).
+- `append_allow:` / `append_deny:` add to the carried-over list.
+
+Reference: `${CLAUDE_PLUGIN_ROOT}/docs/rule-tuning.md` "Replace vs append" ([rule-tuning](../../docs/rule-tuning.md#3-replace-vs-append-ie-copy-paste-or-not)).
+
+Default to `append_*` unless the user is already running a replace-style config or explicitly asks to curate the full list.
+
+## 5. Draft the edit
+
+Write one or more new rule lines. Each rule is one line of natural-language guidance.
+
+- For `append_deny` entries, **always** include a trailing `deny_message:`. The deny_message is the hint shown to the AI when the rule fires; without it, the AI sees a bare refusal and may keep trying.
+- For `append_allow` entries, write at a granularity the LLM can judge from `tool_input` / `tool_input_raw` / `referenced_paths` / `branch_name` / the command string.
+
+Example shapes (Claude target):
+
+```jsonnet
+{
+  ['$schema']: 'https://raw.githubusercontent.com/tak848/ccgate/main/schemas/claude.schema.json',
+  append_allow: [
+    'Edit / Write / MultiEdit targeting Markdown files under repo_root/docs/ is fine; content review happens elsewhere.',
+  ],
+  append_deny: [
+    'Setting production environment variables in the running session. deny_message: configure production via the deployment system, not via shell exports.',
+  ],
+}
+```
+
+Reference: `${CLAUDE_PLUGIN_ROOT}/docs/rule-tuning.md` "Writing rules" ([rule-tuning](../../docs/rule-tuning.md#4-writing-rules)).
+
+## 6. If touching the `provider` block
+
+> [!IMPORTANT]
+> The `provider` block is replaced **atomically** across layers. There is no per-field merge. Always write the full block — `name`, `model`, `base_url` (if needed), `auth` (if needed), `timeout_ms` (if needed). Writing just one field silently drops every other field from lower layers.
+
+Reference: `${CLAUDE_PLUGIN_ROOT}/docs/configuration.md` "How layers compose" ([configuration](../../docs/configuration.md)).
+
+## 7. Apply the edit
+
+Show the diff. If the session is in plan mode, stop here.
+
+Otherwise apply the edit, then suggest the next metrics cycle (re-run `ccgate <target> metrics --details N` in a day or two and check whether the targeted commands moved out of the top entries).
+
+## What this skill does not do
+
+- It does not explain **why** a specific decision was made — that is `/ccgate:debug`.
+- It does not check binary, version, hook registration, or layer routing — that is `/ccgate:doctor`.
+- It does not register the PermissionRequest hook from scratch — that is `/ccgate:setup`.


### PR DESCRIPTION
## Why

Hand ccgate setup, rule tuning, deny / 401 debug, and environment audit to an AI through Claude Code. The docs (`README.md`, `docs/configuration.md`, `docs/rule-tuning.md`, `docs/api-key-helper.md`, `docs/claude-code.md`, `docs/codex-cli.md`, `docs/providers.md`) are mature enough to back AI-driven workflows, and bundling skills alongside those docs keeps them in sync.

## What

Bundle a Claude Code plugin in this repo:

- `.claude-plugin/marketplace.json` (single-plugin marketplace, `name: tak848-ccgate`)
- `.claude-plugin/plugin.json` (`name: ccgate`, semver tracking the ccgate binary version)
- Four skills (follow in next commits on this branch):
  - `/ccgate:setup` — install + hook registration + bring-up
  - `/ccgate:tune` — rule refinement from `ccgate <target> metrics --details N`
  - `/ccgate:debug` — root cause for deny / fallthrough / 401
  - `/ccgate:doctor` — read-only environment audit
- README / `docs/ja/README.md` get a `Claude Code plugin` section pointing at install + skills

Install (subject to short-form verification): `/plugin marketplace add tak848/ccgate` → `/plugin install ccgate@tak848-ccgate`.

Draft until the skills, README sections, and local install verification land on this branch.