### PR TITLE
docs: migrate codex_hooks feature key to hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ That's it — ccgate is now running with its embedded defaults. To customize wha
 ## Quick start — Codex CLI
 
 > [!NOTE]
-> Codex hooks require `[features] codex_hooks = true` in `~/.codex/config.toml`. See [docs/codex-cli.md](docs/codex-cli.md) for details.
+> Codex hooks require `[features] hooks = true` in `~/.codex/config.toml`. See [docs/codex-cli.md](docs/codex-cli.md) for details.
 
 ### 1. Register as a Codex hook
 
@@ -127,7 +127,7 @@ Codex reads hooks from `~/.codex/hooks.json` and `~/.codex/config.toml` (with `<
 
 ```toml
 [features]
-codex_hooks = true   # Codex hooks live behind this feature flag; keep it set for compatibility.
+hooks = true   # Codex hooks live behind this feature flag.
 
 [[hooks.PermissionRequest]]
 matcher = ""

--- a/docs/codex-cli.md
+++ b/docs/codex-cli.md
@@ -6,7 +6,7 @@ Codex-CLI-specific notes for the `ccgate codex` hook.
 
 ## Requirements
 
-- Codex hooks require `[features] codex_hooks = true`. See [OpenAI's Codex hooks docs](https://developers.openai.com/codex/hooks) for the upstream payload schema.
+- Codex hooks require `[features] hooks = true`. See [OpenAI's Codex hooks docs](https://developers.openai.com/codex/hooks) for the upstream payload schema.
 - **Tool-agnostic.** Codex hooks fire for Bash, `apply_patch`, MCP tool calls, and other surfaces. ccgate classifies by `tool_name` + the full `tool_input` JSON, not by tool kind alone.
 
 ## Hook registration
@@ -49,7 +49,7 @@ If you want to keep hooks alongside the rest of your Codex config:
 
 ```toml
 [features]
-codex_hooks = true   # Codex hooks live behind this feature flag; keep it set for compatibility.
+hooks = true   # Codex hooks live behind this feature flag.
 
 [[hooks.PermissionRequest]]
 matcher = ""

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -227,4 +227,4 @@ The same fields exist for the log file (`log_path`, `log_disabled`, `log_max_siz
 
 - **Plan mode (Claude only) is prompt-only.** Under `permission_mode == "plan"`, ccgate relies on the LLM plus prose in the system prompt to (a) reject implementation-side writes and (b) allow read-only queries without an explicit allow-guidance match. Either side can misfire.
 - **No surgical reset for a single embedded default rule.** A layer either replaces a list wholesale or appends to it; removing one specific embedded entry while keeping the rest requires re-stating the whole list under `allow` / `deny` minus that one entry.
-- ccgate decides from the hook payload + ccgate config. The Codex side requires `[features] codex_hooks = true` (see the [OpenAI Codex hooks docs](https://developers.openai.com/codex/hooks) for schema details).
+- ccgate decides from the hook payload + ccgate config. The Codex side requires `[features] hooks = true` (see the [OpenAI Codex hooks docs](https://developers.openai.com/codex/hooks) for schema details).

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -96,7 +96,7 @@ ccgate は default で Anthropic の Claude Haiku を呼びます。 `CCGATE_ANT
 ## クイックスタート — Codex CLI
 
 > [!NOTE]
-> Codex hooks は `~/.codex/config.toml` に `[features] codex_hooks = true` の設定が必要です。詳細は [docs/codex-cli.md](codex-cli.md) を参照。
+> Codex hooks は `~/.codex/config.toml` に `[features] hooks = true` の設定が必要です。詳細は [docs/codex-cli.md](codex-cli.md) を参照。
 
 ### 1. Codex hook として登録
 
@@ -127,7 +127,7 @@ Codex は `~/.codex/hooks.json` と `~/.codex/config.toml` から hook を読み
 
 ```toml
 [features]
-codex_hooks = true   # Codex hooks はこの feature flag 配下にあり、互換性のため明示しておく
+hooks = true   # Codex hooks はこの feature flag 配下にある
 
 [[hooks.PermissionRequest]]
 matcher = ""

--- a/docs/ja/codex-cli.md
+++ b/docs/ja/codex-cli.md
@@ -6,7 +6,7 @@
 
 ## 前提
 
-- Codex hooks は `[features] codex_hooks = true` の設定が必要です。 upstream の payload schema は [OpenAI Codex hooks docs](https://developers.openai.com/codex/hooks) を参照。
+- Codex hooks は `[features] hooks = true` の設定が必要です。 upstream の payload schema は [OpenAI Codex hooks docs](https://developers.openai.com/codex/hooks) を参照。
 - **Tool-agnostic**: Codex hooks は Bash、 `apply_patch`、 MCP tool 呼び出しなど複数の surface で発火します。 ccgate は `tool_name` + `tool_input` JSON 全体で分類。
 
 ## hook 登録
@@ -49,7 +49,7 @@ Codex 設定全体を 1 ファイルにまとめたい場合:
 
 ```toml
 [features]
-codex_hooks = true   # Codex hooks はこの feature flag 配下にあるため、互換性のため明示しておく
+hooks = true   # Codex hooks はこの feature flag 配下にある
 
 [[hooks.PermissionRequest]]
 matcher = ""

--- a/docs/ja/configuration.md
+++ b/docs/ja/configuration.md
@@ -227,4 +227,4 @@ cache 層の失敗は fallthrough せずに自動回復するので、`slog.Warn
 
 - **Plan mode (Claude のみ) はプロンプト依存**: `permission_mode == "plan"` では (a) 実装系 write を拒絶する判定と (b) 明示的な allow guidance なしの read-only クエリ許可 を、LLM とシステムプロンプトの指示文に委ねています。どちらの方向にも誤判定の余地あり
 - **embedded default の特定ルールだけを部分削除する手段なし**: layer は list を **完全置換** (`allow: [...]`) するか **末尾追加** (`append_allow: [...]`) するかのどちらかで、embedded の中の 1 ルールだけ消したい場合は残り全部を `allow:` / `deny:` に書き直すしかない
-- ccgate は hook payload と ccgate の設定からのみ判定する。 Codex 側は `[features] codex_hooks = true` の設定が必要 (schema 詳細は [OpenAI Codex hooks docs](https://developers.openai.com/codex/hooks) を参照)。
+- ccgate は hook payload と ccgate の設定からのみ判定する。 Codex 側は `[features] hooks = true` の設定が必要 (schema 詳細は [OpenAI Codex hooks docs](https://developers.openai.com/codex/hooks) を参照)。


### PR DESCRIPTION
## Why

The `codex_hooks` feature key in `~/.codex/config.toml` is deprecated. `hooks` is now the canonical feature key for enabling Codex hooks. The docs should point users at the supported key.

https://developers.openai.com/codex/hooks
> Hooks are enabled by default. If you need to turn them off in config.toml, set:
> ```toml
> [features]
> hooks = false
> ```
> Use hooks as the canonical feature key. codex_hooks still works as a deprecated alias.

## What

- Replace every `[features] codex_hooks = true` example with `[features] hooks = true` across the docs (README, codex-cli, configuration; English and Japanese).
- Drop the now-unnecessary "keep it set for compatibility" notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/ccgate/pull/92" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->