### PR TITLE
fix(anthropic): suppress SDK env autoload in every auth mode + surface API error reason

### DIFF
--- a/docs/api-key-helper.md
+++ b/docs/api-key-helper.md
@@ -61,6 +61,8 @@ Relative paths in `auth.command` and `auth.path` resolve from the hook's working
 
 Credential resolution order: `provider.auth` (when configured) > `CCGATE_*_API_KEY` > `*_API_KEY`. A configured `auth` block does not fall back to env vars on failure; the hook falls through with `kind=credential_unavailable` so the issue surfaces.
 
+For the Anthropic provider, ccgate disables the SDK's ambient-environment autoload in every mode, so only the credential resolved above is ever used: a stray `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` (even exported empty) or an on-disk `default` profile never shadows it, and `ANTHROPIC_BASE_URL` is ignored — `provider.base_url` is the base-URL control.
+
 ## Helper output
 
 The helper writes one of two shapes on stdout (or, for `auth.type=file`, into the file):

--- a/docs/ja/api-key-helper.md
+++ b/docs/ja/api-key-helper.md
@@ -61,6 +61,8 @@ provider に渡す credential が静的な環境変数では追いつかない�
 
 認証情報の解決順は `provider.auth` (設定済みのとき) > `CCGATE_*_API_KEY` > `*_API_KEY` です。`auth` を設定している状態で解決に失敗しても env var には fallback しません。`kind=credential_unavailable` で fallthrough します。
 
+Anthropic provider では、ccgate は SDK の ambient な env autoload を全モードで無効化するため、使われる credential は上記で解決したものだけです。残っている `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` (空文字で export されていても) やディスク上の `default` profile がそれを上書きすることはなく、`ANTHROPIC_BASE_URL` も無視されます — base URL の指定は `provider.base_url` で行います。
+
 ## helper の出力
 
 helper は次のどちらかの形を stdout (もしくは `auth.type=file` ならファイル中身として) に書きます。

--- a/internal/llm/anthropic/client.go
+++ b/internal/llm/anthropic/client.go
@@ -71,10 +71,9 @@ type Client struct {
 
 	// UseProfile selects the profile-delegation path: ccgate calls
 	// anthropicconfig.LoadProfile / LoadConfig directly and feeds
-	// the resulting *Config into option.WithConfig. ANTHROPIC_API_KEY
-	// / ANTHROPIC_AUTH_TOKEN env vars are suppressed via
-	// option.WithoutEnvironmentDefaults so a leftover env never
-	// shadows the declared profile.
+	// the resulting *Config into option.WithConfig. (Env-default
+	// suppression via option.WithoutEnvironmentDefaults is applied
+	// unconditionally by Decide for every mode, not just this one.)
 	UseProfile bool
 }
 
@@ -91,7 +90,23 @@ func (c *Client) Decide(ctx context.Context, p llm.Prompt) (llm.Result, error) {
 		defer cancel()
 	}
 
-	opts := []option.RequestOption{option.WithMaxRetries(maxRetries)}
+	// WithoutEnvironmentDefaults is unconditional: ccgate always resolves
+	// its own credential (exec/file via keystore, profile via the SDK
+	// loader, or a *_API_KEY env var it reads itself), so the SDK must
+	// contribute nothing from the ambient environment. Without it,
+	// anthropic.NewClient prepends DefaultClientOptions, which autoloads a
+	// stray ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN / ANTHROPIC_BASE_URL or
+	// an on-disk fallback profile (active_config / "default"). In the
+	// WithAPIKey branch a leftover default profile then gets shadowed by our
+	// explicit key, which makes the SDK emit a misleading "ANTHROPIC_API_KEY
+	// is set ... takes precedence over the profile" warning even though the
+	// env var is empty/unset. Suppressing env defaults keeps every mode
+	// deterministic: only ccgate's resolved credential and configured
+	// base_url reach the request.
+	opts := []option.RequestOption{
+		option.WithMaxRetries(maxRetries),
+		option.WithoutEnvironmentDefaults(),
+	}
 	if c.UseProfile {
 		profileOpts, err := c.resolveProfileOptions()
 		if err != nil {
@@ -188,8 +203,10 @@ func (c *Client) resolveProfileOptions() ([]option.RequestOption, error) {
 		"source", "profile",
 		"profile_name_set", c.Profile != "",
 	)
+	// Only the profile wiring lives here; env-default suppression
+	// (option.WithoutEnvironmentDefaults) is applied unconditionally by
+	// Decide for every mode, so it is not repeated here.
 	return []option.RequestOption{
-		option.WithoutEnvironmentDefaults(),
 		option.WithConfig(cfg),
 	}, nil
 }

--- a/internal/llm/anthropic/client_test.go
+++ b/internal/llm/anthropic/client_test.go
@@ -1,9 +1,11 @@
 package anthropic
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -59,6 +61,23 @@ func writeCredentials(t *testing.T, path, profile string) {
 	if err := anthropicconfig.WriteCredentials(path, creds); err != nil {
 		t.Fatalf("WriteCredentials: %v", err)
 	}
+}
+
+// unsetEnvForTest removes an env var for the duration of the test,
+// restoring any prior value on cleanup. t.Setenv cannot express
+// "unset", and an exported-empty value is not equivalent (e.g. the SDK
+// treats ANTHROPIC_PROFILE="" as an explicit empty profile name).
+func unsetEnvForTest(t *testing.T, key string) {
+	t.Helper()
+	prev, had := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("unset %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(key, prev)
+		}
+	})
 }
 
 // setActiveConfig writes the active_config pointer used by
@@ -181,6 +200,71 @@ func TestProfileLoadPaths(t *testing.T) {
 				t.Fatalf("server calls = %d, want 1", got)
 			}
 		})
+	}
+}
+
+// TestNonProfileSuppressesEnvDefaults proves that the WithAPIKey
+// (exec / file / *_API_KEY) path passes option.WithoutEnvironmentDefaults
+// so the SDK's env autoload never runs. Without it, an empty/unset
+// ANTHROPIC_API_KEY makes the SDK fall through to an on-disk fallback
+// profile (active_config / "default"), which our explicit key then
+// shadows — emitting the misleading "ANTHROPIC_API_KEY is set ... takes
+// precedence over the profile" warning. The explicit key is used either
+// way (it shadows the profile), so the only observable signal of the
+// fix is the absence of that warning. This is the only ccgate test that
+// exercises the autoload-shadow path, so the SDK's once-per-process
+// warn dedupe is pristine when it runs.
+//
+// Cannot run t.Parallel — mutates process env via t.Setenv.
+func TestNonProfileSuppressesEnvDefaults(t *testing.T) {
+	t.Setenv("ANTHROPIC_CONFIG_DIR", t.TempDir())
+	// The user's exact scenario: ANTHROPIC_API_KEY exported but empty, so
+	// the SDK skips it and falls through to the on-disk fallback profile.
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	// ANTHROPIC_PROFILE must be UNSET (not empty): an exported-empty value
+	// makes LoadConfig error with "profile name is empty" instead of
+	// falling through to active_config / the literal "default" profile,
+	// which would defeat the autoload this test needs to provoke.
+	unsetEnvForTest(t, "ANTHROPIC_PROFILE")
+
+	// Stage a fallback "default" profile the SDK would autoload if env
+	// defaults were not suppressed.
+	credPath := fixtureProfileConfig(t, "default", "https://should-not-be-used.example")
+	writeCredentials(t, credPath, "default")
+	setActiveConfig(t, "default")
+
+	var gotAuth, gotAPIKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotAPIKey = r.Header.Get("X-Api-Key")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "msg_test", "type": "message", "role": "assistant", "model": "claude-test",
+			"content":     []map[string]any{{"type": "text", "text": `{"behavior":"allow"}`}},
+			"stop_reason": "end_turn",
+			"usage":       map[string]any{"input_tokens": 1, "output_tokens": 1},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	var logBuf bytes.Buffer
+	log.SetOutput(&logBuf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	c := &Client{APIKey: "sk-ant-explicit", BaseURL: srv.URL}
+	if _, err := c.Decide(context.Background(), classificationPrompt("claude-test", 5_000)); err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	if gotAPIKey != "sk-ant-explicit" {
+		t.Errorf("X-Api-Key = %q, want sk-ant-explicit", gotAPIKey)
+	}
+	if gotAuth != "" {
+		t.Errorf("autoloaded profile credential leaked: Authorization = %q", gotAuth)
+	}
+	if out := logBuf.String(); strings.Contains(out, "takes precedence over the profile") {
+		t.Errorf("env defaults not suppressed: SDK emitted shadow warning: %q", out)
 	}
 }
 

--- a/internal/runner/auth_status_test.go
+++ b/internal/runner/auth_status_test.go
@@ -56,53 +56,104 @@ func TestProviderAuthStatus(t *testing.T) {
 	}
 }
 
-// TestRedactProviderError pins the contract that the SDK error
-// string never reaches the runner's log / metrics surface verbatim.
-// Both anthropic-sdk-go and openai-go embed the response body in
+// TestRedactProviderError pins the contract that the runner's
+// log / metrics surface gets the API's structured error type and
+// message (the diagnosable parts) but never the raw response body
+// verbatim. Both anthropic-sdk-go and openai-go embed the body in
 // Error.Error(), and proxies sometimes echo Authorization headers /
 // request signatures there.
 func TestRedactProviderError(t *testing.T) {
 	t.Parallel()
 
 	cases := map[string]struct {
+		provider     string
 		err          error
-		wantContains string
-		wantOmits    string
+		wantContains []string
+		wantOmits    []string
 	}{
-		"anthropic 500": {
-			// Real anthropic-sdk-go errors render with "POST 'url': 500 ..."
-			// and the response body. We can't easily fabricate that body
-			// here, but we can verify the redacted message no longer
-			// contains the long, body-bearing prefix.
+		"anthropic bare status": {
+			// A zero-value SDK error (no parsed type / body) collapses to
+			// just the status — proving empty parts are omitted, not
+			// printed as "type=" / ": ".
+			provider:     "anthropic",
 			err:          &anthropicsdk.Error{StatusCode: 500},
-			wantContains: "anthropic API error (status 500)",
+			wantContains: []string{"anthropic API error (status 500)"},
+			wantOmits:    []string{"type=", ": "},
 		},
-		"openai 502": {
-			err:          &openaisdk.Error{StatusCode: 502},
-			wantContains: "openai API error (status 502)",
+		"openai surfaces type and message": {
+			// openai-go exposes Type / Message as public struct fields, so
+			// we can drive the full format deterministically. This is the
+			// case that would have told the user "model not found" instead
+			// of a bare "status 400".
+			provider: "openai",
+			err: &openaisdk.Error{
+				StatusCode: 400,
+				Type:       "invalid_request_error",
+				Message:    "model: gpt-bogus does not exist",
+			},
+			wantContains: []string{
+				"openai API error (status 400)",
+				"type=invalid_request_error",
+				"model: gpt-bogus does not exist",
+			},
 		},
 		"non-sdk error passthrough": {
+			provider:     "anthropic",
 			err:          errors.New("network read timed out"),
-			wantContains: "network read timed out",
+			wantContains: []string{"network read timed out"},
 		},
-		"nil": {err: nil, wantContains: ""},
+		"nil": {provider: "anthropic", err: nil},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			provider := "anthropic"
-			if strings.Contains(name, "openai") {
-				provider = "openai"
-			}
-			got := redactProviderError(provider, tc.err)
+			got := redactProviderError(tc.provider, tc.err)
 			if tc.err == nil {
 				if got != nil {
 					t.Fatalf("nil err must redact to nil, got %v", got)
 				}
 				return
 			}
-			if !strings.Contains(got.Error(), tc.wantContains) {
-				t.Fatalf("redacted = %q, want substring %q", got.Error(), tc.wantContains)
+			for _, want := range tc.wantContains {
+				if !strings.Contains(got.Error(), want) {
+					t.Fatalf("redacted = %q, want substring %q", got.Error(), want)
+				}
+			}
+			for _, omit := range tc.wantOmits {
+				if strings.Contains(got.Error(), omit) {
+					t.Fatalf("redacted = %q, must not contain %q", got.Error(), omit)
+				}
+			}
+		})
+	}
+}
+
+// TestErrorEnvelopeMessage pins that we lift ONLY the error.message
+// field out of the standard provider envelope — never a sibling field
+// a misbehaving proxy might use to echo a credential / header.
+func TestErrorEnvelopeMessage(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		raw  string
+		want string
+	}{
+		"standard envelope":       {raw: `{"error":{"type":"not_found_error","message":"model: x"}}`, want: "model: x"},
+		"ignores sibling secrets": {raw: `{"error":{"message":"model: x"},"authorization":"Bearer SECRET"}`, want: "model: x"},
+		"empty body":              {raw: "", want: ""},
+		"not an error envelope":   {raw: `{"id":"msg_1","type":"message"}`, want: ""},
+		"malformed json":          {raw: `{"error":{`, want: ""},
+		"proxy html (not json)":   {raw: `<html>502 Bad Gateway</html>`, want: ""},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := errorEnvelopeMessage(tc.raw)
+			if got != tc.want {
+				t.Fatalf("errorEnvelopeMessage(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+			if strings.Contains(got, "SECRET") {
+				t.Fatalf("leaked sibling field into message: %q", got)
 			}
 		})
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -474,32 +474,76 @@ func decide(ctx context.Context, cfg config.Config, in HookInput, ro runtimeOpti
 	}
 }
 
-// redactProviderError strips the SDK error of its raw response
-// body before the runner logs it / writes it to metrics. Both
-// anthropic-sdk-go and openai-go build Error.Error() by embedding
-// the entire response body, which a misbehaving proxy / gateway can
-// populate with Authorization headers, request signatures, or echo
-// of the submitted credential. ccgate.log is `0644` and the
-// metrics JSONL is consumed by the user's other tooling, so we
-// can't risk that surface carrying secrets through.
+// redactProviderError keeps the diagnosable parts of an SDK error
+// (status, the API's structured error `type` and `message`, request
+// id) while dropping the raw response body. Both anthropic-sdk-go and
+// openai-go build Error.Error() by embedding the entire response body,
+// which a misbehaving proxy / gateway can populate with Authorization
+// headers, request signatures, or an echo of the submitted credential.
+// ccgate.log is `0644` and the metrics JSONL is consumed by the user's
+// other tooling, so we can't risk that surface carrying secrets.
 //
-// Known SDK error types collapse to "<provider> <statusCode>".
-// Anything else (transport / context / parse) keeps its original
-// shape because we built those messages ourselves and they don't
-// echo provider response bodies.
+// We surface ONLY the standard `{"error":{"type","message"}}` envelope
+// fields, never the raw dump: that envelope is the API's own
+// human-readable description (e.g. "model: claude-haiku-4-5") and is
+// exactly what a user needs to tell a model-name typo from an auth or
+// rate-limit failure. A body that doesn't fit the envelope leaves
+// type/message empty and collapses to "<provider> API error
+// (status N)".
+//
+// Non-SDK errors (transport / context / parse) keep their original
+// shape because we built those messages ourselves and they don't echo
+// provider response bodies.
 func redactProviderError(providerName string, err error) error {
 	if err == nil {
 		return nil
 	}
 	var anth *anthropicsdk.Error
 	if errors.As(err, &anth) {
-		return fmt.Errorf("%s API error (status %d)", providerName, anth.StatusCode)
+		return providerAPIError(providerName, anth.StatusCode, string(anth.Type()), errorEnvelopeMessage(anth.RawJSON()), anth.RequestID)
 	}
 	var oai *openaisdk.Error
 	if errors.As(err, &oai) {
-		return fmt.Errorf("%s API error (status %d)", providerName, oai.StatusCode)
+		return providerAPIError(providerName, oai.StatusCode, oai.Type, oai.Message, "")
 	}
 	return err
+}
+
+// providerAPIError formats the redacted, secret-free API error string
+// from its already-extracted structured parts. type / message /
+// requestID are appended only when present so a bare body still yields
+// a clean "<provider> API error (status N)".
+func providerAPIError(providerName string, status int, errType, message, requestID string) error {
+	out := fmt.Sprintf("%s API error (status %d)", providerName, status)
+	if errType != "" {
+		out += fmt.Sprintf(", type=%s", errType)
+	}
+	if message != "" {
+		out += ": " + message
+	}
+	if requestID != "" {
+		out += fmt.Sprintf(" (request-id %s)", requestID)
+	}
+	return errors.New(out)
+}
+
+// errorEnvelopeMessage pulls the `error.message` field out of the
+// standard provider error envelope without exposing any other part of
+// the raw body. Returns "" when the body is empty or not shaped like
+// {"error":{"message":"..."}}.
+func errorEnvelopeMessage(rawJSON string) string {
+	if rawJSON == "" {
+		return ""
+	}
+	var envelope struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(rawJSON), &envelope); err != nil {
+		return ""
+	}
+	return envelope.Error.Message
 }
 
 // providerAuthStatus type-checks the error against the


### PR DESCRIPTION
## Why

With `auth.type=exec`/`file` (or a `*_API_KEY` env var), the Anthropic client did not pass `option.WithoutEnvironmentDefaults`, so the SDK ran its env autoload. When `ANTHROPIC_API_KEY` is unset or exported-empty, the SDK falls through to an on-disk fallback profile (`active_config` / `"default"`), which the explicit key then shadows — emitting a misleading `ANTHROPIC_API_KEY is set ... takes precedence over the profile configuration passed via WithConfig` warning even though the env var is empty. The explicit credential is still used, so this is noise + nondeterminism, not a credential swap.

Separately, when a request was genuinely rejected (e.g. a wrong model name), `redactProviderError` collapsed it to `<provider> API error (status 400)`, hiding the reason — a model-name typo was indistinguishable from an auth or rate-limit failure.

## What

- Apply `option.WithoutEnvironmentDefaults` unconditionally in `anthropic.Client.Decide` for every mode (was profile-only). ccgate always resolves its own credential, so the SDK contributes nothing from the ambient environment: a stray `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN`, an on-disk `default` profile, and `ANTHROPIC_BASE_URL` are all ignored. Adds a regression test that reproduces (and now suppresses) the exact shadow warning.
- `redactProviderError` now lifts the standard `{"error":{"type","message"}}` envelope fields so the API's own description (e.g. `model: ... not found`) reaches the log/metrics, while still dropping the raw response body so a proxy can't leak headers/signatures. Tests cover the openai type/message path and the message-extraction helper (incl. a no-sibling-leak case).

Docs: note in `docs/api-key-helper.md` (+ ja) that for the Anthropic provider ccgate ignores ambient env / on-disk profiles; `provider.base_url` is the base-URL control.