### PR TITLE
chore(renovate): harden dependency update foundation

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -36,12 +36,16 @@
       matchManagers: ["gomod"],
       matchPackageNames: ["github.com/anthropics/anthropic-sdk-go"],
       groupName: "anthropic-sdk-go",
+      // Override the slug inherited from group:allNonMajor so minor/patch bumps
+      // get their own branch instead of being folded into renovate/all-minor-patch.
+      groupSlug: "anthropic-sdk-go",
     },
     {
       description: "invopop/jsonschema: independent PR; v0.14 switched OrderedMap to pb33f and breaks anthropic-sdk-go until upstream migrates",
       matchManagers: ["gomod"],
       matchPackageNames: ["github.com/invopop/jsonschema"],
       groupName: "jsonschema",
+      groupSlug: "jsonschema",
     },
     {
       description: "go directive: keep pinned at 1.25.0",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,14 +10,39 @@
   ],
   rangeStrategy: "bump",
   postUpdateOptions: ["gomodTidy"],
+  minimumReleaseAge: "3 days",
   labels: ["renovate"],
   prConcurrentLimit: 0,
   prHourlyLimit: 0,
   major: { labels: ["renovate", "update_major"] },
+  // Opt-in to the beta nix manager (disabled by default) so flake.lock is maintained.
+  nix: { enabled: true },
   gitIgnoredAuthors: [
     "github-actions[bot]@users.noreply.github.com",
   ],
   packageRules: [
+    {
+      description: "Rename the allNonMajor group (avoid 'non-major' wording)",
+      matchUpdateTypes: ["minor", "patch"],
+      groupName: "minor & patch updates",
+    },
+    {
+      description: "Nix flake.lock: refresh via lock file maintenance (beta nix manager)",
+      matchManagers: ["nix"],
+      lockFileMaintenance: { enabled: true },
+    },
+    {
+      description: "anthropic-sdk-go: independent PR (coupled to jsonschema's OrderedMap dep)",
+      matchManagers: ["gomod"],
+      matchPackageNames: ["github.com/anthropics/anthropic-sdk-go"],
+      groupName: "anthropic-sdk-go",
+    },
+    {
+      description: "invopop/jsonschema: independent PR; v0.14 switched OrderedMap to pb33f and breaks anthropic-sdk-go until upstream migrates",
+      matchManagers: ["gomod"],
+      matchPackageNames: ["github.com/invopop/jsonschema"],
+      groupName: "jsonschema",
+    },
     {
       description: "go directive: keep pinned at 1.25.0",
       matchDepNames: ["go"],


### PR DESCRIPTION
## Why

Grouped Renovate PR #47 (`update all non-major dependencies`) is red on every OS because `group:allNonMajor` bumped `anthropic-sdk-go` and `invopop/jsonschema` together. `jsonschema` v0.14 switched its `Schema` OrderedMap from `wk8/go-ordered-map` to `pb33f/ordered-map`, which breaks `anthropic-sdk-go` (still on `wk8`) at compile time, so `go vet`/test/lint fail. A single incompatible pair shouldn't keep the whole batch red.

## What

Reworks `.github/renovate.json5` to make the update flow more robust:

- Carve `anthropic-sdk-go` and `invopop/jsonschema` into their own groups so they get independent PRs. The `anthropic-sdk-go` bump can land green on its own; the `jsonschema` bump stays isolated (it cannot pass until upstream `anthropic-sdk-go` migrates to `pb33f`) instead of blocking everything else.
- Rename the `allNonMajor` group to `minor & patch updates` to drop the `non-major` wording from PR titles.
- Add a global `minimumReleaseAge: "3 days"` to avoid pulling in just-published versions.
- Opt-in to the beta `nix` manager and enable `lockFileMaintenance` for it so `flake.lock` is kept fresh within the Renovate flow.

`go mod tidy` was already covered by `postUpdateOptions: ["gomodTidy"]`; no change needed there.