### PR TITLE
chore: follow the latest Go, raise minors in their own PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,7 +28,6 @@
       managerFilePatterns: ["/(^|/)flake\\.nix$/"],
       matchStrings: ["go_(?<goMajor>\\d+)_(?<goMinor>\\d+)"],
       depNameTemplate: "go",
-      depTypeTemplate: "golang",
       currentValueTemplate: "{{{goMajor}}}.{{{goMinor}}}.0",
       autoReplaceStringTemplate: "go_{{{newMajor}}}_{{{newMinor}}}",
       datasourceTemplate: "golang-version",
@@ -46,10 +45,9 @@
       lockFileMaintenance: { enabled: true },
     },
     {
-      description: "Minor-only go pins (go.mod directive, flake.nix): only the .0 release",
+      description: "flake.nix pins Go by minor, so only .0 releases apply",
       matchDepNames: ["go"],
-      matchManagers: ["gomod", "custom.regex"],
-      matchDepTypes: ["golang"],
+      matchManagers: ["custom.regex"],
       allowedVersions: "/^\\d+\\.\\d+\\.0$/",
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,6 +21,19 @@
   gitIgnoredAuthors: [
     "github-actions[bot]@users.noreply.github.com",
   ],
+  customManagers: [
+    {
+      customType: "regex",
+      description: "flake.nix pins the Go minor as a nixpkgs attribute (go_1_25)",
+      managerFilePatterns: ["/(^|/)flake\\.nix$/"],
+      matchStrings: ["go_(?<goMajor>\\d+)_(?<goMinor>\\d+)"],
+      depNameTemplate: "go",
+      depTypeTemplate: "golang",
+      currentValueTemplate: "{{{goMajor}}}.{{{goMinor}}}.0",
+      autoReplaceStringTemplate: "go_{{{newMajor}}}_{{{newMinor}}}",
+      datasourceTemplate: "golang-version",
+    },
+  ],
   packageRules: [
     {
       description: "Rename the allNonMajor group (avoid 'non-major' wording)",
@@ -33,24 +46,21 @@
       lockFileMaintenance: { enabled: true },
     },
     {
-      description: "go directive: keep pinned at 1.25.0",
+      description: "Minor-only go pins (go.mod directive, flake.nix): only the .0 release",
       matchDepNames: ["go"],
-      matchManagers: ["gomod"],
+      matchManagers: ["gomod", "custom.regex"],
       matchDepTypes: ["golang"],
-      enabled: false,
+      allowedVersions: "/^\\d+\\.\\d+\\.0$/",
     },
     {
-      description: "go toolchain: follow 1.25.x patches only",
+      description: "A Go minor is effectively a major: raise it on its own PR",
       matchDepNames: ["go"],
-      matchManagers: ["gomod"],
-      matchDepTypes: ["toolchain"],
-      allowedVersions: "<{{major}}.{{add minor 1}}",
-    },
-    {
-      description: "mise go: follow 1.25.x patches only",
-      matchDepNames: ["go"],
-      matchManagers: ["mise"],
-      allowedVersions: "<{{major}}.{{add minor 1}}",
+      matchManagers: ["gomod", "mise", "custom.regex"],
+      matchUpdateTypes: ["minor"],
+      groupName: "go minor",
+      prBodyNotes: [
+        "`README.md`, `docs/ja/README.md` and `CLAUDE.md` mention the Go minor in prose. Update them in this PR.",
+      ],
     },
   ],
 }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/tak848/ccgate
 
-go 1.25.0
-
-toolchain go1.25.12
+go 1.25.12
 
 require (
 	github.com/alecthomas/kong v1.15.0


### PR DESCRIPTION
## Why

Go 1.27 is out, but #112 only moved go from 1.25.12 to 1.25.14. Two rules capped it: `allowedVersions: "<{{major}}.{{add minor 1}}"` expands to `<1.26` from the current value, so 1.26 and 1.27 never became candidates. The `go` directive in go.mod was disabled outright.

Staying a minor behind is what a library does, so that its consumers can compile it with an older toolchain. ccgate is not one. Every implementation package lives under `internal/`, the root and `scripts/genschema` are `package main`, and the only importable non-internal package (`schemas`) has no exported declarations at all — it is a place to keep generated JSON schemas. All five install paths in the README hand out a binary. If the hook I/O types are ever published, a separate module is needed anyway (there is one go.mod), so following the latest here does not constrain that.

The same reasoning applies to the `go 1.25.0` + `toolchain go1.25.12` split. Per the toolchain docs, that shape exists so a module others depend on can keep its minimum requirement below the toolchain it develops against. With no dependents it buys nothing, and `go get go@latest` produces the opposite shape: the `go` directive carries the full version, and the `toolchain` line is dropped when it would match exactly.

`go install` users are unaffected in practice: with the default `GOTOOLCHAIN=auto`, a newer `go` line makes the go command fetch and run the matching toolchain.

This revisits the policy set in 43ebcc6.

## What

- Drop the version caps on the go.mod `go` directive and the mise pin, so both follow the latest release.
- Collapse go.mod to a single `go 1.25.12` line (`go mod edit -go=1.25.12 -toolchain=none`), which is the shape `go get go@latest` produces.
- Add a custom manager for `flake.nix`, which pins Go as the nixpkgs attribute `go_1_25`. It is restricted to `x.y.0`, both because the attribute is per-minor and because Renovate re-extracts the file after writing and discards the update unless the value round-trips — `go_1_27` re-extracts as `1.27.0`.
- Raise Go minors in their own PR (`go minor`). Patches stay in the existing `minor & patch updates` group.

Once this lands, the `go minor` PR should move go.mod (`go 1.25.12` → `1.27.x`), mise.toml (`1.25.12` → `1.27.x`) and flake.nix (`go_1_25` → `go_1_27`) together.

Note on ordering: golangci-lint gained Go 1.27 support in v2.13.0, and mise.toml still pins 2.12.2. #112 is the PR that raises it to 2.13.2, so merge that before the `go minor` PR. The prose mentions of "Go 1.25" in `README.md`, `docs/ja/README.md` and `CLAUDE.md` are not covered by any manager and need updating by hand in the `go minor` PR — `prBodyNotes` puts a reminder in its body.
