### PR TITLE
fix: don't fallthrough on allow-matching ops just because they have side effects

### DIFF
--- a/internal/cmd/claude/defaults.jsonnet
+++ b/internal/cmd/claude/defaults.jsonnet
@@ -59,7 +59,7 @@
   allow: [
     'Read-Only Operations: Read, Glob, Grep, and other read-only tools that do not modify state.',
     'Local Development: Build, test, lint, format commands in the current repository.',
-    'Git Feature Branch: Git operations on non-protected branches (not main, master, release/*, prod).',
+    'Git Feature Branch: Git operations on non-protected branches (not main, master, release/*, prod). For switch -c / checkout -b, the target branch is in the command; context.branch_name is the pre-command branch.',
     'Package Manager Install: Package manager commands (npm install, go mod tidy, pip install, etc.) in the current repository.',
   ],
 

--- a/internal/cmd/codex/defaults.jsonnet
+++ b/internal/cmd/codex/defaults.jsonnet
@@ -62,7 +62,7 @@
     'Local writes inside the workspace: apply_patch hunks whose target paths are all under cwd / repo_root, edits to project files for editing/refactoring/scaffolding the AI is currently doing. Workspace-internal writes for the active coding task are in scope; writes that escape cwd / repo_root or that match a deny rule are not.',
     'Local build/test against project-defined scripts: make, just, mise run, pnpm test, go test, cargo test, etc.',
     'Package install confined to this repo: pnpm/cargo/go install with no global flags.',
-    'Git feature-branch operations on non-protected branches.',
+    'Git feature-branch operations on non-protected branches. For switch -c / checkout -b, the target branch is in the command; context.branch_name is the pre-command branch.',
     'MCP tools whose server is explicitly trusted by the user and whose side effects are confined to the user-authorized scope (read APIs, project-scoped writes).',
   ],
 

--- a/internal/prompt/build.go
+++ b/internal/prompt/build.go
@@ -119,11 +119,12 @@ func writeNormalModeRules(b *strings.Builder, hasRecentTranscript bool) {
 		b.WriteString("- deny: When a deny guidance rule matches. EXCEPT: if recent_transcript shows the user explicitly requested the exact operation, use fallthrough instead of deny to let the user confirm.\n")
 		b.WriteString("- allow: When the operation matches allow guidance and no deny rule matches.\n")
 		b.WriteString("- fallthrough: When genuinely uncertain, OR when a deny rule matches but the user explicitly requested the operation.\n")
-		b.WriteString("Deny rules always take priority over allow rules. Explicit user requests can only escalate deny to fallthrough, never to allow.\n\n")
+		b.WriteString("Deny rules always take priority over allow rules. Explicit user requests can only escalate deny to fallthrough, never to allow.\n")
 	} else {
 		b.WriteString("- deny: When a deny guidance rule matches. (No recent_transcript field is delivered by this target, so explicit-user-intent escalation from deny to fallthrough is not available -- judge solely from tool_name + tool_input + cwd.)\n")
 		b.WriteString("- allow: When the operation matches allow guidance and no deny rule matches.\n")
 		b.WriteString("- fallthrough: When genuinely uncertain.\n")
-		b.WriteString("Deny rules always take priority over allow rules.\n\n")
+		b.WriteString("Deny rules always take priority over allow rules.\n")
 	}
+	b.WriteString("A state-changing or side-effecting operation (commit, branch create/switch, package install, build, file write) is NOT by itself a reason to fallthrough: if it matches allow guidance and no deny rule applies, return allow.\n\n")
 }


### PR DESCRIPTION
## Why

The LLM judge returned `fallthrough` (forcing a Claude Code confirmation prompt) for a routine feature-branch flow — `git switch -c <branch> && git add … && git commit … && git ls-remote …` — even though it matches the Git Feature Branch allow rule and no deny rule. The model's own reason acknowledged the operation was on a non-protected branch and user-requested, yet it fabricated a "requires confirmation" rationale grounded in no deny rule.

Same class of bug as the earlier `settings_permissions` clarification: the normal-mode decision rules never said that a side effect alone is not a reason to fallthrough, so the model defaulted to caution and effectively hollowed out the whole allow list (which is full of side-effecting operations: build, test, package install).

A secondary confounder: the hook fires *before* the command runs, so `context.branch_name` reports the pre-command branch (`main`) on a `switch -c`, contradicting the "non-protected branch" allow rule for the common branch-off-main flow.

## What

- `internal/prompt/build.go`: add one shared line to `writeNormalModeRules` — a state-changing or side-effecting operation is not by itself a reason to fallthrough; if it matches allow guidance and no deny rule applies, return allow. Deny priority is unchanged, and plan-mode rules are untouched.
- `internal/cmd/claude/defaults.jsonnet`, `internal/cmd/codex/defaults.jsonnet`: clarify the feature-branch allow line — for `switch -c` / `checkout -b` the target branch is in the command; `context.branch_name` is the pre-command branch.

Verified by feeding the original failing HookInput to the rebuilt hook (now `allow`) and confirming `git push --force` still denies. `mise run test` / `vet` green.