### PR TITLE
feat: add Nix flake dev shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,8 @@ nix develop -c go test ./...   # Run a one-off command in the shell
 
 Requires Nix with flakes enabled (`experimental-features = nix-command flakes`).
 
+macOS note: `path_helper` may shadow Nix paths with system bins — verify with `which go`.
+
 ## Articles
 
 - English (dev.to): <https://dev.to/tak848/ccgate-delegate-claude-code-codex-cli-permission-prompts-to-an-llm-274c>

--- a/README.md
+++ b/README.md
@@ -295,6 +295,17 @@ mise run vet      # Run go vet
 mise run schema   # Regenerate schemas/{claude,codex}.schema.json
 ```
 
+### Nix (flakes)
+
+A `flake.nix` is provided as an alternative to mise. It pins Go 1.25, `golangci-lint`, `gopls`, `goimports`, `staticcheck`, and `delve` into a dev shell.
+
+```bash
+nix develop                    # Enter the dev shell
+nix develop -c go test ./...   # Run a one-off command in the shell
+```
+
+Requires Nix with flakes enabled (`experimental-features = nix-command flakes`).
+
 ## Articles
 
 - English (dev.to): <https://dev.to/tak848/ccgate-delegate-claude-code-codex-cli-permission-prompts-to-an-llm-274c>

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -293,6 +293,17 @@ mise run vet      # go vet
 mise run schema   # schemas/{claude,codex}.schema.json を再生成
 ```
 
+### Nix (flakes)
+
+mise の代わりに `flake.nix` でも開発環境を立ち上げられます。Go 1.25 / `golangci-lint` / `gopls` / `goimports` / `staticcheck` / `delve` を dev shell にピン留めしています。
+
+```bash
+nix develop                    # dev shell に入る
+nix develop -c go test ./...   # シェルに入らず単発でコマンドを流す
+```
+
+flakes が有効な Nix が必要です (`experimental-features = nix-command flakes`)。
+
 ## 関連記事
 
 - 日本語 (Zenn): <https://zenn.dev/layerx/articles/20260428-ccgate>

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -304,6 +304,8 @@ nix develop -c go test ./...   # シェルに入らず単発でコマンドを�
 
 flakes が有効な Nix が必要です (`experimental-features = nix-command flakes`)。
 
+macOS では `path_helper` がシステム PATH を Nix より優先することがあります。`which go` で確認してください。
+
 ## 関連記事
 
 - 日本語 (Zenn): <https://zenn.dev/layerx/articles/20260428-ccgate>

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,104 @@
+{
+  description = "ccgate - Claude Code PermissionRequest hook (Go)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = f:
+        nixpkgs.lib.genAttrs systems (system: f {
+          inherit system;
+          pkgs = import nixpkgs { inherit system; };
+        });
+    in
+    {
+      devShells = forAllSystems ({ pkgs, ... }: {
+        default = pkgs.mkShell {
+          name = "ccgate";
+
+          packages = with pkgs; [
+            go_1_25
+            gopls
+            gotools
+            go-tools
+            golangci-lint
+            delve
+            git
+          ];
+
+          shellHook = ''
+            export GOPATH="''${GOPATH:-$HOME/go}"
+            export PATH="$GOPATH/bin:$PATH"
+
+            # Append host PATH so outside-the-shell tools (mise, gh, brew, etc.) stay reachable.
+            # Nix paths keep priority; host dirs are fallback only.
+            for _p in \
+              "$HOME/.local/share/mise/shims" \
+              "$HOME/.local/bin" \
+              "$HOME/.nix-profile/bin" \
+              "/nix/var/nix/profiles/default/bin" \
+              "/etc/profiles/per-user/$USER/bin" \
+              "/opt/homebrew/bin" \
+              "/opt/homebrew/sbin" \
+              "/usr/local/bin" \
+              "/usr/local/sbin" \
+              "/usr/bin" \
+              "/bin" \
+              "/usr/sbin" \
+              "/sbin"; do
+              if [ -d "$_p" ] && [[ ":$PATH:" != *":$_p:"* ]]; then
+                PATH="$PATH:$_p"
+              fi
+            done
+            unset _p
+            export PATH
+
+            echo "ccgate dev shell"
+            echo "  $(go version)"
+            echo "  $(golangci-lint --version 2>/dev/null | head -1)"
+
+            # nix develop forces bash and overwrites $SHELL with the nix store bash,
+            # so personal aliases/functions in ~/.zshrc are not loaded. Look up the
+            # user's actual login shell from the OS and re-exec into it.
+            # Only run when interactive and not already re-exec'd this session.
+            if [ -z "$CCGATE_DEVSHELL_EXEC" ] && [ -t 0 ] && [ -t 1 ]; then
+              _login_shell=""
+              if [ "$(uname -s)" = "Darwin" ] && command -v dscl >/dev/null 2>&1; then
+                _login_shell=$(dscl . -read "/Users/$USER" UserShell 2>/dev/null | awk '{print $2}')
+              fi
+              if [ -z "$_login_shell" ] && command -v getent >/dev/null 2>&1; then
+                _login_shell=$(getent passwd "$USER" 2>/dev/null | cut -d: -f7)
+              fi
+              if [ -z "$_login_shell" ] && [ -r /etc/passwd ]; then
+                _login_shell=$(awk -F: -v u="$USER" '$1==u {print $7}' /etc/passwd)
+              fi
+
+              if [ -n "$_login_shell" ] && [ -x "$_login_shell" ] \
+                && [ "$(basename "$_login_shell")" != "bash" ]; then
+                export CCGATE_DEVSHELL_EXEC=1
+                # Prompt marker so users can tell they are inside the nix shell.
+                export CCGATE_IN_NIX_SHELL=1
+                # Override $SHELL so child processes (e.g. tmux, nvim :term) inherit
+                # the user's shell rather than nix's bash.
+                export SHELL="$_login_shell"
+                exec "$_login_shell"
+              fi
+              unset _login_shell
+            fi
+
+            # Fallback (bash) prompt — only reached when we did not exec into zsh.
+            # PROMPT_COMMAND fires before each prompt — wins over /etc/bashrc and nix's prefix.
+            PROMPT_COMMAND='PS1="(nix:ccgate) \u\$ "'
+          '';
+        };
+      });
+    };
+}


### PR DESCRIPTION
## What

- Add `flake.nix` exposing a dev shell that pins Go 1.25, `golangci-lint`, `gopls`, `gotools` (provides `goimports`), `go-tools` (provides `staticcheck`), `delve`, and `git`.
- Append host PATH (mise shims, `~/.local/bin`, Homebrew, system bins) **after** Nix paths so external tools like `gh` and `mise` stay reachable; Nix-pinned binaries keep priority.
- Look up the user's login shell from the OS user database (`dscl` on macOS, `getent passwd` / `/etc/passwd` on Linux) and `exec` into it on shell entry, since `nix develop` otherwise forces bash and overwrites `\$SHELL`. Falls back to bash with a `(nix:ccgate)` prompt when no other login shell is detected.
- Export `CCGATE_IN_NIX_SHELL=1` as a marker.
- Document the workflow in `README.md` and `docs/ja/README.md` under a new **Nix (flakes)** section.

## Notes

- Requires Nix with `experimental-features = nix-command flakes`.
- Existing `mise.toml` is unchanged.
- Verified on `aarch64-darwin`: `nix flake check` passes; `nix develop` enters zsh and loads `~/.zshrc`.