### PR TITLE
docs: add a copy-pasteable OpenAI provider block

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ If `ccgate` is not on your `PATH` (e.g. when relying on `mise exec` instead of a
 
 ccgate calls Anthropic's Claude Haiku by default. Export `CCGATE_ANTHROPIC_API_KEY` (or `ANTHROPIC_API_KEY` as fallback). For OpenAI / Gemini and the resolution order, see [docs/providers.md#api-keys](docs/providers.md#api-keys).
 
+[Switching providers](docs/providers.md#switching-providers) has a copy-pasteable block for OpenAI with `gpt-5.6-luna`.
+
 That's it — ccgate is now running with its embedded defaults. To customize what is allowed or denied, see [docs/rule-tuning.md](docs/rule-tuning.md); for background on how rules work, see [Concepts](#concepts).
 
 ## Quick start — Codex CLI
@@ -142,7 +144,7 @@ See [docs/codex-cli.md](docs/codex-cli.md) for the full lookup order, project-lo
 
 ### 2. API key
 
-Export the provider API key — see [docs/providers.md#api-keys](docs/providers.md#api-keys).
+Export the provider API key — see [docs/providers.md#api-keys](docs/providers.md#api-keys). The default is Anthropic's Claude Haiku; [Switching providers](docs/providers.md#switching-providers) has a copy-pasteable block for OpenAI with `gpt-5.6-luna`.
 
 That's it — ccgate is now running with its embedded defaults. To customize what is allowed or denied, see [docs/rule-tuning.md](docs/rule-tuning.md); for background on how rules work, see [Concepts](#concepts).
 

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -91,6 +91,8 @@ brew install tak848/tap/ccgate
 
 ccgate は default で Anthropic の Claude Haiku を呼びます。 `CCGATE_ANTHROPIC_API_KEY` (`ANTHROPIC_API_KEY` でも可) を export してください。 OpenAI / Gemini に切り替える場合や、 各 provider の発行ページと環境変数の解決順は [docs/ja/providers.md#api-キー](providers.md#api-キー) を参照。
 
+[Provider の切り替え](providers.md#provider-の切り替え) に OpenAI の `gpt-5.6-luna` の設定ブロックがあります。
+
 ここまでで ccgate は組み込みデフォルトで動き始めます。allow / deny を自分で書きたい場合は [docs/ja/rule-tuning.md](rule-tuning.md) を、ルールの仕組みを先に押さえたい場合は [コンセプト](#コンセプト) を参照してください。
 
 ## クイックスタート — Codex CLI
@@ -142,7 +144,7 @@ lookup 順序、 project-local overlay、 in-tree dev build 用の `go run` レ�
 
 ### 2. API キー
 
-provider の API キーを export してください — [docs/ja/providers.md#api-キー](providers.md#api-キー) を参照。
+provider の API キーを export してください — [docs/ja/providers.md#api-キー](providers.md#api-キー) を参照。 default は Anthropic の Claude Haiku で、 [Provider の切り替え](providers.md#provider-の切り替え) に OpenAI の `gpt-5.6-luna` の設定ブロックがあります。
 
 ここまでで ccgate は組み込みデフォルトで動き始めます。allow / deny を自分で書きたい場合は [docs/ja/rule-tuning.md](rule-tuning.md) を、ルールの仕組みを先に押さえたい場合は [コンセプト](#コンセプト) を参照してください。
 

--- a/docs/ja/providers.md
+++ b/docs/ja/providers.md
@@ -14,7 +14,9 @@ ccgate は各 PermissionRequest を provider LLM (default: Claude Haiku) に投�
 
 ## Provider の切り替え
 
-任意の layer で `provider.name` (必要なら `provider.model` も) を書き換えます:
+任意の layer で `provider.name` (必要なら `provider.model` も) を書き換え、対応する API キー (下の [API キー](#api-キー) 参照) を export してください。キーが見つからない場合 ccgate は上流ツールの確認画面に fallthrough するので、 provider 切替で hook が壊れることはありません。
+
+OpenAI の `gpt-5.6-luna` の場合:
 
 ```jsonnet
 {
@@ -25,7 +27,11 @@ ccgate は各 PermissionRequest を provider LLM (default: Claude Haiku) に投�
 }
 ```
 
-対応する API キー (下の [API キー](#api-キー) 参照) を export してください。キーが見つからない場合 ccgate は上流ツールの確認画面に fallthrough するので、 provider 切替で hook が壊れることはありません。
+```sh
+export CCGATE_OPENAI_API_KEY=sk-...
+```
+
+このモデルは ccgate の既定 `reasoning_effort` をそのまま受理するので、他に設定は要りません。[拒否するモデルもあります](#reasoning_effort)。
 
 ## API キー
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -14,7 +14,9 @@ ccgate calls a provider LLM (default: Claude Haiku) to classify each PermissionR
 
 ## Switching providers
 
-Set `provider.name` (and `provider.model` when needed) in any layer:
+Set `provider.name` (and `provider.model` when needed) in any layer, then export the matching API key (see [API keys](#api-keys) below). If the key is missing, ccgate falls through to the upstream tool's permission prompt, so a wrong provider name cannot break the hook.
+
+OpenAI with `gpt-5.6-luna`:
 
 ```jsonnet
 {
@@ -25,7 +27,11 @@ Set `provider.name` (and `provider.model` when needed) in any layer:
 }
 ```
 
-Export the matching API key (see [API keys](#api-keys) below). If the key is missing, ccgate falls through to the upstream tool's permission prompt, so a wrong provider name cannot break the hook.
+```sh
+export CCGATE_OPENAI_API_KEY=sk-...
+```
+
+This model takes ccgate's default `reasoning_effort`, so nothing else is needed; [some models reject it](#reasoning_effort).
 
 ## API keys
 


### PR DESCRIPTION
## Why

Someone moving off the default provider had to assemble the configuration from three places. "Switching providers" showed a provider block but not the key export, and said nothing about whether anything else was needed — which now matters, since `reasoning_effort` is sent by default and not every model accepts the same values. Both quick starts linked only to the key table.

## What

Fill out the switching section into one complete example: the provider block, the env var, and a line noting this model takes the default `reasoning_effort` while some models do not. Point both quick-start "API key" steps at it.

`gpt-5.6-luna` is the model in the example, not a recommendation — it is there because it works with no extra configuration, which is what makes it a useful thing to copy.

en and ja.
