### PR TITLE
fix(llm): emit reason before behavior in classifier output schema

### DIFF
--- a/internal/llm/anthropic/client.go
+++ b/internal/llm/anthropic/client.go
@@ -17,7 +17,6 @@ import (
 	anthropicsdk "github.com/anthropics/anthropic-sdk-go"
 	anthropicconfig "github.com/anthropics/anthropic-sdk-go/config"
 	"github.com/anthropics/anthropic-sdk-go/option"
-	"github.com/invopop/jsonschema"
 
 	"github.com/tak848/ccgate/internal/llm"
 )
@@ -121,7 +120,11 @@ func (c *Client) Decide(ctx context.Context, p llm.Prompt) (llm.Result, error) {
 	}
 	client := anthropicsdk.NewClient(opts...)
 
-	schema, err := outputSchema()
+	// The SDK's Schema field is map[string]any, whose keys the encoder
+	// sorts alphabetically; OutputSchemaMap injects `properties` as a
+	// json.RawMessage so the reason-first property order survives. See
+	// llm.OutputSchemaMap.
+	schema, err := llm.OutputSchemaMap()
 	if err != nil {
 		return llm.Result{}, fmt.Errorf("generate output schema: %w", err)
 	}
@@ -276,23 +279,6 @@ func classifyProfileLoadError(err error) string {
 		return "profile_config_invalid"
 	}
 	return "unknown"
-}
-
-func outputSchema() (map[string]any, error) {
-	reflector := jsonschema.Reflector{
-		AllowAdditionalProperties: false,
-		DoNotReference:            true,
-	}
-	schema := reflector.Reflect(llm.Output{})
-	data, err := json.Marshal(schema)
-	if err != nil {
-		return nil, fmt.Errorf("marshal schema: %w", err)
-	}
-	var out map[string]any
-	if err := json.Unmarshal(data, &out); err != nil {
-		return nil, fmt.Errorf("unmarshal schema: %w", err)
-	}
-	return out, nil
 }
 
 func extractMessageText(message *anthropicsdk.Message) string {

--- a/internal/llm/anthropic/schema_wire_test.go
+++ b/internal/llm/anthropic/schema_wire_test.go
@@ -1,0 +1,71 @@
+package anthropic
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	anthropicsdk "github.com/anthropics/anthropic-sdk-go"
+
+	"github.com/tak848/ccgate/internal/llm"
+)
+
+// orderedKeys returns the keys of a JSON object in source order.
+func orderedKeys(t *testing.T, obj json.RawMessage) []string {
+	t.Helper()
+	dec := json.NewDecoder(bytes.NewReader(obj))
+	tok, err := dec.Token()
+	if err != nil {
+		t.Fatalf("read opening token: %v", err)
+	}
+	if delim, ok := tok.(json.Delim); !ok || delim != '{' {
+		t.Fatalf("expected object, got %v", tok)
+	}
+	var keys []string
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			t.Fatalf("read key token: %v", err)
+		}
+		keys = append(keys, keyTok.(string))
+		var skip json.RawMessage
+		if err := dec.Decode(&skip); err != nil {
+			t.Fatalf("skip value: %v", err)
+		}
+	}
+	return keys
+}
+
+// TestOutputSchemaWireOrder marshals the schema through the Anthropic
+// SDK's own encoder (the JSONOutputFormatParam path used by Decide) and
+// asserts the property order survives as reason, behavior, deny_message.
+// Unlike the std-lib check in internal/llm, this guards against an SDK
+// upgrade changing how it serializes json.RawMessage values nested in a
+// map[string]any -- which would silently revert order to alphabetical.
+func TestOutputSchemaWireOrder(t *testing.T) {
+	m, err := llm.OutputSchemaMap()
+	if err != nil {
+		t.Fatalf("OutputSchemaMap: %v", err)
+	}
+
+	wire, err := json.Marshal(anthropicsdk.JSONOutputFormatParam{Schema: m})
+	if err != nil {
+		t.Fatalf("marshal JSONOutputFormatParam: %v", err)
+	}
+
+	var format struct {
+		Schema struct {
+			Properties json.RawMessage `json:"properties"`
+		} `json:"schema"`
+	}
+	if err := json.Unmarshal(wire, &format); err != nil {
+		t.Fatalf("unmarshal wire payload: %v", err)
+	}
+
+	got := orderedKeys(t, format.Schema.Properties)
+	want := []string{"reason", "behavior", "deny_message"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("wire property order = %v, want %v\npayload: %s", got, want, wire)
+	}
+}

--- a/internal/llm/openai/client.go
+++ b/internal/llm/openai/client.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/invopop/jsonschema"
 	openaigo "github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/option"
 	"github.com/openai/openai-go/v3/packages/param"
@@ -59,7 +58,10 @@ func (c *Client) Decide(ctx context.Context, p llm.Prompt) (llm.Result, error) {
 	}
 	client := openaigo.NewClient(opts...)
 
-	schema, err := outputSchema()
+	// json.RawMessage keeps the schema's property order (reason first)
+	// intact on the wire; a map[string]any would be re-sorted
+	// alphabetically by the JSON encoder. See llm.OutputSchemaRaw.
+	schema, err := llm.OutputSchemaRaw()
 	if err != nil {
 		return llm.Result{}, fmt.Errorf("generate output schema: %w", err)
 	}
@@ -119,21 +121,4 @@ func (c *Client) Decide(ctx context.Context, p llm.Prompt) (llm.Result, error) {
 	}
 
 	return llm.Result{Output: output, Usage: usage}, nil
-}
-
-func outputSchema() (map[string]any, error) {
-	reflector := jsonschema.Reflector{
-		AllowAdditionalProperties: false,
-		DoNotReference:            true,
-	}
-	schema := reflector.Reflect(llm.Output{})
-	data, err := json.Marshal(schema)
-	if err != nil {
-		return nil, fmt.Errorf("marshal schema: %w", err)
-	}
-	var out map[string]any
-	if err := json.Unmarshal(data, &out); err != nil {
-		return nil, fmt.Errorf("unmarshal schema: %w", err)
-	}
-	return out, nil
 }

--- a/internal/llm/openai/schema_wire_test.go
+++ b/internal/llm/openai/schema_wire_test.go
@@ -1,0 +1,76 @@
+package openai
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	openaigo "github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+
+	"github.com/tak848/ccgate/internal/llm"
+)
+
+// orderedKeys returns the keys of a JSON object in source order.
+func orderedKeys(t *testing.T, obj json.RawMessage) []string {
+	t.Helper()
+	dec := json.NewDecoder(bytes.NewReader(obj))
+	tok, err := dec.Token()
+	if err != nil {
+		t.Fatalf("read opening token: %v", err)
+	}
+	if delim, ok := tok.(json.Delim); !ok || delim != '{' {
+		t.Fatalf("expected object, got %v", tok)
+	}
+	var keys []string
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			t.Fatalf("read key token: %v", err)
+		}
+		keys = append(keys, keyTok.(string))
+		var skip json.RawMessage
+		if err := dec.Decode(&skip); err != nil {
+			t.Fatalf("skip value: %v", err)
+		}
+	}
+	return keys
+}
+
+// TestOutputSchemaWireOrder marshals the schema through the OpenAI SDK's
+// own encoder (the ResponseFormatJSONSchema path used by Decide) and
+// asserts the property order survives as reason, behavior, deny_message.
+// This guards against an SDK upgrade changing how it serializes the
+// json.RawMessage schema value, which would silently revert order to
+// alphabetical and reintroduce decide-before-reason.
+func TestOutputSchemaWireOrder(t *testing.T) {
+	raw, err := llm.OutputSchemaRaw()
+	if err != nil {
+		t.Fatalf("OutputSchemaRaw: %v", err)
+	}
+
+	wire, err := json.Marshal(openaigo.ResponseFormatJSONSchemaJSONSchemaParam{
+		Name:   "permission_decision",
+		Strict: param.NewOpt(true),
+		Schema: raw,
+	})
+	if err != nil {
+		t.Fatalf("marshal ResponseFormatJSONSchemaJSONSchemaParam: %v", err)
+	}
+
+	var format struct {
+		Schema struct {
+			Properties json.RawMessage `json:"properties"`
+		} `json:"schema"`
+	}
+	if err := json.Unmarshal(wire, &format); err != nil {
+		t.Fatalf("unmarshal wire payload: %v", err)
+	}
+
+	got := orderedKeys(t, format.Schema.Properties)
+	want := []string{"reason", "behavior", "deny_message"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("wire property order = %v, want %v\npayload: %s", got, want, wire)
+	}
+}

--- a/internal/llm/schema.go
+++ b/internal/llm/schema.go
@@ -1,0 +1,61 @@
+package llm
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/invopop/jsonschema"
+)
+
+// reflectOutputSchema reflects Output into a JSON schema. The schema's
+// Properties is an ordered map, so marshaling it preserves the struct
+// field order (reason, behavior, deny_message).
+func reflectOutputSchema() *jsonschema.Schema {
+	reflector := jsonschema.Reflector{
+		AllowAdditionalProperties: false,
+		DoNotReference:            true,
+	}
+	return reflector.Reflect(Output{})
+}
+
+// OutputSchemaRaw returns the Output JSON schema as raw bytes with
+// property order preserved (reason, behavior, deny_message). Use it for
+// SDK schema fields typed as `any` (e.g. OpenAI): passing a
+// json.RawMessage keeps the order intact on the wire because the SDK
+// emits json.Marshaler values verbatim.
+func OutputSchemaRaw() (json.RawMessage, error) {
+	data, err := json.Marshal(reflectOutputSchema())
+	if err != nil {
+		return nil, fmt.Errorf("marshal output schema: %w", err)
+	}
+	return json.RawMessage(data), nil
+}
+
+// OutputSchemaMap returns the Output JSON schema as a map, required by
+// SDK schema fields typed as map[string]any (e.g. Anthropic).
+//
+// Marshaling a Go map sorts keys alphabetically, which would reorder
+// `properties` to behavior, deny_message, reason and defeat the
+// reason-first contract (see Output). To prevent that, `properties` is
+// injected as a json.RawMessage built from the ordered reflected
+// schema; the SDK's apijson encoder emits json.Marshaler values
+// verbatim, so the property order survives even though the surrounding
+// map keys still get sorted (those remaining keys -- type, required,
+// additionalProperties -- are order-insensitive).
+func OutputSchemaMap() (map[string]any, error) {
+	schema := reflectOutputSchema()
+	full, err := json.Marshal(schema)
+	if err != nil {
+		return nil, fmt.Errorf("marshal output schema: %w", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(full, &m); err != nil {
+		return nil, fmt.Errorf("unmarshal output schema: %w", err)
+	}
+	props, err := json.Marshal(schema.Properties)
+	if err != nil {
+		return nil, fmt.Errorf("marshal output schema properties: %w", err)
+	}
+	m["properties"] = json.RawMessage(props)
+	return m, nil
+}

--- a/internal/llm/schema_test.go
+++ b/internal/llm/schema_test.go
@@ -1,0 +1,120 @@
+package llm
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// orderedPropertyKeys returns the keys of a JSON object in source order
+// (encoding/json into a map would lose it).
+func orderedPropertyKeys(t *testing.T, obj json.RawMessage) []string {
+	t.Helper()
+	dec := json.NewDecoder(bytes.NewReader(obj))
+	tok, err := dec.Token()
+	if err != nil {
+		t.Fatalf("read opening token: %v", err)
+	}
+	if delim, ok := tok.(json.Delim); !ok || delim != '{' {
+		t.Fatalf("expected object, got %v", tok)
+	}
+	var keys []string
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			t.Fatalf("read key token: %v", err)
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			t.Fatalf("expected string key, got %v", keyTok)
+		}
+		keys = append(keys, key)
+		var skip json.RawMessage
+		if err := dec.Decode(&skip); err != nil {
+			t.Fatalf("skip value for %q: %v", key, err)
+		}
+	}
+	return keys
+}
+
+// TestOutputSchemaPropertyOrder is the regression guard for the bug
+// where the schema reached the model with properties in alphabetical
+// order (behavior, deny_message, reason), forcing the model to emit its
+// decision before its reasoning. reason MUST come first. The check runs
+// against both producers, marshaling the map exactly as an SDK would.
+func TestOutputSchemaPropertyOrder(t *testing.T) {
+	wantOrder := []string{"reason", "behavior", "deny_message"}
+
+	producers := map[string]func() ([]byte, error){
+		"raw": func() ([]byte, error) {
+			r, err := OutputSchemaRaw()
+			return []byte(r), err
+		},
+		"map": func() ([]byte, error) {
+			m, err := OutputSchemaMap()
+			if err != nil {
+				return nil, err
+			}
+			return json.Marshal(m)
+		},
+	}
+
+	for name, produce := range producers {
+		t.Run(name, func(t *testing.T) {
+			data, err := produce()
+			if err != nil {
+				t.Fatalf("produce schema: %v", err)
+			}
+
+			var shape struct {
+				Properties json.RawMessage `json:"properties"`
+				Required   []string        `json:"required"`
+			}
+			if err := json.Unmarshal(data, &shape); err != nil {
+				t.Fatalf("unmarshal schema: %v", err)
+			}
+
+			gotOrder := orderedPropertyKeys(t, shape.Properties)
+			if !reflect.DeepEqual(gotOrder, wantOrder) {
+				t.Errorf("property order = %v, want %v", gotOrder, wantOrder)
+			}
+
+			// All fields must be required: Anthropic places required
+			// fields before optional ones, so a non-required field would
+			// be reordered and break the contract.
+			gotRequired := append([]string(nil), shape.Required...)
+			sort.Strings(gotRequired)
+			wantRequired := []string{"behavior", "deny_message", "reason"}
+			if !reflect.DeepEqual(gotRequired, wantRequired) {
+				t.Errorf("required = %v, want all of %v", shape.Required, wantRequired)
+			}
+		})
+	}
+}
+
+// TestOutputSchemaBehaviorEnum verifies behavior is constrained to the
+// three valid decisions so the model cannot return an out-of-band value.
+func TestOutputSchemaBehaviorEnum(t *testing.T) {
+	raw, err := OutputSchemaRaw()
+	if err != nil {
+		t.Fatalf("OutputSchemaRaw: %v", err)
+	}
+	var shape struct {
+		Properties struct {
+			Behavior struct {
+				Enum []string `json:"enum"`
+			} `json:"behavior"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(raw, &shape); err != nil {
+		t.Fatalf("unmarshal schema: %v", err)
+	}
+	got := append([]string(nil), shape.Properties.Behavior.Enum...)
+	sort.Strings(got)
+	want := []string{"allow", "deny", "fallthrough"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("behavior enum = %v, want %v", shape.Properties.Behavior.Enum, want)
+	}
+}

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -23,9 +23,18 @@ type Prompt struct {
 }
 
 // Output is the structured response from the LLM.
+//
+// Field order is deliberate and load-bearing: providers generate the
+// JSON keys in schema property order (OpenAI follows schema order;
+// Anthropic follows it for required fields, which all of these are).
+// Reason MUST come first so the model writes its justification before
+// committing to a behavior -- emitting behavior first makes weak models
+// (e.g. haiku, kimi) lock in a decision before reasoning, producing
+// reason/behavior contradictions. See internal/llm/schema.go for how
+// the order survives the trip to each SDK.
 type Output struct {
-	Behavior    string `json:"behavior"     jsonschema_description:"One of allow, deny, fallthrough."`
-	Reason      string `json:"reason"       jsonschema_description:"Brief reason for the decision. Always provide this regardless of behavior."`
+	Reason      string `json:"reason"       jsonschema_description:"Brief reason for the decision. Always provide this regardless of behavior. Write this BEFORE deciding behavior."`
+	Behavior    string `json:"behavior"     jsonschema:"enum=allow,enum=deny,enum=fallthrough" jsonschema_description:"One of allow, deny, fallthrough. Must be consistent with reason."`
 	DenyMessage string `json:"deny_message" jsonschema_description:"When behavior is deny, a concise explanation of why. Must not be empty when denying."`
 }
 

--- a/internal/prompt/build.go
+++ b/internal/prompt/build.go
@@ -60,7 +60,7 @@ func Build(args Args) llm.Prompt {
 	sys.WriteString(target)
 	sys.WriteString(".\n")
 	sys.WriteString("Return one of: allow, deny, fallthrough.\n")
-	sys.WriteString("Decide quickly. Do not deliberate or reconsider.\n\n")
+	sys.WriteString("First put a brief justification in `reason`, then set `behavior` consistent with it. Keep it short; do not over-deliberate.\n\n")
 
 	if args.PlanMode {
 		writePlanModeRules(&sys, args.HasRecentTranscript)


### PR DESCRIPTION
## Why

The classifier was returning contradictory decisions: `reason` reasoned toward one outcome while `behavior` said the opposite, often with an unrelated `deny_message` (e.g. denying an allowed plan-file edit and pasting in a `cd` rule's message). It showed up most with weaker classifier models (haiku, kimi).

Root cause: `outputSchema()` round-tripped the reflected schema through `map[string]any` before passing it to the provider SDKs. `encoding/json` sorts map keys alphabetically, so `properties` reached the model as `behavior, deny_message, reason`. Under constrained/structured decoding the model generates keys in schema order, so it had to emit its decision (`behavior`) before its reasoning (`reason`) — and weak models lock in the wrong answer before thinking.

This bug is in released `v0.9.3` (the helper has had this shape since the OpenAI provider landed).

## What

- Reorder `llm.Output` to `reason, behavior, deny_message` so the model justifies before deciding.
- Preserve that order on the wire in a new shared `internal/llm/schema.go`:
  - OpenAI `Schema` is `any` → pass the ordered schema as `json.RawMessage`.
  - Anthropic `Schema` is `map[string]any` → inject `properties` as a `json.RawMessage` so it survives the map's alphabetical key sort (both SDK encoders emit `json.Marshaler` values verbatim).
- Constrain `behavior` with an `enum` (allow/deny/fallthrough).
- Prompt now asks for the justification first instead of "decide quickly, do not deliberate".
- Add a regression test asserting property order is `reason, behavior, deny_message` and all fields are required, for both the raw (OpenAI) and map (Anthropic) shapes.

Gemini delegates to the OpenAI client, so it is covered by the same fix.

Verified: `mise run test` and `mise run vet` pass.