### PR TITLE
fix(gitutil): false-positive worktree detection in repo subdirectories

### DIFF
--- a/internal/gitutil/context.go
+++ b/internal/gitutil/context.go
@@ -1,6 +1,7 @@
 package gitutil
 
 import (
+	"os"
 	"path/filepath"
 )
 
@@ -53,11 +54,13 @@ func BuildContext(cwd string) Context {
 	}
 
 	// Worktree detection: in a linked worktree, git-dir and git-common-dir
-	// point at different directories. git may emit either value relative
-	// to cwd (e.g. "../.git" from a subdirectory), so resolve both to
-	// absolute before comparing — otherwise a plain subdirectory of the
-	// main checkout is mistaken for a worktree.
-	if gitDir != "" && gitCommonDir != "" && resolveAbs(cwd, gitDir) != resolveAbs(cwd, gitCommonDir) {
+	// point at different directories. git may emit either value relative to
+	// cwd (e.g. "../.git" from a subdirectory), and the absolute value may
+	// differ cosmetically from a resolved relative one — symlinked temp
+	// dirs (macOS /var vs /private/var) or mixed separators (Windows C:/
+	// vs C:\). Compare by filesystem identity so none of that causes a
+	// plain subdirectory of the main checkout to be mistaken for a worktree.
+	if gitDir != "" && gitCommonDir != "" && !samePath(cwd, gitDir, gitCommonDir) {
 		ctx.IsWorktree = true
 	}
 
@@ -80,4 +83,22 @@ func resolveAbs(base, p string) string {
 		return filepath.Clean(p)
 	}
 	return filepath.Clean(filepath.Join(base, p))
+}
+
+// samePath reports whether two git paths (each possibly relative to cwd)
+// refer to the same filesystem location. Paths are resolved against cwd
+// and compared by os.SameFile so symlinks and path-separator differences
+// do not cause false mismatches. If either path cannot be stat'd, it
+// falls back to a lexical comparison of the resolved absolute paths.
+func samePath(cwd, a, b string) bool {
+	ra, rb := resolveAbs(cwd, a), resolveAbs(cwd, b)
+	if ra == rb {
+		return true
+	}
+	sa, errA := os.Stat(ra)
+	sb, errB := os.Stat(rb)
+	if errA == nil && errB == nil {
+		return os.SameFile(sa, sb)
+	}
+	return false
 }

--- a/internal/gitutil/context.go
+++ b/internal/gitutil/context.go
@@ -31,6 +31,10 @@ func BuildContext(cwd string) Context {
 		ctx.RepoRoot = repoRoot
 	}
 
+	// GitDir and GitCommonDir mirror git's output verbatim, which may be
+	// relative to cwd (e.g. "../.git" from a subdirectory). They are kept
+	// raw for payload fidelity; any comparison or derivation below resolves
+	// them to absolute first. RepoRoot/PrimaryCheckoutRoot are absolute.
 	gitDir, err := Output(cwd, "rev-parse", "--git-dir")
 	if err == nil {
 		ctx.GitDir = gitDir

--- a/internal/gitutil/context.go
+++ b/internal/gitutil/context.go
@@ -2,7 +2,6 @@ package gitutil
 
 import (
 	"path/filepath"
-	"strings"
 )
 
 // Context is the cwd-derived git information ccgate exposes to the
@@ -40,13 +39,21 @@ func BuildContext(cwd string) Context {
 	gitCommonDir, err := Output(cwd, "rev-parse", "--git-common-dir")
 	if err == nil {
 		ctx.GitCommonDir = gitCommonDir
-		if strings.HasSuffix(gitCommonDir, "/.git") || strings.HasSuffix(gitCommonDir, string(filepath.Separator)+".git") {
-			ctx.PrimaryCheckoutRoot = filepath.Dir(gitCommonDir)
+		// git emits --git-common-dir relative to cwd (e.g. "../.git")
+		// when cwd is a repository subdirectory; resolve it so the
+		// PrimaryCheckoutRoot and the worktree comparison below are
+		// stable regardless of how git printed the path.
+		if abs := resolveAbs(cwd, gitCommonDir); filepath.Base(abs) == ".git" {
+			ctx.PrimaryCheckoutRoot = filepath.Dir(abs)
 		}
 	}
 
-	// Worktree detection: git-dir and git-common-dir differ in worktrees.
-	if gitDir != "" && gitCommonDir != "" && gitDir != gitCommonDir {
+	// Worktree detection: in a linked worktree, git-dir and git-common-dir
+	// point at different directories. git may emit either value relative
+	// to cwd (e.g. "../.git" from a subdirectory), so resolve both to
+	// absolute before comparing — otherwise a plain subdirectory of the
+	// main checkout is mistaken for a worktree.
+	if gitDir != "" && gitCommonDir != "" && resolveAbs(cwd, gitDir) != resolveAbs(cwd, gitCommonDir) {
 		ctx.IsWorktree = true
 	}
 
@@ -55,4 +62,18 @@ func BuildContext(cwd string) Context {
 	}
 
 	return ctx
+}
+
+// resolveAbs returns p as a cleaned absolute path, resolving relative
+// paths against base. git rev-parse emits paths relative to the working
+// directory when cwd is a repository subdirectory, so callers must
+// resolve before comparing or embedding such values.
+func resolveAbs(base, p string) string {
+	if p == "" {
+		return ""
+	}
+	if filepath.IsAbs(p) {
+		return filepath.Clean(p)
+	}
+	return filepath.Clean(filepath.Join(base, p))
 }

--- a/internal/gitutil/gitutil_test.go
+++ b/internal/gitutil/gitutil_test.go
@@ -216,6 +216,56 @@ func TestMainWorktreeRootBareRepo(t *testing.T) {
 	}
 }
 
+func TestBuildContextWorktreeDetection(t *testing.T) {
+	t.Run("subdirectory of main checkout is not a worktree", func(t *testing.T) {
+		t.Parallel()
+
+		main := t.TempDir()
+		initGit(t, main)
+
+		// A plain subdirectory of the main checkout, not a linked worktree.
+		// git rev-parse emits --git-common-dir relative to cwd here
+		// (e.g. "../.git"), which used to be string-compared against an
+		// absolute --git-dir and misclassify the directory as a worktree.
+		sub := filepath.Join(main, "sub")
+		if err := os.Mkdir(sub, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := BuildContext(sub)
+		if ctx.IsWorktree {
+			t.Fatalf("plain subdirectory misdetected as worktree: git_dir=%q git_common_dir=%q",
+				ctx.GitDir, ctx.GitCommonDir)
+		}
+	})
+
+	t.Run("linked worktree detected", func(t *testing.T) {
+		t.Parallel()
+
+		main := t.TempDir()
+		initGit(t, main)
+		gitRun(t, main, "commit", "--allow-empty", "-m", "init")
+		wt := filepath.Join(filepath.Dir(main), filepath.Base(main)+"-wt")
+		t.Cleanup(func() { _ = os.RemoveAll(wt) })
+		gitRun(t, main, "worktree", "add", "--detach", wt)
+
+		ctx := BuildContext(wt)
+		if !ctx.IsWorktree {
+			t.Fatalf("linked worktree not detected: git_dir=%q git_common_dir=%q",
+				ctx.GitDir, ctx.GitCommonDir)
+		}
+
+		wantMain, _ := filepath.EvalSymlinks(main)
+		gotMain, err := filepath.EvalSymlinks(ctx.PrimaryCheckoutRoot)
+		if err != nil {
+			t.Fatalf("EvalSymlinks(%q): %v", ctx.PrimaryCheckoutRoot, err)
+		}
+		if gotMain != wantMain {
+			t.Fatalf("PrimaryCheckoutRoot=%q, want %q", gotMain, wantMain)
+		}
+	})
+}
+
 func initGit(t *testing.T, dir string) {
 	t.Helper()
 	gitRun(t, dir, "init")

--- a/internal/gitutil/gitutil_test.go
+++ b/internal/gitutil/gitutil_test.go
@@ -217,53 +217,55 @@ func TestMainWorktreeRootBareRepo(t *testing.T) {
 }
 
 func TestBuildContextWorktreeDetection(t *testing.T) {
-	t.Run("subdirectory of main checkout is not a worktree", func(t *testing.T) {
-		t.Parallel()
+	t.Parallel()
 
-		main := t.TempDir()
-		initGit(t, main)
+	// When cwd is a repository subdirectory, git rev-parse emits
+	// --git-common-dir relative to cwd (e.g. "../.git") while --git-dir
+	// may come back absolute; BuildContext must not mistake that mismatch
+	// for a linked worktree. The linked-worktree case guards the reverse.
+	cases := map[string]struct {
+		makeWorktree bool
+	}{
+		"main checkout subdirectory is not a worktree": {makeWorktree: false},
+		"linked worktree is detected":                  {makeWorktree: true},
+	}
 
-		// A plain subdirectory of the main checkout, not a linked worktree.
-		// git rev-parse emits --git-common-dir relative to cwd here
-		// (e.g. "../.git"), which used to be string-compared against an
-		// absolute --git-dir and misclassify the directory as a worktree.
-		sub := filepath.Join(main, "sub")
-		if err := os.Mkdir(sub, 0o755); err != nil {
-			t.Fatal(err)
-		}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-		ctx := BuildContext(sub)
-		if ctx.IsWorktree {
-			t.Fatalf("plain subdirectory misdetected as worktree: git_dir=%q git_common_dir=%q",
-				ctx.GitDir, ctx.GitCommonDir)
-		}
-	})
+			main := t.TempDir()
+			initGit(t, main)
 
-	t.Run("linked worktree detected", func(t *testing.T) {
-		t.Parallel()
+			target := filepath.Join(main, "sub")
+			if tc.makeWorktree {
+				gitRun(t, main, "commit", "--allow-empty", "-m", "init")
+				target = filepath.Join(filepath.Dir(main), filepath.Base(main)+"-wt")
+				t.Cleanup(func() { _ = os.RemoveAll(target) })
+				gitRun(t, main, "worktree", "add", "--detach", target)
+			} else if err := os.Mkdir(target, 0o755); err != nil {
+				t.Fatal(err)
+			}
 
-		main := t.TempDir()
-		initGit(t, main)
-		gitRun(t, main, "commit", "--allow-empty", "-m", "init")
-		wt := filepath.Join(filepath.Dir(main), filepath.Base(main)+"-wt")
-		t.Cleanup(func() { _ = os.RemoveAll(wt) })
-		gitRun(t, main, "worktree", "add", "--detach", wt)
+			ctx := BuildContext(target)
 
-		ctx := BuildContext(wt)
-		if !ctx.IsWorktree {
-			t.Fatalf("linked worktree not detected: git_dir=%q git_common_dir=%q",
-				ctx.GitDir, ctx.GitCommonDir)
-		}
+			if ctx.IsWorktree != tc.makeWorktree {
+				t.Fatalf("IsWorktree=%v, want %v (git_dir=%q git_common_dir=%q)",
+					ctx.IsWorktree, tc.makeWorktree, ctx.GitDir, ctx.GitCommonDir)
+			}
 
-		wantMain, _ := filepath.EvalSymlinks(main)
-		gotMain, err := filepath.EvalSymlinks(ctx.PrimaryCheckoutRoot)
-		if err != nil {
-			t.Fatalf("EvalSymlinks(%q): %v", ctx.PrimaryCheckoutRoot, err)
-		}
-		if gotMain != wantMain {
-			t.Fatalf("PrimaryCheckoutRoot=%q, want %q", gotMain, wantMain)
-		}
-	})
+			if tc.makeWorktree {
+				wantMain, _ := filepath.EvalSymlinks(main)
+				gotMain, err := filepath.EvalSymlinks(ctx.PrimaryCheckoutRoot)
+				if err != nil {
+					t.Fatalf("EvalSymlinks(%q): %v", ctx.PrimaryCheckoutRoot, err)
+				}
+				if gotMain != wantMain {
+					t.Fatalf("PrimaryCheckoutRoot=%q, want %q", gotMain, wantMain)
+				}
+			}
+		})
+	}
 }
 
 func initGit(t *testing.T, dir string) {


### PR DESCRIPTION
## Problem

`BuildContext` misclassifies a **plain subdirectory of the main checkout** as a linked worktree, which arms the embedded *Sibling Checkout / Worktree Confusion* deny rule and causes in-repo commands to be denied with:

> Accessing paths outside the current worktree is not allowed.

Reproduced from a real session (cwd is a subdirectory of the main checkout, **not** a `git worktree add` worktree). `ccgate`'s computed context was:

```json
{
  "cwd": "/home/<user>/repo/subdir",
  "repo_root": "/home/<user>/repo",
  "git_dir": "/home/<user>/repo/.git",          // absolute
  "git_common_dir": "../.git",                  // relative to cwd
  "is_worktree": true,                           // ← wrong
  "primary_checkout_root": ".."                  // ← resolves to repo_root
}
```

`git rev-parse --git-common-dir` returns a path **relative to cwd** (`../.git`) when cwd is a repository subdirectory, while `--git-dir` comes back absolute. The detection compared them as raw strings:

```go
// Worktree detection: git-dir and git-common-dir differ in worktrees.
if gitDir != "" && gitCommonDir != "" && gitDir != gitCommonDir {
    ctx.IsWorktree = true
}
```

→ they never match → `IsWorktree = true`. The deny rule then treats every path under the (misdetected) `primary_checkout_root` as out-of-scope, denying routine operations. This hits compound forms especially hard (`git add <file>`, `|` pipelines, `$(...)` substitution), since those slip past the host tool's literal allow patterns and always reach the LLM classifier.

## Fix

Resolve both `--git-dir` and `--git-common-dir` to absolute paths (relative to `cwd`) before comparing. `PrimaryCheckoutRoot` is likewise derived from the resolved path so it is absolute rather than e.g. `".."`. Real linked worktrees still differ after resolution, so detection there is unchanged.

```go
func resolveAbs(base, p string) string {
    if p == "" {
        return ""
    }
    if filepath.IsAbs(p) {
        return filepath.Clean(p)
    }
    return filepath.Clean(filepath.Join(base, p))
}
```

While here, replaced the `strings.HasSuffix(..., "/.git")` heuristic (which was also written twice with `filepath.Separator`) with `filepath.Base(abs) == ".git"` on the resolved path.

## Verification

New test `TestBuildContextWorktreeDetection` covers both directions:

- **before fix:** `subdirectory ... is not a worktree` FAILS —
  `git_dir="/tmp/.../001/.git"` vs `git_common_dir="../.git"` → misdetected.
- **after fix:** both subtests PASS (subdirectory correctly *not* a worktree; linked worktree still detected with correct `PrimaryCheckoutRoot`).

```
--- PASS: TestBuildContextWorktreeDetection/subdirectory_of_main_checkout_is_not_a_worktree
--- PASS: TestBuildContextWorktreeDetection/linked_worktree_detected
```

Full package suite green, including the existing `TestMainWorktreeRoot` and `TestMainWorktreeRootBareRepo` (conventional `repo.git` + hostile `<dir>/.git`) cases, so bare-repo handling and real-worktree protection are preserved. `gofmt`/`go vet` clean.

End-to-end, the commands previously denied with the worktree message now classify as `allow`:

| command | before | after |
| --- | --- | --- |
| `git add AGENTS.md Makefile` | deny | allow |
| `git add src/*.c` | deny | allow |
| `git diff --cached --stat \| tail -4` | deny | allow |
| `echo "$(git diff --cached --name-only \| wc -l)"` | deny | allow |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tak848/ccgate/pull/111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->