### PR TITLE
chore(renovate): classify dependency updates as chores

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,7 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
     "config:recommended",
+    ":semanticCommitTypeAll(chore)",
     "helpers:pinGitHubActionDigestsToSemver",
     "group:allNonMajor",
     ":separateMultipleMajorReleases",


### PR DESCRIPTION
## Why

Renovate production dependency updates are currently generated as `fix(deps)`, so GoReleaser groups them under Bug Fixes via the existing `^fix` changelog rule even when the change is only a dependency refresh.

## What

- Add Renovate's `:semanticCommitTypeAll(chore)` preset so Renovate dependency update PRs use `chore(deps)` instead of `fix(deps)`.
- Keep the existing GoReleaser changelog grouping unchanged.
- Validated with `pnpm dlx --package renovate renovate-config-validator .github/renovate.json5`.