### PR TITLE
feat: add codex-oauth provider support for ChatGPT-authenticated Code…

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ Export the matching API key — see [docs/providers.md#api-keys](docs/providers.
 
 Provider switching, model selection constraints, API key resolution order, and compatible-proxy setup are all consolidated in [docs/providers.md](docs/providers.md).
 
+For ChatGPT subscription-backed Codex classification, set `provider.name: 'codex-oauth'`. It uses `codex app-server` and an isolated Codex `CODEX_HOME` under ccgate state by default; sign in once with `CODEX_HOME="${XDG_STATE_HOME:-$HOME/.local/state}/ccgate/codex-oauth/codex-home" codex login`.
+
 **Refreshable credentials** (AWS STS, Vertex ADC, OpenAI-compatible gateways with virtual keys, internal key brokers — anything a static env var cannot keep up with) are handled via `provider.auth`. Three shapes are supported:
 
 - `type=exec` — ccgate runs a **credential helper** command and uses its stdout as the credential, with caching keyed on `expires_at`.

--- a/ccgate.schema.json
+++ b/ccgate.schema.json
@@ -105,6 +105,14 @@
           "type": "integer",
           "minimum": 0,
           "description": "API timeout in milliseconds. 0 means no timeout. Default: 20000"
+        },
+        "codex_bin": {
+          "type": "string",
+          "description": "codex-oauth only. Path to the Codex CLI executable that provides `codex app-server`. Empty value resolves to `codex` on PATH."
+        },
+        "codex_home": {
+          "type": "string",
+          "description": "codex-oauth only. CODEX_HOME used for ChatGPT OAuth credentials. Empty value resolves to $XDG_STATE_HOME/ccgate/codex-oauth/codex-home (or ~/.local/state/ccgate/codex-oauth/codex-home)."
         }
       }
     },

--- a/docs/api-key-helper.md
+++ b/docs/api-key-helper.md
@@ -12,6 +12,8 @@ When the credential the provider needs rotates faster than a static env var can 
 
 (`*_API_KEY` env var is a separate path used when `provider.auth` is omitted — it's not one of the `auth` modes.)
 
+`provider.name="codex-oauth"` is separate from this mechanism: it uses Codex app-server's ChatGPT login cache under `provider.codex_home`, not `provider.auth` or API keys.
+
 The shell that runs an `exec` helper is selected per-config via `auth.shell` (default `bash`); see [Helper contract](#helper-contract) for the shells ccgate currently spawns.
 
 ## Config

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,11 +49,13 @@ If you want repo-wide policy that everyone gets, ship it in your own fork's embe
 
 | Field                    | Type                              | Default                                                                       | Description                                                                                            |
 |--------------------------|-----------------------------------|-------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
-| `provider.name`          | string                            | `"anthropic"`                                                                 | Provider name. One of `"anthropic"` / `"openai"` / `"gemini"`. See [docs/providers.md](providers.md).   |
+| `provider.name`          | string                            | `"anthropic"`                                                                 | Provider name. One of `"anthropic"` / `"openai"` / `"gemini"` / `"codex-oauth"`. See [docs/providers.md](providers.md). |
 | `provider.model`         | string                            | `"claude-haiku-4-5"`                                                          | Model name. See [docs/providers.md](providers.md#model-selection) for selection guidance.              |
 | `provider.base_url`      | string                            | `""`                                                                          | API base URL override. Empty = SDK default. See [docs/providers.md#base_url-and-compatible-proxies](providers.md#base_url-and-compatible-proxies). |
 | `provider.auth`          | object (`{type, ...}`)            | (omit = env var)                                                              | Discriminated union for refreshable credentials. `type=exec` / `type=file` / `type=profile`. See [docs/api-key-helper.md](api-key-helper.md). |
 | `provider.timeout_ms`    | int                               | `20000`                                                                       | API timeout (ms). `0` = no timeout.                                                                    |
+| `provider.codex_bin`     | string                            | `"codex"`                                                                     | `codex-oauth` only. Codex CLI executable that provides `codex app-server`.                             |
+| `provider.codex_home`    | string                            | `$XDG_STATE_HOME/ccgate/codex-oauth/codex-home`                               | `codex-oauth` only. CODEX_HOME for ChatGPT OAuth credentials. Supports absolute or `~/` paths.         |
 | `log_path`               | string                            | `$XDG_STATE_HOME/ccgate/<target>/ccgate.log`                                  | Log file path. Supports `~` for home directory.                                                        |
 | `log_disabled`           | bool                              | `false`                                                                       | Disable logging entirely.                                                                              |
 | `log_max_size`           | int                               | `5242880`                                                                     | Max log file size in bytes before rotation (default 5MB). `0` = no rotation.                           |
@@ -157,7 +159,7 @@ ccgate codex  metrics --days 7         # same shape, codex side
 
 `ft_kind` is filled when the LLM returned (or the runtime forced) a fallthrough; the value tells you which fallback path fired (`llm`, `api_unusable`, `no_apikey`, `credential_unavailable`, `unknown_provider`, `bypass`, `dontask`, `user_interaction`). `forced=true` means `fallthrough_strategy` promoted an LLM `fallthrough` into the recorded `decision`.
 
-`credential_source` is set only when `ft_kind=credential_unavailable`. It carries the credential stage that produced (or failed to produce) the credential — `exec` / `file` / `cache` / `lock` (matching the keystore-managed `auth.type=exec` / `auth.type=file` paths) plus `profile` (Anthropic-only `auth.type=profile`, which delegates resolution to anthropic-sdk-go and never touches the keystore). The set is open and consumers parsing this field should treat it as a free-form short string and tolerate unknown values rather than enum-validate it.
+`credential_source` is set only when `ft_kind=credential_unavailable`. It carries the credential stage that produced (or failed to produce) the credential — `exec` / `file` / `cache` / `lock` (matching the keystore-managed `auth.type=exec` / `auth.type=file` paths), `profile` (Anthropic-only `auth.type=profile`, which delegates resolution to anthropic-sdk-go and never touches the keystore), or `codex-oauth` (Codex app-server ChatGPT login). The set is open and consumers parsing this field should treat it as a free-form short string and tolerate unknown values rather than enum-validate it.
 
 The `reason` field meaning depends on `ft_kind`:
 
@@ -183,12 +185,15 @@ The `reason` field meaning depends on `ft_kind`:
 | `cache_unavailable`     | Cache directory cannot be created or `chmod`'d. Fail-fast (helper exec is skipped). |
 | `provider_auth`         | Provider rejected the credential with HTTP 401 or 403. |
 | `profile_load`          | `auth.type=profile` could not produce a usable credential before the SDK ran. |
+| `codex_oauth_login`     | `provider.name="codex-oauth"` could not use a ChatGPT-authenticated Codex account from `provider.codex_home`. |
 
 `cache_unavailable` is fail-fast because without the sibling lock file ccgate cannot serialise concurrent helpers and would let them race the broker.
 
 `provider_auth` reaction by `auth.type`: `exec` invalidates the cache so the next fire re-runs the helper, `file` falls through (no cache to clear), `profile` falls through (the SDK's refresh-token loop owns the credential). Env-var keys are not routed here because ccgate cannot rotate env vars and swallowing the rejection would hide user-side misconfiguration. So `credential_unavailable` covers both "credential resolution failed" and "provider received and rejected the credential" (401 / 403).
 
 `profile_load` cause is narrowed by the slog `error_class` field; see the [Recovery checklist in docs/api-key-helper.md](api-key-helper.md#recovery-checklist) for the full label list and triage steps.
+
+`codex_oauth_login` usually means the configured `CODEX_HOME` has no ChatGPT login yet, is logged in with an API key instead of ChatGPT, or the cached ChatGPT token was rejected by Codex. Run `CODEX_HOME=<provider.codex_home> codex login` with ChatGPT, or remove API-key credentials from that Codex home.
 
 #### Log-only credential warnings (not in metrics)
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -222,6 +222,8 @@ provider と hook の登録が済んでから、自分の `allow` / `deny` / `ap
 
 provider の切替手順、 モデル選定時の確認事項、 API キーの解決順、 互換 proxy 経由での利用は [docs/ja/providers.md](providers.md) にまとめてあります。
 
+ChatGPT サブスクリプションの Codex で分類したい場合は `provider.name: 'codex-oauth'` を設定します。`codex app-server` と ccgate state 配下の専用 Codex `CODEX_HOME` を使うため、初回だけ `CODEX_HOME="${XDG_STATE_HOME:-$HOME/.local/state}/ccgate/codex-oauth/codex-home" codex login` でログインしてください。
+
 **Refresh される credential** (AWS STS / Vertex ADC / OpenAI 互換 gateway の virtual key / 社内 key broker など、 静的 env では追従できないケース) を扱いたいときは `provider.auth` を設定します。 3 形式から選びます:
 
 - `type=exec` — ccgate が **credential helper** コマンドを実行し、 stdout を credential として使う (`expires_at` を keyed cache)。

--- a/docs/ja/api-key-helper.md
+++ b/docs/ja/api-key-helper.md
@@ -12,6 +12,8 @@ provider に渡す credential が静的な環境変数では追いつかない�
 
 (`*_API_KEY` env var は `provider.auth` が省略されている場合の別経路。`auth` のモードではありません。)
 
+`provider.name="codex-oauth"` はこの仕組みとは別です。`provider.auth` や API key ではなく、`provider.codex_home` 配下の Codex app-server / CLI の ChatGPT login cache を使います。
+
 `exec` の helper を動かすシェルは `auth.shell` で選択 (default `bash`)。詳細は [helper の契約](#helper-の契約) を参照。
 
 ## 設定

--- a/docs/ja/configuration.md
+++ b/docs/ja/configuration.md
@@ -49,11 +49,13 @@ repo 全体に効くポリシーが必要なら、自前 fork の埋込デフォ
 
 | フィールド               | 型                                | デフォルト                                                                       | 説明                                                                                                       |
 |--------------------------|-----------------------------------|---------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
-| `provider.name`          | string                            | `"anthropic"`                                                                   | プロバイダー名。`"anthropic"` / `"openai"` / `"gemini"`。詳細は [docs/ja/providers.md](providers.md)。      |
+| `provider.name`          | string                            | `"anthropic"`                                                                   | プロバイダー名。`"anthropic"` / `"openai"` / `"gemini"` / `"codex-oauth"`。詳細は [docs/ja/providers.md](providers.md)。 |
 | `provider.model`         | string                            | `"claude-haiku-4-5"`                                                            | モデル名。選定指針は [docs/ja/providers.md](providers.md#モデル選択) を参照。                              |
 | `provider.base_url`      | string                            | `""`                                                                            | API base URL の上書き。空文字列 (default) で SDK の既定 endpoint を使用。詳細は [docs/ja/providers.md#base_url-と互換-proxy](providers.md#base_url-と互換-proxy)。 |
 | `provider.auth`          | object (`{type, ...}`)            | (省略時は env var)                                                              | refresh される credential を扱う discriminated union。`type=exec` / `type=file` / `type=profile`。詳細は [docs/ja/api-key-helper.md](api-key-helper.md)。 |
 | `provider.timeout_ms`    | int                               | `20000`                                                                         | API タイムアウト (ms)。`0` = タイムアウトなし。                                                            |
+| `provider.codex_bin`     | string                            | `"codex"`                                                                       | `codex-oauth` 専用。`codex app-server` を提供する Codex CLI 実行ファイル。                               |
+| `provider.codex_home`    | string                            | `$XDG_STATE_HOME/ccgate/codex-oauth/codex-home`                                 | `codex-oauth` 専用。ChatGPT OAuth credential 用の CODEX_HOME。絶対パスまたは `~/` パス。                  |
 | `log_path`               | string                            | `$XDG_STATE_HOME/ccgate/<target>/ccgate.log`                                    | ログファイルパス。`~` でホームディレクトリ展開。                                                           |
 | `log_disabled`           | bool                              | `false`                                                                         | ログ出力を完全に無効化。                                                                                   |
 | `log_max_size`           | int                               | `5242880`                                                                       | ローテーション閾値 (bytes, デフォルト 5MB)。`0` = ローテーションなし。                                     |
@@ -157,7 +159,7 @@ ccgate codex  metrics --days 7         # codex 側も同 shape
 
 `ft_kind` は LLM (またはランタイム) が fallthrough を返したときに埋まり、どの fallback path が発火したかを示します (`llm`, `api_unusable`, `no_apikey`, `credential_unavailable`, `unknown_provider`, `bypass`, `dontask`, `user_interaction`)。`forced=true` は `fallthrough_strategy` が LLM `fallthrough` を `decision` に promote したことを意味します。
 
-`credential_source` は `ft_kind=credential_unavailable` のときだけ埋まります。credential 解決のどの段階で起きた / 失敗したかを示し、 `exec` / `file` / `cache` / `lock` (keystore 経由の `auth.type=exec` / `auth.type=file`)、 `profile` (Anthropic 専用 `auth.type=profile`、解決は anthropic-sdk-go に委譲し keystore は通らない) を取ります。値の集合は open で、この field を parse する側は固定 enum で validation せず、未知の短い文字列を許容してください。
+`credential_source` は `ft_kind=credential_unavailable` のときだけ埋まります。credential 解決のどの段階で起きた / 失敗したかを示し、 `exec` / `file` / `cache` / `lock` (keystore 経由の `auth.type=exec` / `auth.type=file`)、 `profile` (Anthropic 専用 `auth.type=profile`、解決は anthropic-sdk-go に委譲し keystore は通らない)、 `codex-oauth` (Codex app-server の ChatGPT login) を取ります。値の集合は open で、この field を parse する側は固定 enum で validation せず、未知の短い文字列を許容してください。
 
 `reason` の意味は `ft_kind` で文脈が変わります:
 
@@ -183,12 +185,15 @@ ccgate codex  metrics --days 7         # codex 側も同 shape
 | `cache_unavailable`     | cache dir を作成 / `chmod` できない。 fail-fast (helper exec せずに fallthrough)。 |
 | `provider_auth`         | provider が HTTP 401 または 403 で credential を拒否。 |
 | `profile_load`          | `auth.type=profile` で credential を SDK に渡す前に失敗。 |
+| `codex_oauth_login`     | `provider.name="codex-oauth"` が `provider.codex_home` の ChatGPT 認証済み Codex account を使えなかった。 |
 
 `cache_unavailable` が fail-fast なのは、 隣接 lock file も作れず concurrent helper の race を防げないためです。
 
 `provider_auth` の `auth.type` 別挙動: `exec` は cache を invalidate して次回 hook 発火時に helper を再実行、 `file` は内部 cache がないため fallthrough のみ、 `profile` も fallthrough (SDK の refresh-token loop が credential を保有)。 env var 経路は意図的にこの経路に乗せず exit 1 (ccgate からは rotate できず、 握り潰すと user 側の設定ミスを隠してしまうため)。 したがって `credential_unavailable` は「credential 解決に失敗した」だけでなく「provider が credential を受け取った上で拒否した」 (401 / 403) ケースも含みます。
 
 `profile_load` の具体的な原因は slog の `error_class` で narrow できます (profile config 不在 / parse error / profile 名不正、 credentials file の preflight 失敗 = 不在 / 読めない、 など)。 完全なラベルと triage 手順は [docs/ja/api-key-helper.md の障害時の復旧チェックリスト](api-key-helper.md#障害時の復旧チェックリスト) を参照。
+
+`codex_oauth_login` は、設定された `CODEX_HOME` に ChatGPT login がまだ無い、API key login になっていて `codex-oauth` の契約と合わない、または cached ChatGPT token が Codex に拒否された場合に出ます。`CODEX_HOME=<provider.codex_home> codex login` を ChatGPT で実行するか、その Codex home から API key credential を取り除いてください。
 
 #### log のみで出る credential 警告 (metrics には乗らない)
 

--- a/docs/ja/providers.md
+++ b/docs/ja/providers.md
@@ -11,6 +11,7 @@ ccgate は各 PermissionRequest を provider LLM (default: Claude Haiku) に投�
 | `anthropic`     | `anthropic-sdk-go` | `claude-haiku-4-5`               |
 | `openai`        | `openai-go`        | (`provider.model` で明示指定が必要) |
 | `gemini`        | Gemini の OpenAI 互換 endpoint 経由で `openai-go` | (同じく明示指定が必要) |
+| `codex-oauth`   | Codex app-server (stdio JSON-RPC) | (明示指定、例: `gpt-5.4`) |
 
 ## Provider の切り替え
 
@@ -27,6 +28,25 @@ ccgate は各 PermissionRequest を provider LLM (default: Claude Haiku) に投�
 
 対応する API キー (下の [API キー](#api-キー) 参照) を export してください。キーが見つからない場合 ccgate は上流ツールの確認画面に fallthrough するので、 provider 切替で hook が壊れることはありません。
 
+ChatGPT サブスクリプションで Codex を使う場合は `codex-oauth` を使います:
+
+```jsonnet
+{
+  provider: {
+    name: 'codex-oauth',
+    model: 'gpt-5.4',
+  },
+}
+```
+
+`codex-oauth` は分類ごとに `codex app-server` を起動し、Codex 側の ChatGPT login を使います。既定では `$XDG_STATE_HOME/ccgate/codex-oauth/codex-home` (未設定なら `~/.local/state/ccgate/codex-oauth/codex-home`) を専用 `CODEX_HOME` として使い、そこに `cli_auth_credentials_store = "file"` の Codex `config.toml` を作ります。初回だけ次でログインしてください:
+
+```sh
+CODEX_HOME="${XDG_STATE_HOME:-$HOME/.local/state}/ccgate/codex-oauth/codex-home" codex login
+```
+
+普段使いの `~/.codex` などを意図的に再利用したい場合は `provider.codex_home`、`codex` が `PATH` にない場合は `provider.codex_bin` を設定します。`codex-oauth` の子プロセスからは `CODEX_API_KEY` / `OPENAI_API_KEY` / `CCGATE_OPENAI_API_KEY` を除去するため、API key 課金へ silent に落ちることはありません。
+
 ## API キー
 
 `CCGATE_*_API_KEY` が優先され bare 変数を上書きします。 AI ツール本体の API キーと ccgate 用キーを分けられます。
@@ -36,8 +56,11 @@ ccgate は各 PermissionRequest を provider LLM (default: Claude Haiku) に投�
 | `anthropic`     | `CCGATE_ANTHROPIC_API_KEY` | `ANTHROPIC_API_KEY`   | <https://platform.claude.com/settings/keys> |
 | `openai`        | `CCGATE_OPENAI_API_KEY`    | `OPENAI_API_KEY`      | <https://platform.openai.com/api-keys>      |
 | `gemini`        | `CCGATE_GEMINI_API_KEY`    | `GEMINI_API_KEY`      | <https://aistudio.google.com/app/api-keys>  |
+| `codex-oauth`   | (なし)                     | (なし)                | ChatGPT で `codex login`                    |
 
 全体の解決順: `provider.auth` (設定済み) → `CCGATE_*_API_KEY` → `*_API_KEY`。`provider.auth` を設定した状態で失敗しても env var に silent に fallback はせず、 `kind=credential_unavailable` で fallthrough します。 helper の契約と復旧手順は [docs/ja/api-key-helper.md](api-key-helper.md) を参照。
+
+`codex-oauth` は例外で、`provider.auth` や API key env var を使いません。ChatGPT OAuth の保存と token refresh は Codex app-server / CLI の login cache に委譲します。
 
 ## モデル選択
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -11,6 +11,7 @@ ccgate calls a provider LLM (default: Claude Haiku) to classify each PermissionR
 | `anthropic`     | `anthropic-sdk-go` | `claude-haiku-4-5` |
 | `openai`        | `openai-go`        | (set explicitly via `provider.model`) |
 | `gemini`        | `openai-go` against Gemini's OpenAI-compat endpoint | (set explicitly) |
+| `codex-oauth`   | Codex app-server over stdio | (set explicitly, e.g. `gpt-5.4`) |
 
 ## Switching providers
 
@@ -27,6 +28,25 @@ Set `provider.name` (and `provider.model` when needed) in any layer:
 
 Export the matching API key (see [API keys](#api-keys) below). If the key is missing, ccgate falls through to the upstream tool's permission prompt, so a wrong provider name cannot break the hook.
 
+For ChatGPT subscription-backed Codex usage, use `codex-oauth`:
+
+```jsonnet
+{
+  provider: {
+    name: 'codex-oauth',
+    model: 'gpt-5.4',
+  },
+}
+```
+
+`codex-oauth` starts `codex app-server` for each classification and requires a ChatGPT-authenticated Codex login. By default ccgate isolates that login under `$XDG_STATE_HOME/ccgate/codex-oauth/codex-home` (or `~/.local/state/ccgate/codex-oauth/codex-home`) and writes a local Codex `config.toml` there with `cli_auth_credentials_store = "file"`. Sign in once with:
+
+```sh
+CODEX_HOME="${XDG_STATE_HOME:-$HOME/.local/state}/ccgate/codex-oauth/codex-home" codex login
+```
+
+Set `provider.codex_home` if you intentionally want to reuse another Codex profile, such as `~/.codex`. Set `provider.codex_bin` if `codex` is not on `PATH`. The child app-server process has `CODEX_API_KEY`, `OPENAI_API_KEY`, and `CCGATE_OPENAI_API_KEY` removed from its environment so this provider does not silently fall back to API-key billing.
+
 ## API keys
 
 `CCGATE_*_API_KEY` is the preferred name and overrides the bare variant, so ccgate's key can stay separate from the AI tool's own key.
@@ -36,8 +56,11 @@ Export the matching API key (see [API keys](#api-keys) below). If the key is mis
 | `anthropic`     | `CCGATE_ANTHROPIC_API_KEY` | `ANTHROPIC_API_KEY`  | <https://platform.claude.com/settings/keys> |
 | `openai`        | `CCGATE_OPENAI_API_KEY`    | `OPENAI_API_KEY`     | <https://platform.openai.com/api-keys>      |
 | `gemini`        | `CCGATE_GEMINI_API_KEY`    | `GEMINI_API_KEY`     | <https://aistudio.google.com/app/api-keys>  |
+| `codex-oauth`   | (none)                     | (none)               | `codex login` with ChatGPT                  |
 
 Resolution order overall: `provider.auth` (when set) → `CCGATE_*_API_KEY` → `*_API_KEY`. When `provider.auth` is set and fails, ccgate does **not** silently fall back to env vars — the hook falls through with `kind=credential_unavailable`. See [docs/api-key-helper.md](api-key-helper.md) for the helper contract and recovery.
+
+`codex-oauth` is the exception: it does not use `provider.auth` or API key env vars. It delegates ChatGPT OAuth storage and token refresh to Codex's app-server / CLI login cache.
 
 ## Model selection
 

--- a/internal/cmd/claude/defaults.jsonnet
+++ b/internal/cmd/claude/defaults.jsonnet
@@ -18,9 +18,14 @@
     // Alternatives:
     //   name: 'openai',  model: 'gpt-4o-mini',        (env: OPENAI_API_KEY)
     //   name: 'gemini',  model: 'gemini-2.0-flash',    (env: GEMINI_API_KEY)
+    //   name: 'codex-oauth', model: 'gpt-5.4',          (ChatGPT OAuth via Codex app-server)
     // base_url:  route through an OpenAI-/Anthropic-compatible proxy.
     //            See https://github.com/tak848/ccgate/blob/main/docs/providers.md#base_url-and-compatible-proxies
     // timeout_ms: API timeout in ms, default 20000.
+    // codex-oauth only:
+    //   codex_bin:  path to the Codex CLI executable (default: codex)
+    //   codex_home: isolated CODEX_HOME for ChatGPT OAuth credentials
+    //               (default: $XDG_STATE_HOME/ccgate/codex-oauth/codex-home)
     // auth: short-lived / rotating credentials. Discriminated
     //   by auth.type:
     //     auth: { type: 'exec', command: '/usr/local/bin/my-broker --provider anthropic' }

--- a/internal/cmd/codex/defaults.jsonnet
+++ b/internal/cmd/codex/defaults.jsonnet
@@ -28,9 +28,14 @@
     // Alternatives:
     //   name: 'openai',  model: 'gpt-4o-mini',        (env: OPENAI_API_KEY)
     //   name: 'gemini',  model: 'gemini-2.0-flash',    (env: GEMINI_API_KEY)
+    //   name: 'codex-oauth', model: 'gpt-5.4',          (ChatGPT OAuth via Codex app-server)
     // base_url:  route through an OpenAI-/Anthropic-compatible proxy.
     //            See https://github.com/tak848/ccgate/blob/main/docs/providers.md#base_url-and-compatible-proxies
     // timeout_ms: API timeout in ms, default 20000.
+    // codex-oauth only:
+    //   codex_bin:  path to the Codex CLI executable (default: codex)
+    //   codex_home: isolated CODEX_HOME for ChatGPT OAuth credentials
+    //               (default: $XDG_STATE_HOME/ccgate/codex-oauth/codex-home)
     // auth: short-lived / rotating credentials. Discriminated
     //   by auth.type:
     //     auth: { type: 'exec', command: '/usr/local/bin/my-broker --provider anthropic' }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ const (
 	DefaultTimeoutMS      = 20_000
 	DefaultModel          = string(anthropic.ModelClaudeHaiku4_5)
 	DefaultProvider       = "anthropic"
+	DefaultCodexOAuthBin  = "codex"
 	DefaultLogMaxSize     = 5 * 1024 * 1024 // 5MB
 	DefaultMetricsMaxSize = 2 * 1024 * 1024 // 2MB
 	BaseConfigName        = "ccgate.jsonnet"
@@ -153,6 +154,17 @@ type ProviderConfig struct {
 	// sources (`type=exec` shell helper, `type=file` rotator file).
 	Auth      *AuthConfig `json:"auth,omitempty"`
 	TimeoutMS *int        `json:"timeout_ms,omitempty"`
+	// CodexBin is used only when provider.name="codex-oauth".
+	// It points at the Codex CLI executable that exposes
+	// `codex app-server`. Empty value resolves to "codex" on PATH.
+	CodexBin string `json:"codex_bin,omitempty"`
+	// CodexHome is used only when provider.name="codex-oauth".
+	// Empty value resolves to $XDG_STATE_HOME/ccgate/codex-oauth/codex-home
+	// (or ~/.local/state/ccgate/codex-oauth/codex-home). ccgate sets
+	// CODEX_HOME to this directory for the app-server child process so
+	// ChatGPT OAuth credentials stay isolated from the user's normal
+	// Codex CLI profile unless the user explicitly overrides it.
+	CodexHome string `json:"codex_home,omitempty"`
 }
 
 // AuthConfig is the discriminated union for short-lived / rotating
@@ -198,6 +210,23 @@ func (p ProviderConfig) GetTimeoutMS() int {
 		return DefaultTimeoutMS
 	}
 	return *p.TimeoutMS
+}
+
+// GetCodexBin returns the Codex CLI executable for provider.name="codex-oauth".
+func (p ProviderConfig) GetCodexBin() string {
+	if strings.TrimSpace(p.CodexBin) == "" {
+		return DefaultCodexOAuthBin
+	}
+	return strings.TrimSpace(p.CodexBin)
+}
+
+// ResolveCodexHome returns the CODEX_HOME directory ccgate should pass to
+// `codex app-server` for provider.name="codex-oauth".
+func (p ProviderConfig) ResolveCodexHome() string {
+	if strings.TrimSpace(p.CodexHome) == "" {
+		return DefaultCodexOAuthHome()
+	}
+	return resolvePath(strings.TrimSpace(p.CodexHome))
 }
 
 // GetRefreshMargin returns the refresh margin as a time.Duration,
@@ -434,6 +463,15 @@ func StateDir(sub string) string {
 // under StateDir.
 func DefaultAuthPath(target string) string {
 	return filepath.Join(StateDir(target), "auth_key.json")
+}
+
+// DefaultCodexOAuthHome is the isolated CODEX_HOME used by
+// provider.name="codex-oauth" when the user does not override
+// provider.codex_home. It lives under ccgate state rather than
+// ~/.codex so the provider does not mutate the user's primary Codex
+// CLI/app profile by default.
+func DefaultCodexOAuthHome() string {
+	return filepath.Join(StateDir("codex-oauth"), "codex-home")
 }
 
 // Load composes the runtime config from three layers, all using the

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -226,6 +226,54 @@ func TestProfileAuthCrossFieldProvider(t *testing.T) {
 	}
 }
 
+func TestValidateCodexOAuthProviderFields(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		provider ProviderConfig
+		wantErr  bool
+	}{
+		"codex oauth minimal": {
+			provider: ProviderConfig{Name: "codex-oauth", Model: "gpt-5.4", TimeoutMS: intPtr(1000)},
+		},
+		"codex oauth with home and bin": {
+			provider: ProviderConfig{Name: "codex-oauth", Model: "gpt-5.4", TimeoutMS: intPtr(1000), CodexHome: "~/.local/state/ccgate/codex-oauth/codex-home", CodexBin: "codex"},
+		},
+		"codex oauth rejects auth": {
+			provider: ProviderConfig{Name: "codex-oauth", Model: "gpt-5.4", TimeoutMS: intPtr(1000), Auth: &AuthConfig{Type: AuthTypeExec, Command: "echo sk"}},
+			wantErr:  true,
+		},
+		"codex oauth rejects base url": {
+			provider: ProviderConfig{Name: "codex-oauth", Model: "gpt-5.4", TimeoutMS: intPtr(1000), BaseURL: "https://example.test"},
+			wantErr:  true,
+		},
+		"codex oauth rejects relative home": {
+			provider: ProviderConfig{Name: "codex-oauth", Model: "gpt-5.4", TimeoutMS: intPtr(1000), CodexHome: ".codex"},
+			wantErr:  true,
+		},
+		"other provider rejects codex home": {
+			provider: ProviderConfig{Name: "openai", Model: "gpt-test", TimeoutMS: intPtr(1000), CodexHome: "~/.codex"},
+			wantErr:  true,
+		},
+		"other provider rejects codex bin": {
+			provider: ProviderConfig{Name: "openai", Model: "gpt-test", TimeoutMS: intPtr(1000), CodexBin: "codex"},
+			wantErr:  true,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			err := Config{Provider: tc.provider}.Validate()
+			if tc.wantErr && err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected validation error: %v", err)
+			}
+		})
+	}
+}
+
 func TestAuthDurationDefaults(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -21,14 +21,18 @@ func (c Config) Validate() error {
 	if err := validateAuth(c.Provider.Auth); err != nil {
 		errs = append(errs, err)
 	}
+	providerName := strings.ToLower(strings.TrimSpace(c.Provider.Name))
 	// type=profile delegates to anthropic-sdk-go's profile loader, so
 	// the abstraction only makes sense when the provider is anthropic.
 	// Catch the obvious user error (`provider.name = "openai" + auth.type
 	// = "profile"`) at config load time instead of at the first hook fire.
 	if c.Provider.Auth != nil && c.Provider.Auth.Type == AuthTypeProfile {
-		if strings.ToLower(strings.TrimSpace(c.Provider.Name)) != "anthropic" {
+		if providerName != "anthropic" {
 			errs = append(errs, fmt.Errorf(`provider.auth.type=%q is only supported when provider.name="anthropic"`, AuthTypeProfile))
 		}
+	}
+	if err := validateCodexOAuthProviderFields(c.Provider, providerName); err != nil {
+		errs = append(errs, err)
 	}
 	if c.LogMaxSize != nil && *c.LogMaxSize < 0 {
 		errs = append(errs, fmt.Errorf("log_max_size must not be negative, got %d", *c.LogMaxSize))
@@ -45,6 +49,56 @@ func (c Config) Validate() error {
 		}
 	}
 	return errors.Join(errs...)
+}
+
+func validateCodexOAuthProviderFields(p ProviderConfig, providerName string) error {
+	var errs []error
+	switch providerName {
+	case "codex-oauth":
+		if p.Auth != nil {
+			errs = append(errs, fmt.Errorf(`provider.auth is not supported when provider.name="codex-oauth"; use Codex ChatGPT login under provider.codex_home instead`))
+		}
+		if strings.TrimSpace(p.BaseURL) != "" {
+			errs = append(errs, fmt.Errorf(`provider.base_url is not supported when provider.name="codex-oauth"`))
+		}
+		if p.CodexBin != "" && strings.TrimSpace(p.CodexBin) == "" {
+			errs = append(errs, fmt.Errorf("provider.codex_bin must not be whitespace only"))
+		}
+		if p.CodexHome != "" {
+			if strings.TrimSpace(p.CodexHome) == "" {
+				errs = append(errs, fmt.Errorf("provider.codex_home must not be whitespace only"))
+			} else if err := validateCodexHomePath(p.CodexHome); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	default:
+		if strings.TrimSpace(p.CodexBin) != "" {
+			errs = append(errs, fmt.Errorf(`provider.codex_bin is only supported when provider.name="codex-oauth"`))
+		}
+		if strings.TrimSpace(p.CodexHome) != "" {
+			errs = append(errs, fmt.Errorf(`provider.codex_home is only supported when provider.name="codex-oauth"`))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func validateCodexHomePath(path string) error {
+	v := strings.TrimSpace(path)
+	if v == "~" || v == "~/" {
+		return fmt.Errorf("provider.codex_home must point at a directory below home, got bare %q", v)
+	}
+	if strings.HasPrefix(v, "~/") || strings.HasPrefix(v, "/") || strings.HasPrefix(v, `\\`) {
+		return nil
+	}
+	// Windows absolute paths are accepted by filepath.IsAbs in
+	// validateAuthPath's callers only after importing filepath. Keep
+	// this function dependency-light and accept drive-letter paths
+	// explicitly; all other relative values are rejected because this
+	// directory stores OAuth credentials and should not vary by hook cwd.
+	if len(v) >= 3 && ((v[0] >= 'A' && v[0] <= 'Z') || (v[0] >= 'a' && v[0] <= 'z')) && v[1] == ':' && (v[2] == '\\' || v[2] == '/') {
+		return nil
+	}
+	return fmt.Errorf("provider.codex_home must be absolute or ~/-prefixed, got %q", v)
 }
 
 // validateAuth enforces the discriminated-union shape of provider.auth.

--- a/internal/keystore/keystore.go
+++ b/internal/keystore/keystore.go
@@ -49,6 +49,10 @@ const (
 	// the shared vocabulary so runner can route the fallthrough into
 	// the same `reason=` slot as the keystore-resolved cases.
 	ReasonProfileLoad Reason = "profile_load"
+	// ReasonCodexOAuthLogin is produced by internal/llm/codexoauth
+	// when provider.name="codex-oauth" cannot use a ChatGPT
+	// authenticated Codex account from its CODEX_HOME.
+	ReasonCodexOAuthLogin Reason = "codex_oauth_login"
 
 	// Log-only (Resolve still succeeds; these never sit in metrics).
 	ReasonCacheParse Reason = "cache_parse"

--- a/internal/llm/codexoauth/client.go
+++ b/internal/llm/codexoauth/client.go
@@ -1,0 +1,650 @@
+// Package codexoauth implements llm.Provider by driving the Codex
+// app-server over stdio. The app-server owns ChatGPT subscription
+// authentication and token refresh; ccgate only supplies a
+// classification prompt and parses the structured final answer.
+package codexoauth
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/tak848/ccgate/internal/llm"
+)
+
+const (
+	defaultCodexBin           = "codex"
+	serviceName               = "ccgate"
+	threadSandboxModeReadOnly = "read-only"
+	turnSandboxPolicyReadOnly = "readOnly"
+	maxLineBytes              = 16 * 1024 * 1024
+)
+
+var (
+	// ErrAuthUnavailable means the Codex app-server could not find a
+	// ChatGPT-authenticated account in CODEX_HOME, or the cached
+	// ChatGPT token was rejected. runner.decide treats it as a
+	// credential_unavailable fallthrough rather than an exit-1 error.
+	ErrAuthUnavailable = errors.New("codex-oauth: ChatGPT Codex auth unavailable")
+	// ErrWrongAuthMode means the Codex app-server is logged in with
+	// an API key, which would defeat provider.name="codex-oauth"'s
+	// contract of using ChatGPT subscription auth.
+	ErrWrongAuthMode = errors.New("codex-oauth: Codex account is not ChatGPT auth")
+)
+
+// Client talks to `codex app-server` over stdio.
+type Client struct {
+	CodexBin        string
+	CodexHome       string
+	EnsureCodexHome bool
+}
+
+// Decide sends a single classification request through Codex and
+// parses the app-server's structured final response.
+func (c *Client) Decide(ctx context.Context, p llm.Prompt) (llm.Result, error) {
+	if p.TimeoutMS > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(p.TimeoutMS)*time.Millisecond)
+		defer cancel()
+	}
+
+	if c.EnsureCodexHome {
+		if err := ensureManagedCodexHome(c.CodexHome); err != nil {
+			return llm.Result{}, fmt.Errorf("prepare codex home: %w", err)
+		}
+	}
+
+	s, err := startAppServer(ctx, c.CodexBin, c.CodexHome)
+	if err != nil {
+		return llm.Result{}, err
+	}
+	defer s.Close()
+
+	if err := s.initialize(); err != nil {
+		return llm.Result{}, fmt.Errorf("initialize app-server: %w", err)
+	}
+	if err := s.requireChatGPTAccount(); err != nil {
+		return llm.Result{}, err
+	}
+
+	threadID, err := s.startThread(p)
+	if err != nil {
+		return llm.Result{}, fmt.Errorf("start thread: %w", err)
+	}
+	defer s.archiveThread(threadID)
+
+	turnID, err := s.startTurn(threadID, p)
+	if err != nil {
+		return llm.Result{}, fmt.Errorf("start turn: %w", err)
+	}
+	text, err := s.waitTurn(threadID, turnID)
+	if err != nil {
+		return llm.Result{}, err
+	}
+
+	out, err := parseOutput(text)
+	if err != nil {
+		return llm.Result{}, err
+	}
+	if out.Behavior == llm.BehaviorDeny && strings.TrimSpace(out.DenyMessage) == "" {
+		out.DenyMessage = llm.DefaultDenyMessage
+	}
+	return llm.Result{Output: out}, nil
+}
+
+func ensureManagedCodexHome(home string) error {
+	if strings.TrimSpace(home) == "" {
+		return nil
+	}
+	if err := os.MkdirAll(home, 0o700); err != nil {
+		return fmt.Errorf("create %s: %w", home, err)
+	}
+	configPath := filepath.Join(home, "config.toml")
+	if _, err := os.Stat(configPath); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat %s: %w", configPath, err)
+	}
+	// Keep the managed ccgate CODEX_HOME self-contained. The file
+	// contains no secret, but mode 0600 matches the adjacent auth.json
+	// sensitivity and avoids leaking user configuration details.
+	if err := os.WriteFile(configPath, []byte("cli_auth_credentials_store = \"file\"\n"), 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", configPath, err)
+	}
+	return nil
+}
+
+type appServer struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	reader *bufio.Reader
+	stderr *bytes.Buffer
+	nextID int
+	done   chan error
+}
+
+func startAppServer(ctx context.Context, codexBin, codexHome string) (*appServer, error) {
+	bin := strings.TrimSpace(codexBin)
+	if bin == "" {
+		bin = defaultCodexBin
+	}
+	cmd := exec.CommandContext(ctx, bin, "app-server")
+	cmd.Env = codexAppServerEnv(os.Environ(), codexHome)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("open app-server stdin: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("open app-server stdout: %w", err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start %s app-server: %w", bin, err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	return &appServer{
+		cmd:    cmd,
+		stdin:  stdin,
+		reader: bufio.NewReaderSize(stdout, 64*1024),
+		stderr: &stderr,
+		nextID: 1,
+		done:   done,
+	}, nil
+}
+
+func codexAppServerEnv(base []string, codexHome string) []string {
+	out := make([]string, 0, len(base)+1)
+	for _, kv := range base {
+		key, _, _ := strings.Cut(kv, "=")
+		switch key {
+		case "CODEX_API_KEY", "OPENAI_API_KEY", "CCGATE_OPENAI_API_KEY", "CODEX_HOME":
+			continue
+		default:
+			out = append(out, kv)
+		}
+	}
+	if strings.TrimSpace(codexHome) != "" {
+		out = append(out, "CODEX_HOME="+codexHome)
+	}
+	return out
+}
+
+func (s *appServer) Close() {
+	_ = s.stdin.Close()
+	if s.cmd.Process != nil {
+		_ = s.cmd.Process.Kill()
+	}
+	select {
+	case err := <-s.done:
+		if err != nil {
+			slog.Debug("codex app-server exited", "error", err)
+		}
+	case <-time.After(2 * time.Second):
+		slog.Debug("codex app-server did not exit promptly")
+	}
+}
+
+func (s *appServer) initialize() error {
+	if _, err := s.call("initialize", map[string]any{
+		"clientInfo": map[string]any{
+			"name":    serviceName,
+			"title":   "ccgate",
+			"version": "0.1.0",
+		},
+	}); err != nil {
+		return err
+	}
+	return s.notify("initialized", map[string]any{})
+}
+
+func (s *appServer) requireChatGPTAccount() error {
+	raw, err := s.call("account/read", map[string]any{"refreshToken": true})
+	if err != nil {
+		return fmt.Errorf("read account: %w", err)
+	}
+	return validateChatGPTAccount(raw)
+}
+
+func validateChatGPTAccount(raw json.RawMessage) error {
+	var res struct {
+		Account *struct {
+			Type     string `json:"type"`
+			PlanType string `json:"planType"`
+			Email    string `json:"email"`
+		} `json:"account"`
+		RequiresOpenAIAuth bool `json:"requiresOpenaiAuth"`
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return fmt.Errorf("parse account/read result: %w", err)
+	}
+	if res.Account == nil {
+		return fmt.Errorf("%w: run `CODEX_HOME=<provider.codex_home> codex login` first", ErrAuthUnavailable)
+	}
+	switch res.Account.Type {
+	case "chatgpt", "chatgptAuthTokens":
+		return nil
+	default:
+		return fmt.Errorf("%w: got account type %q", ErrWrongAuthMode, res.Account.Type)
+	}
+}
+
+func (s *appServer) startThread(p llm.Prompt) (string, error) {
+	raw, err := s.call("thread/start", threadStartParams(p))
+	if err != nil {
+		return "", err
+	}
+	var res struct {
+		Thread struct {
+			ID string `json:"id"`
+		} `json:"thread"`
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return "", fmt.Errorf("parse thread/start result: %w", err)
+	}
+	if res.Thread.ID == "" {
+		return "", errors.New("thread/start result missing thread.id")
+	}
+	return res.Thread.ID, nil
+}
+
+func threadStartParams(p llm.Prompt) map[string]any {
+	return map[string]any{
+		"model":          p.Model,
+		"cwd":            promptCwd(p),
+		"approvalPolicy": "never",
+		"sandbox":        threadSandboxModeReadOnly,
+		"serviceName":    serviceName,
+	}
+}
+
+func (s *appServer) archiveThread(threadID string) {
+	if threadID == "" {
+		return
+	}
+	if _, err := s.call("thread/archive", map[string]any{"threadId": threadID}); err != nil {
+		slog.Debug("codex app-server thread/archive failed", "error", err)
+	}
+}
+
+func (s *appServer) startTurn(threadID string, p llm.Prompt) (string, error) {
+	raw, err := s.call("turn/start", turnStartParams(threadID, p))
+	if err != nil {
+		return "", err
+	}
+	var res struct {
+		Turn struct {
+			ID string `json:"id"`
+		} `json:"turn"`
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return "", fmt.Errorf("parse turn/start result: %w", err)
+	}
+	if res.Turn.ID == "" {
+		return "", errors.New("turn/start result missing turn.id")
+	}
+	return res.Turn.ID, nil
+}
+
+func turnStartParams(threadID string, p llm.Prompt) map[string]any {
+	return map[string]any{
+		"threadId":       threadID,
+		"input":          []map[string]string{{"type": "text", "text": classificationPrompt(p)}},
+		"cwd":            promptCwd(p),
+		"approvalPolicy": "never",
+		"sandboxPolicy": map[string]any{
+			"type":          turnSandboxPolicyReadOnly,
+			"networkAccess": false,
+		},
+		"model":        p.Model,
+		"outputSchema": outputSchema(),
+	}
+}
+
+func classificationPrompt(p llm.Prompt) string {
+	return strings.Join([]string{
+		"You are running inside ccgate's codex-oauth provider.",
+		"Classify the PermissionRequest only from the supplied policy and payload.",
+		"Do not inspect files, run commands, use tools, browse, edit files, or ask follow-up questions.",
+		"Return only the structured JSON requested by outputSchema.",
+		"",
+		"System policy:",
+		p.System,
+		"",
+		"PermissionRequest payload:",
+		p.User,
+	}, "\n")
+}
+
+func outputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"behavior": map[string]any{
+				"type": "string",
+				"enum": []string{llm.BehaviorAllow, llm.BehaviorDeny, llm.BehaviorFallthrough},
+			},
+			"reason": map[string]any{
+				"type": "string",
+			},
+			"deny_message": map[string]any{
+				"type": "string",
+			},
+		},
+		"required":             []string{"behavior", "reason", "deny_message"},
+		"additionalProperties": false,
+	}
+}
+
+func promptCwd(p llm.Prompt) string {
+	var payload struct {
+		Context struct {
+			Cwd string `json:"cwd"`
+		} `json:"context"`
+	}
+	if err := json.Unmarshal([]byte(p.User), &payload); err == nil && payload.Context.Cwd != "" {
+		return payload.Context.Cwd
+	}
+	if wd, err := os.Getwd(); err == nil {
+		return wd
+	}
+	return "."
+}
+
+func (s *appServer) waitTurn(threadID, turnID string) (string, error) {
+	var deltas strings.Builder
+	var finalText string
+	for {
+		msg, err := s.read()
+		if err != nil {
+			return "", err
+		}
+		if len(msg.ID) > 0 && msg.Method != "" {
+			_ = s.handleServerRequest(msg)
+			continue
+		}
+		switch msg.Method {
+		case "item/agentMessage/delta":
+			if delta := agentDeltaText(msg.Params); delta != "" {
+				deltas.WriteString(delta)
+			}
+		case "item/completed":
+			if text := completedAgentMessageText(msg.Params); text != "" {
+				finalText = text
+			}
+		case "turn/completed":
+			status, text, err := completedTurn(msg.Params, threadID, turnID)
+			if status == "" && text == "" && err == nil {
+				continue
+			}
+			if text != "" {
+				finalText = text
+			}
+			if err != nil {
+				return "", err
+			}
+			if status == "completed" {
+				if strings.TrimSpace(finalText) != "" {
+					return finalText, nil
+				}
+				if strings.TrimSpace(deltas.String()) != "" {
+					return deltas.String(), nil
+				}
+				return "", errors.New("codex-oauth: turn completed without agent message")
+			}
+			return "", fmt.Errorf("codex-oauth: turn ended with status %q", status)
+		}
+	}
+}
+
+func agentDeltaText(raw json.RawMessage) string {
+	var p struct {
+		Delta string `json:"delta"`
+		Text  string `json:"text"`
+	}
+	_ = json.Unmarshal(raw, &p)
+	if p.Delta != "" {
+		return p.Delta
+	}
+	return p.Text
+}
+
+func completedAgentMessageText(raw json.RawMessage) string {
+	var p struct {
+		Item struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"item"`
+	}
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return ""
+	}
+	if p.Item.Type == "agentMessage" {
+		return p.Item.Text
+	}
+	return ""
+}
+
+func completedTurn(raw json.RawMessage, threadID, turnID string) (string, string, error) {
+	var p struct {
+		ThreadID string `json:"threadId"`
+		Turn     struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+			Error  *struct {
+				Message        string `json:"message"`
+				CodexErrorInfo *struct {
+					Type           string `json:"type"`
+					HTTPStatusCode int    `json:"httpStatusCode"`
+				} `json:"codexErrorInfo"`
+			} `json:"error"`
+			Items []json.RawMessage `json:"items"`
+		} `json:"turn"`
+	}
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return "", "", fmt.Errorf("parse turn/completed: %w", err)
+	}
+	if p.ThreadID != "" && p.ThreadID != threadID {
+		return "", "", nil
+	}
+	if p.Turn.ID != "" && p.Turn.ID != turnID {
+		return "", "", nil
+	}
+	if p.Turn.Status == "failed" && p.Turn.Error != nil {
+		if p.Turn.Error.CodexErrorInfo != nil {
+			if p.Turn.Error.CodexErrorInfo.Type == "Unauthorized" || p.Turn.Error.CodexErrorInfo.HTTPStatusCode == 401 {
+				return "", "", fmt.Errorf("%w: %s", ErrAuthUnavailable, p.Turn.Error.Message)
+			}
+		}
+		return "", "", fmt.Errorf("codex-oauth: turn failed: %s", p.Turn.Error.Message)
+	}
+	for _, rawItem := range p.Turn.Items {
+		var item struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		}
+		if err := json.Unmarshal(rawItem, &item); err == nil && item.Type == "agentMessage" && item.Text != "" {
+			return p.Turn.Status, item.Text, nil
+		}
+	}
+	return p.Turn.Status, "", nil
+}
+
+func (s *appServer) handleServerRequest(msg rpcMessage) error {
+	var result any
+	switch msg.Method {
+	case "item/commandExecution/requestApproval", "item/fileChange/requestApproval":
+		result = "decline"
+	case "item/tool/requestUserInput":
+		result = map[string]any{"decision": "cancel"}
+	default:
+		result = map[string]any{"error": "unsupported request"}
+	}
+	return s.respond(msg.ID, result)
+}
+
+type rpcMessage struct {
+	ID     json.RawMessage `json:"id,omitempty"`
+	Method string          `json:"method,omitempty"`
+	Params json.RawMessage `json:"params,omitempty"`
+	Result json.RawMessage `json:"result,omitempty"`
+	Error  *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func (s *appServer) call(method string, params any) (json.RawMessage, error) {
+	id := s.nextID
+	s.nextID++
+	if err := s.write(map[string]any{"method": method, "id": id, "params": params}); err != nil {
+		return nil, err
+	}
+	wantID := strconv.Itoa(id)
+	for {
+		msg, err := s.read()
+		if err != nil {
+			return nil, err
+		}
+		if len(msg.ID) > 0 && msg.Method != "" {
+			_ = s.handleServerRequest(msg)
+			continue
+		}
+		if string(msg.ID) != wantID {
+			continue
+		}
+		if msg.Error != nil {
+			return nil, fmt.Errorf("app-server %s: %s", method, msg.Error.Message)
+		}
+		return msg.Result, nil
+	}
+}
+
+func (s *appServer) notify(method string, params any) error {
+	return s.write(map[string]any{"method": method, "params": params})
+}
+
+func (s *appServer) respond(id json.RawMessage, result any) error {
+	return s.write(map[string]any{"id": json.RawMessage(id), "result": result})
+}
+
+func (s *appServer) write(v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("marshal app-server message: %w", err)
+	}
+	data = append(data, '\n')
+	if _, err := s.stdin.Write(data); err != nil {
+		return fmt.Errorf("write app-server message: %w", err)
+	}
+	return nil
+}
+
+func (s *appServer) read() (rpcMessage, error) {
+	line, err := s.reader.ReadBytes('\n')
+	if err != nil {
+		select {
+		case waitErr := <-s.done:
+			if waitErr != nil {
+				return rpcMessage{}, fmt.Errorf("codex app-server exited: %w; stderr: %s", waitErr, truncate(s.stderr.String()))
+			}
+		default:
+		}
+		return rpcMessage{}, fmt.Errorf("read app-server message: %w; stderr: %s", err, truncate(s.stderr.String()))
+	}
+	if len(line) > maxLineBytes {
+		return rpcMessage{}, fmt.Errorf("app-server message exceeded %d bytes", maxLineBytes)
+	}
+	line = bytes.TrimSpace(line)
+	if len(line) == 0 {
+		return s.read()
+	}
+	var msg rpcMessage
+	if err := json.Unmarshal(line, &msg); err != nil {
+		return rpcMessage{}, fmt.Errorf("parse app-server message: %w", err)
+	}
+	return msg, nil
+}
+
+func parseOutput(text string) (llm.Output, error) {
+	clean := strings.TrimSpace(text)
+	if clean == "" {
+		return llm.Output{}, errors.New("codex-oauth: empty final response")
+	}
+	var out llm.Output
+	if err := json.Unmarshal([]byte(clean), &out); err == nil {
+		return out, nil
+	}
+	obj, ok := firstJSONObject(clean)
+	if !ok {
+		return llm.Output{}, fmt.Errorf("parse Codex response: no JSON object in %q", truncate(clean))
+	}
+	if err := json.Unmarshal([]byte(obj), &out); err != nil {
+		return llm.Output{}, fmt.Errorf("parse Codex response JSON: %w", err)
+	}
+	return out, nil
+}
+
+func firstJSONObject(s string) (string, bool) {
+	start := strings.IndexByte(s, '{')
+	if start < 0 {
+		return "", false
+	}
+	depth := 0
+	inString := false
+	escaped := false
+	for i := start; i < len(s); i++ {
+		ch := s[i]
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			switch ch {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		switch ch {
+		case '"':
+			inString = true
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return s[start : i+1], true
+			}
+		}
+	}
+	return "", false
+}
+
+func truncate(s string) string {
+	const max = 500
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}

--- a/internal/llm/codexoauth/client_test.go
+++ b/internal/llm/codexoauth/client_test.go
@@ -1,0 +1,226 @@
+package codexoauth
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tak848/ccgate/internal/llm"
+)
+
+func TestThreadStartParamsUseCodexAppServerSandboxMode(t *testing.T) {
+	t.Parallel()
+
+	p := llm.Prompt{
+		Model: "gpt-5.4",
+		User:  `{"context":{"cwd":"/tmp/workspace"}}`,
+	}
+	params := threadStartParams(p)
+
+	if got := params["model"]; got != "gpt-5.4" {
+		t.Fatalf("model = %q, want gpt-5.4", got)
+	}
+	if got := params["cwd"]; got != "/tmp/workspace" {
+		t.Fatalf("cwd = %q, want /tmp/workspace", got)
+	}
+	if got := params["approvalPolicy"]; got != "never" {
+		t.Fatalf("approvalPolicy = %q, want never", got)
+	}
+	if got := params["sandbox"]; got != threadSandboxModeReadOnly {
+		t.Fatalf("sandbox = %q, want %q", got, threadSandboxModeReadOnly)
+	}
+	if params["sandbox"] == "readOnly" {
+		t.Fatal("thread/start sandbox must use Codex app-server mode spelling read-only, not readOnly")
+	}
+	if got := params["serviceName"]; got != serviceName {
+		t.Fatalf("serviceName = %q, want %q", got, serviceName)
+	}
+}
+
+func TestTurnStartParamsUseReadOnlySandboxPolicy(t *testing.T) {
+	t.Parallel()
+
+	p := llm.Prompt{
+		Model:  "gpt-5.4",
+		System: "system rules",
+		User:   `{"context":{"cwd":"/tmp/workspace"},"tool_name":"Bash"}`,
+	}
+	params := turnStartParams("thread-123", p)
+
+	if got := params["threadId"]; got != "thread-123" {
+		t.Fatalf("threadId = %q, want thread-123", got)
+	}
+	if got := params["cwd"]; got != "/tmp/workspace" {
+		t.Fatalf("cwd = %q, want /tmp/workspace", got)
+	}
+	if got := params["model"]; got != "gpt-5.4" {
+		t.Fatalf("model = %q, want gpt-5.4", got)
+	}
+	if got := params["approvalPolicy"]; got != "never" {
+		t.Fatalf("approvalPolicy = %q, want never", got)
+	}
+
+	sandbox, ok := params["sandboxPolicy"].(map[string]any)
+	if !ok {
+		t.Fatalf("sandboxPolicy has type %T, want map[string]any", params["sandboxPolicy"])
+	}
+	if got := sandbox["type"]; got != turnSandboxPolicyReadOnly {
+		t.Fatalf("sandboxPolicy.type = %q, want %q", got, turnSandboxPolicyReadOnly)
+	}
+	if got := sandbox["networkAccess"]; got != false {
+		t.Fatalf("sandboxPolicy.networkAccess = %v, want false", got)
+	}
+	if _, ok := sandbox["access"]; ok {
+		t.Fatal("turn/start sandboxPolicy must not include the old unsupported access shape")
+	}
+
+	input, ok := params["input"].([]map[string]string)
+	if !ok || len(input) != 1 {
+		t.Fatalf("input = %#v, want one text input", params["input"])
+	}
+	if input[0]["type"] != "text" {
+		t.Fatalf("input[0].type = %q, want text", input[0]["type"])
+	}
+	if !strings.Contains(input[0]["text"], "system rules") || !strings.Contains(input[0]["text"], `"tool_name":"Bash"`) {
+		t.Fatalf("classification prompt missing policy or payload: %q", input[0]["text"])
+	}
+	if _, ok := params["outputSchema"].(map[string]any); !ok {
+		t.Fatalf("outputSchema has type %T, want map[string]any", params["outputSchema"])
+	}
+}
+
+func TestValidateChatGPTAccount(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		raw     string
+		wantErr error
+	}{
+		"chatgpt account": {
+			raw: `{"account":{"type":"chatgpt","email":"user@example.test"}}`,
+		},
+		"chatgpt auth tokens account": {
+			raw: `{"account":{"type":"chatgptAuthTokens"}}`,
+		},
+		"missing account": {
+			raw:     `{"account":null,"requiresOpenaiAuth":true}`,
+			wantErr: ErrAuthUnavailable,
+		},
+		"api key account": {
+			raw:     `{"account":{"type":"apiKey"}}`,
+			wantErr: ErrWrongAuthMode,
+		},
+		"invalid json": {
+			raw:     `{`,
+			wantErr: errors.New("parse account/read result"),
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			err := validateChatGPTAccount([]byte(tc.raw))
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Fatalf("validateChatGPTAccount returned error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if errors.Is(tc.wantErr, ErrAuthUnavailable) || errors.Is(tc.wantErr, ErrWrongAuthMode) {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("error = %v, want sentinel %v", err, tc.wantErr)
+				}
+				return
+			}
+			if !strings.Contains(err.Error(), tc.wantErr.Error()) {
+				t.Fatalf("error = %v, want substring %q", err, tc.wantErr.Error())
+			}
+		})
+	}
+}
+
+func TestEnsureManagedCodexHomeCreatesFileCredentialConfig(t *testing.T) {
+	t.Parallel()
+
+	home := filepath.Join(t.TempDir(), "codex-home")
+	if err := ensureManagedCodexHome(home); err != nil {
+		t.Fatalf("ensureManagedCodexHome returned error: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(home, "config.toml"))
+	if err != nil {
+		t.Fatalf("read config.toml: %v", err)
+	}
+	if got, want := string(data), "cli_auth_credentials_store = \"file\"\n"; got != want {
+		t.Fatalf("config.toml = %q, want %q", got, want)
+	}
+
+	custom := []byte("model = \"gpt-test\"\n")
+	if err := os.WriteFile(filepath.Join(home, "config.toml"), custom, 0o600); err != nil {
+		t.Fatalf("write custom config.toml: %v", err)
+	}
+	if err := ensureManagedCodexHome(home); err != nil {
+		t.Fatalf("ensureManagedCodexHome second call returned error: %v", err)
+	}
+	data, err = os.ReadFile(filepath.Join(home, "config.toml"))
+	if err != nil {
+		t.Fatalf("read config.toml after second call: %v", err)
+	}
+	if string(data) != string(custom) {
+		t.Fatalf("ensureManagedCodexHome overwrote existing config: %q", data)
+	}
+}
+
+func TestParseOutput(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"plain json":    `{"behavior":"allow","reason":"safe read","deny_message":""}`,
+		"wrapped json":  "```json\n{\"behavior\":\"deny\",\"reason\":\"unsafe\",\"deny_message\":\"blocked\"}\n```",
+		"braces inside": `prefix {"behavior":"fallthrough","reason":"ambiguous {input}","deny_message":""} suffix`,
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			out, err := parseOutput(input)
+			if err != nil {
+				t.Fatalf("parseOutput returned error: %v", err)
+			}
+			switch out.Behavior {
+			case llm.BehaviorAllow, llm.BehaviorDeny, llm.BehaviorFallthrough:
+			default:
+				t.Fatalf("unexpected behavior %q", out.Behavior)
+			}
+		})
+	}
+}
+
+func TestCodexAppServerEnvRemovesAPIKeys(t *testing.T) {
+	t.Parallel()
+
+	home := filepath.Join(string(filepath.Separator), "tmp", "codex-home")
+	env := codexAppServerEnv([]string{
+		"PATH=/bin",
+		"OPENAI_API_KEY=sk-api",
+		"CCGATE_OPENAI_API_KEY=sk-ccgate",
+		"CODEX_API_KEY=sk-codex",
+		"CODEX_HOME=/old",
+		"OTHER=value",
+	}, home)
+
+	joined := "\n" + strings.Join(env, "\n") + "\n"
+	for _, forbidden := range []string{"\nOPENAI_API_KEY=", "\nCCGATE_OPENAI_API_KEY=", "\nCODEX_API_KEY=", "\nCODEX_HOME=/old\n"} {
+		if strings.Contains(joined, forbidden) {
+			t.Fatalf("env leaked %s in %q", forbidden, joined)
+		}
+	}
+	if !strings.Contains(joined, "\nOTHER=value\n") {
+		t.Fatalf("env dropped unrelated variable: %q", joined)
+	}
+	if !strings.Contains(joined, "\nCODEX_HOME="+home+"\n") {
+		t.Fatalf("env did not set managed CODEX_HOME: %q", joined)
+	}
+}

--- a/internal/runner/auth_status_test.go
+++ b/internal/runner/auth_status_test.go
@@ -142,3 +142,23 @@ func TestResolveAPIKeyUnknownProviderShortCircuit(t *testing.T) {
 		t.Fatalf("reason/source = %q/%q, want empty (no helper attempt)", reason, source)
 	}
 }
+
+func TestResolveAPIKeyCodexOAuthDoesNotRequireAPIKey(t *testing.T) {
+	t.Parallel()
+
+	key, kind, reason, source, err := resolveAPIKey(
+		context.Background(),
+		config.ProviderConfig{Name: "codex-oauth", Model: "gpt-5.4"},
+		"codex-oauth",
+		"codex",
+	)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if key != "" || kind != "" || reason != "" {
+		t.Fatalf("key/kind/reason = %q/%q/%q, want empty success path", key, kind, reason)
+	}
+	if source != credentialSourceCodexOAuth {
+		t.Fatalf("source = %q, want %q", source, credentialSourceCodexOAuth)
+	}
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -37,6 +37,7 @@ import (
 	"github.com/tak848/ccgate/internal/keystore"
 	"github.com/tak848/ccgate/internal/llm"
 	"github.com/tak848/ccgate/internal/llm/anthropic"
+	"github.com/tak848/ccgate/internal/llm/codexoauth"
 	"github.com/tak848/ccgate/internal/llm/gemini"
 	"github.com/tak848/ccgate/internal/llm/openai"
 	"github.com/tak848/ccgate/internal/metrics"
@@ -54,6 +55,8 @@ const PermissionModePlan = "plan"
 // credential_source slot with the keystore-managed values in
 // metrics.Entry so the field has a uniform meaning.
 const credentialSourceProfile = "profile"
+
+const credentialSourceCodexOAuth = "codex-oauth"
 
 // HookInput is the on-the-wire JSON Claude Code and Codex CLI both
 // deliver to the PermissionRequest hook. Fields that only one of the
@@ -398,6 +401,18 @@ func decide(ctx context.Context, cfg config.Config, in HookInput, ro runtimeOpti
 				credentialSourceProfile,
 				res.Usage, nil
 		}
+		if errors.Is(err, codexoauth.ErrAuthUnavailable) || errors.Is(err, codexoauth.ErrWrongAuthMode) {
+			slog.Warn("codex oauth credential unavailable, falling through",
+				"kind", llm.FallthroughKindCredentialUnavailable,
+				"reason", string(keystore.ReasonCodexOAuthLogin),
+				"source", credentialSourceCodexOAuth,
+			)
+			return llm.Decision{}, false,
+				llm.FallthroughKindCredentialUnavailable,
+				string(keystore.ReasonCodexOAuthLogin),
+				credentialSourceCodexOAuth,
+				res.Usage, nil
+		}
 		// 401 / 403 against a key that came from a helper / file
 		// path is the canonical "the credential we just used is
 		// stale or wrong" signal: invalidate the keystore cache
@@ -700,6 +715,10 @@ func resolveAPIKey(ctx context.Context, p config.ProviderConfig, providerName, t
 		return "", llm.FallthroughKindUnknownProvider, "", "", nil
 	}
 
+	if providerName == "codex-oauth" {
+		return "", "", "", credentialSourceCodexOAuth, nil
+	}
+
 	if p.Auth != nil {
 		// auth.type=profile delegates credential resolution to the
 		// Anthropic SDK at request time, so runner returns
@@ -768,7 +787,7 @@ func resolveAPIKey(ctx context.Context, p config.ProviderConfig, providerName, t
 // real key to.
 func isKnownProvider(name string) bool {
 	switch name {
-	case "anthropic", "openai", "gemini":
+	case "anthropic", "openai", "gemini", "codex-oauth":
 		return true
 	}
 	return false
@@ -776,6 +795,12 @@ func isKnownProvider(name string) bool {
 
 func newProviderClient(providerName string, p config.ProviderConfig, apiKey, baseURL string) llm.Provider {
 	switch providerName {
+	case "codex-oauth":
+		return &codexoauth.Client{
+			CodexBin:        p.GetCodexBin(),
+			CodexHome:       p.ResolveCodexHome(),
+			EnsureCodexHome: strings.TrimSpace(p.CodexHome) == "",
+		}
 	case "openai":
 		return &openai.Client{APIKey: apiKey, BaseURL: baseURL}
 	case "gemini":

--- a/schemas/claude.schema.json
+++ b/schemas/claude.schema.json
@@ -111,6 +111,12 @@
         },
         "timeout_ms": {
           "type": "integer"
+        },
+        "codex_bin": {
+          "type": "string"
+        },
+        "codex_home": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/schemas/codex.schema.json
+++ b/schemas/codex.schema.json
@@ -111,6 +111,12 @@
         },
         "timeout_ms": {
           "type": "integer"
+        },
+        "codex_bin": {
+          "type": "string"
+        },
+        "codex_home": {
+          "type": "string"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## Why

Currently, ccgate requires explicit API keys for LLM providers. However, users who already have a ChatGPT subscription may prefer to use the Codex CLI's built-in OAuth authentication instead of provisioning and paying for a separate OpenAI developer API key. This change allows users to run ccgate using their existing ChatGPT subscription by leveraging the native Codex CLI session.

## What

- Adds support for a new `codex-oauth` LLM provider.
- Implements a client that invokes the Codex CLI binary natively to perform permission classification using its authenticated session.
- Adds `codex_bin` and `codex_home` configuration options to securely manage the Codex CLI execution environment without leaking existing environment variables.
- Updates the JSON schemas (`claude.schema.json` and `codex.schema.json`) to support the new provider configurations.

(Also we can communicate with Japanese.)