### PR TITLE
chore(renovate): merge anthropic-sdk-go and jsonschema into the main group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,22 +32,6 @@
       lockFileMaintenance: { enabled: true },
     },
     {
-      description: "anthropic-sdk-go: independent PR (coupled to jsonschema's OrderedMap dep)",
-      matchManagers: ["gomod"],
-      matchPackageNames: ["github.com/anthropics/anthropic-sdk-go"],
-      groupName: "anthropic-sdk-go",
-      // Override the slug inherited from group:allNonMajor so minor/patch bumps
-      // get their own branch instead of being folded into renovate/all-minor-patch.
-      groupSlug: "anthropic-sdk-go",
-    },
-    {
-      description: "invopop/jsonschema: independent PR; v0.14 switched OrderedMap to pb33f and breaks anthropic-sdk-go until upstream migrates",
-      matchManagers: ["gomod"],
-      matchPackageNames: ["github.com/invopop/jsonschema"],
-      groupName: "jsonschema",
-      groupSlug: "jsonschema",
-    },
-    {
       description: "go directive: keep pinned at 1.25.0",
       matchDepNames: ["go"],
       matchManagers: ["gomod"],


### PR DESCRIPTION
## Why

`anthropic-sdk-go` and `invopop/jsonschema` were split into independent PRs because jsonschema v0.14 switched `OrderedMap` to the pb33f implementation and broke anthropic-sdk-go. That incompatibility is now resolved — in fact the two must be bumped together or CI fails, so isolating them into separate PRs is actively harmful.

## What

Removes both dedicated package rules from `.github/renovate.json5` so the two packages fall back into the default `group:allNonMajor` ("minor & patch updates"). They now always land in a single PR alongside other non-major updates and move in lockstep. Major updates remain separated via `:separateMultipleMajorReleases` (manual handling, out of scope).