### PR TITLE
refactor: apply go fix

### DIFF
--- a/internal/cmd/claude/transcript.go
+++ b/internal/cmd/claude/transcript.go
@@ -83,10 +83,7 @@ func readTail(path string, n int64) ([]byte, error) {
 	}
 
 	size := info.Size()
-	offset := size - n
-	if offset < 0 {
-		offset = 0
-	}
+	offset := max(size-n, 0)
 	if _, err := f.Seek(offset, 0); err != nil {
 		return nil, err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -320,7 +320,7 @@ func (AuthConfig) JSONSchema() *jsonschema.Schema {
 func authExecBranchSchema() *jsonschema.Schema {
 	props := orderedmap.New[string, *jsonschema.Schema]()
 	props.Set("type", &jsonschema.Schema{Type: "string", Const: AuthTypeExec})
-	props.Set("command", &jsonschema.Schema{Type: "string", MinLength: ptr(uint64(1)), Description: "Shell command. Stdout is the credential. Run via the configured shell (default bash)."})
+	props.Set("command", &jsonschema.Schema{Type: "string", MinLength: new(uint64(1)), Description: "Shell command. Stdout is the credential. Run via the configured shell (default bash)."})
 	props.Set("shell", &jsonschema.Schema{Type: "string", Enum: []any{AuthShellBash, AuthShellPowerShell}, Description: "Shell that runs `command`. \"bash\" runs `bash -c <command>`. \"powershell\" runs `pwsh -Command <command>` when pwsh is on PATH (PowerShell 7+, cross-platform) and falls back to `powershell -Command <command>` (Windows PowerShell 5.1) otherwise. Default: bash."})
 	props.Set("refresh_margin_ms", &jsonschema.Schema{Type: "integer", Minimum: json.Number("0"), Description: "Cache early-refresh threshold + minimum remaining TTL guard for fresh credentials, in milliseconds. Default: 60000."})
 	props.Set("timeout_ms", &jsonschema.Schema{Type: "integer", Minimum: json.Number("1"), Description: "Hard cap on one Resolve call (lock + helper exec), in milliseconds. Default: 30000."})
@@ -336,7 +336,7 @@ func authExecBranchSchema() *jsonschema.Schema {
 func authFileBranchSchema() *jsonschema.Schema {
 	props := orderedmap.New[string, *jsonschema.Schema]()
 	props.Set("type", &jsonschema.Schema{Type: "string", Const: AuthTypeFile})
-	props.Set("path", &jsonschema.Schema{Type: "string", MinLength: ptr(uint64(1)), Description: "Path to the credential file. Absolute, ~/-prefixed, or relative (relative paths resolve from the hook's working directory at fire time, not the config file's directory). Omit the field to use the default $XDG_STATE_HOME/ccgate/<target>/auth_key.json; do not set it to an empty string."})
+	props.Set("path", &jsonschema.Schema{Type: "string", MinLength: new(uint64(1)), Description: "Path to the credential file. Absolute, ~/-prefixed, or relative (relative paths resolve from the hook's working directory at fire time, not the config file's directory). Omit the field to use the default $XDG_STATE_HOME/ccgate/<target>/auth_key.json; do not set it to an empty string."})
 	props.Set("refresh_margin_ms", &jsonschema.Schema{Type: "integer", Minimum: json.Number("0"), Description: "Minimum remaining TTL guard for file output, in milliseconds. Default: 60000."})
 	props.Set("timeout_ms", &jsonschema.Schema{Type: "integer", Minimum: json.Number("1"), Description: "Hard cap on the file read so a stalled mount surfaces as reason=timeout. Default: 30000."})
 	return &jsonschema.Schema{
@@ -359,8 +359,6 @@ func authProfileBranchSchema() *jsonschema.Schema {
 	}
 }
 
-func ptr[T any](v T) *T { return &v }
-
 // Default returns a Config seeded with the provider/log/metrics
 // defaults common to every target. LogPath / MetricsPath are left
 // empty on purpose — Load fills them from LoadOptions so each
@@ -372,16 +370,12 @@ func Default() Config {
 		Provider: ProviderConfig{
 			Name:      DefaultProvider,
 			Model:     DefaultModel,
-			TimeoutMS: intPtr(DefaultTimeoutMS),
+			TimeoutMS: new(DefaultTimeoutMS),
 		},
-		LogMaxSize:     int64Ptr(DefaultLogMaxSize),
-		MetricsMaxSize: int64Ptr(DefaultMetricsMaxSize),
+		LogMaxSize:     new(int64(DefaultLogMaxSize)),
+		MetricsMaxSize: new(int64(DefaultMetricsMaxSize)),
 	}
 }
-
-func intPtr(v int) *int          { return &v }
-func int64Ptr(v int64) *int64    { return &v }
-func stringPtr(v string) *string { return &v }
 
 // GetTimeoutMS returns the provider timeout in milliseconds.
 // nil defaults to DefaultTimeoutMS.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -56,11 +56,11 @@ func TestValidateErrors(t *testing.T) {
 	}{
 		{
 			name: "empty provider name",
-			cfg:  Config{Provider: ProviderConfig{Name: "", Model: "m", TimeoutMS: intPtr(1000)}},
+			cfg:  Config{Provider: ProviderConfig{Name: "", Model: "m", TimeoutMS: new(1000)}},
 		},
 		{
 			name: "empty model",
-			cfg:  Config{Provider: ProviderConfig{Name: "anthropic", Model: "", TimeoutMS: intPtr(1000)}},
+			cfg:  Config{Provider: ProviderConfig{Name: "anthropic", Model: "", TimeoutMS: new(1000)}},
 		},
 		{
 			name: "negative timeout",
@@ -69,7 +69,7 @@ func TestValidateErrors(t *testing.T) {
 		{
 			name: "invalid fallthrough_strategy",
 			cfg: Config{
-				Provider:            ProviderConfig{Name: "anthropic", Model: "m", TimeoutMS: intPtr(1000)},
+				Provider:            ProviderConfig{Name: "anthropic", Model: "m", TimeoutMS: new(1000)},
 				FallthroughStrategy: &bogusStrategy,
 			},
 		},
@@ -93,7 +93,7 @@ func TestValidateAuthFields(t *testing.T) {
 		return Config{Provider: ProviderConfig{
 			Name:      "anthropic",
 			Model:     "m",
-			TimeoutMS: intPtr(1000),
+			TimeoutMS: new(1000),
 			Auth:      a,
 		}}
 	}
@@ -120,36 +120,36 @@ func TestValidateAuthFields(t *testing.T) {
 		// type=exec: command required, refresh_margin/timeout/cache_key optional.
 		"exec ok":                 {auth: &AuthConfig{Type: "exec", Command: "echo"}, wantErr: false},
 		"exec missing command":    {auth: &AuthConfig{Type: "exec"}, wantErr: true},
-		"exec with path":          {auth: &AuthConfig{Type: "exec", Command: "x", Path: stringPtr("y")}, wantErr: true},
+		"exec with path":          {auth: &AuthConfig{Type: "exec", Command: "x", Path: new("y")}, wantErr: true},
 		"exec with cache_key":     {auth: &AuthConfig{Type: "exec", Command: "x", CacheKey: "prod"}, wantErr: false},
 		"exec with cache_key var": {auth: &AuthConfig{Type: "exec", Command: "x", CacheKey: "${AWS_PROFILE}"}, wantErr: false},
 
 		// refresh_margin_ms: >= 0 accepted, 0 allowed (disables guard),
 		// negative rejected.
-		"refresh_margin 30000": {auth: &AuthConfig{Type: "exec", Command: "x", RefreshMarginMS: intPtr(30000)}, wantErr: false},
-		"refresh_margin 0":     {auth: &AuthConfig{Type: "exec", Command: "x", RefreshMarginMS: intPtr(0)}, wantErr: false},
-		"refresh_margin -1":    {auth: &AuthConfig{Type: "exec", Command: "x", RefreshMarginMS: intPtr(-1)}, wantErr: true},
+		"refresh_margin 30000": {auth: &AuthConfig{Type: "exec", Command: "x", RefreshMarginMS: new(30000)}, wantErr: false},
+		"refresh_margin 0":     {auth: &AuthConfig{Type: "exec", Command: "x", RefreshMarginMS: new(0)}, wantErr: false},
+		"refresh_margin -1":    {auth: &AuthConfig{Type: "exec", Command: "x", RefreshMarginMS: new(-1)}, wantErr: true},
 
 		// timeout_ms: > 0 required, 0 rejected (would wedge hot path).
-		"timeout 5000":     {auth: &AuthConfig{Type: "exec", Command: "x", TimeoutMS: intPtr(5000)}, wantErr: false},
-		"timeout 0":        {auth: &AuthConfig{Type: "exec", Command: "x", TimeoutMS: intPtr(0)}, wantErr: true},
-		"timeout negative": {auth: &AuthConfig{Type: "exec", Command: "x", TimeoutMS: intPtr(-1)}, wantErr: true},
+		"timeout 5000":     {auth: &AuthConfig{Type: "exec", Command: "x", TimeoutMS: new(5000)}, wantErr: false},
+		"timeout 0":        {auth: &AuthConfig{Type: "exec", Command: "x", TimeoutMS: new(0)}, wantErr: true},
+		"timeout negative": {auth: &AuthConfig{Type: "exec", Command: "x", TimeoutMS: new(-1)}, wantErr: true},
 
 		// type=file: path required (absolute or ~/), command/timeout_ms/cache_key forbidden,
 		// refresh_margin_ms allowed (minimum-remaining-TTL guard).
-		"file abs":               {auth: &AuthConfig{Type: "file", Path: stringPtr(absKey)}, wantErr: false},
-		"file home":              {auth: &AuthConfig{Type: "file", Path: stringPtr("~/.ccgate/key")}, wantErr: false},
-		"file relative dot":      {auth: &AuthConfig{Type: "file", Path: stringPtr("./key")}, wantErr: false},
-		"file relative bare":     {auth: &AuthConfig{Type: "file", Path: stringPtr("key")}, wantErr: false},
+		"file abs":               {auth: &AuthConfig{Type: "file", Path: new(absKey)}, wantErr: false},
+		"file home":              {auth: &AuthConfig{Type: "file", Path: new("~/.ccgate/key")}, wantErr: false},
+		"file relative dot":      {auth: &AuthConfig{Type: "file", Path: new("./key")}, wantErr: false},
+		"file relative bare":     {auth: &AuthConfig{Type: "file", Path: new("key")}, wantErr: false},
 		"file path omitted":      {auth: &AuthConfig{Type: "file"}, wantErr: false},
-		"file path empty string": {auth: &AuthConfig{Type: "file", Path: stringPtr("")}, wantErr: true},
-		"file bare ~":            {auth: &AuthConfig{Type: "file", Path: stringPtr("~")}, wantErr: true},
-		"file bare ~/":           {auth: &AuthConfig{Type: "file", Path: stringPtr("~/")}, wantErr: true},
-		"file with command":      {auth: &AuthConfig{Type: "file", Path: stringPtr(absKey), Command: "x"}, wantErr: true},
-		"file with timeout":      {auth: &AuthConfig{Type: "file", Path: stringPtr(absKey), TimeoutMS: intPtr(5000)}, wantErr: false},
-		"file with zero timeout": {auth: &AuthConfig{Type: "file", Path: stringPtr(absKey), TimeoutMS: intPtr(0)}, wantErr: true},
-		"file with cache_key":    {auth: &AuthConfig{Type: "file", Path: stringPtr(absKey), CacheKey: "x"}, wantErr: true},
-		"file refresh_margin":    {auth: &AuthConfig{Type: "file", Path: stringPtr(absKey), RefreshMarginMS: intPtr(60000)}, wantErr: false},
+		"file path empty string": {auth: &AuthConfig{Type: "file", Path: new("")}, wantErr: true},
+		"file bare ~":            {auth: &AuthConfig{Type: "file", Path: new("~")}, wantErr: true},
+		"file bare ~/":           {auth: &AuthConfig{Type: "file", Path: new("~/")}, wantErr: true},
+		"file with command":      {auth: &AuthConfig{Type: "file", Path: new(absKey), Command: "x"}, wantErr: true},
+		"file with timeout":      {auth: &AuthConfig{Type: "file", Path: new(absKey), TimeoutMS: new(5000)}, wantErr: false},
+		"file with zero timeout": {auth: &AuthConfig{Type: "file", Path: new(absKey), TimeoutMS: new(0)}, wantErr: true},
+		"file with cache_key":    {auth: &AuthConfig{Type: "file", Path: new(absKey), CacheKey: "x"}, wantErr: true},
+		"file refresh_margin":    {auth: &AuthConfig{Type: "file", Path: new(absKey), RefreshMarginMS: new(60000)}, wantErr: false},
 
 		// Unknown type values are rejected — keeps the discriminator
 		// closed so editors and validate agree on what's accepted.
@@ -166,15 +166,15 @@ func TestValidateAuthFields(t *testing.T) {
 		"profile ok with profile":         {auth: &AuthConfig{Type: "profile", Profile: "ccgate"}, wantErr: false},
 		"profile profile whitespace only": {auth: &AuthConfig{Type: "profile", Profile: "   "}, wantErr: true},
 		"profile with command":            {auth: &AuthConfig{Type: "profile", Command: "x"}, wantErr: true},
-		"profile with path":               {auth: &AuthConfig{Type: "profile", Path: stringPtr(absKey)}, wantErr: true},
+		"profile with path":               {auth: &AuthConfig{Type: "profile", Path: new(absKey)}, wantErr: true},
 		"profile with shell":              {auth: &AuthConfig{Type: "profile", Shell: AuthShellBash}, wantErr: true},
-		"profile with refresh_margin":     {auth: &AuthConfig{Type: "profile", RefreshMarginMS: intPtr(30000)}, wantErr: true},
-		"profile with timeout_ms":         {auth: &AuthConfig{Type: "profile", Profile: "ccgate", TimeoutMS: intPtr(60000)}, wantErr: true},
+		"profile with refresh_margin":     {auth: &AuthConfig{Type: "profile", RefreshMarginMS: new(30000)}, wantErr: true},
+		"profile with timeout_ms":         {auth: &AuthConfig{Type: "profile", Profile: "ccgate", TimeoutMS: new(60000)}, wantErr: true},
 		"profile with cache_key":          {auth: &AuthConfig{Type: "profile", CacheKey: "prod"}, wantErr: true},
 
 		// Cross-type guards: profile field is profile-only.
 		"exec with profile": {auth: &AuthConfig{Type: "exec", Command: "x", Profile: "ccgate"}, wantErr: true},
-		"file with profile": {auth: &AuthConfig{Type: "file", Path: stringPtr(absKey), Profile: "ccgate"}, wantErr: true},
+		"file with profile": {auth: &AuthConfig{Type: "file", Path: new(absKey), Profile: "ccgate"}, wantErr: true},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -212,7 +212,7 @@ func TestProfileAuthCrossFieldProvider(t *testing.T) {
 			cfg := Config{Provider: ProviderConfig{
 				Name:      tc.providerName,
 				Model:     "m",
-				TimeoutMS: intPtr(1000),
+				TimeoutMS: new(1000),
 				Auth:      &AuthConfig{Type: "profile", Profile: "ccgate"},
 			}}
 			err := cfg.Validate()
@@ -239,8 +239,8 @@ func TestAuthDurationDefaults(t *testing.T) {
 		t.Fatalf("GetTimeout() default = %s, want %s", got, wantTimeout)
 	}
 
-	a.RefreshMarginMS = intPtr(90000)
-	a.TimeoutMS = intPtr(12000)
+	a.RefreshMarginMS = new(90000)
+	a.TimeoutMS = new(12000)
 	if got := a.GetRefreshMargin(); got != 90*time.Second {
 		t.Fatalf("GetRefreshMargin() = %s, want 90s", got)
 	}
@@ -468,7 +468,7 @@ func TestValidateZeroTimeoutIsValid(t *testing.T) {
 	t.Parallel()
 
 	cfg := Default()
-	cfg.Provider.TimeoutMS = intPtr(0)
+	cfg.Provider.TimeoutMS = new(0)
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("timeout_ms=0 should be valid (unlimited), got: %v", err)
 	}

--- a/internal/llm/anthropic/client.go
+++ b/internal/llm/anthropic/client.go
@@ -321,8 +321,7 @@ func classifyProfileLoadError(err error) string {
 	if errors.Is(err, fs.ErrNotExist) {
 		return "profile_config_missing"
 	}
-	var syntaxErr *json.SyntaxError
-	if errors.As(err, &syntaxErr) {
+	if _, ok := errors.AsType[*json.SyntaxError](err); ok {
 		return "profile_config_parse"
 	}
 	if err != nil {

--- a/internal/runner/reasoning_test.go
+++ b/internal/runner/reasoning_test.go
@@ -25,10 +25,10 @@ func TestNewProviderClientCarriesReasoningEffort(t *testing.T) {
 		"openai gets the default":     {provider: "openai", want: config.DefaultReasoningEffort},
 		"gemini gets the default":     {provider: "gemini", want: config.DefaultReasoningEffort},
 		"anthropic gets the default":  {provider: "anthropic", want: config.DefaultReasoningEffort},
-		"openai gets an explicit set": {provider: "openai", effort: ptr(llm.ReasoningEffortLow), want: llm.ReasoningEffortLow},
-		"the opt-out reaches openai":  {provider: "openai", effort: ptr(llm.ReasoningEffortOff), want: llm.ReasoningEffortOff},
-		"the opt-out reaches gemini":  {provider: "gemini", effort: ptr(llm.ReasoningEffortOff), want: llm.ReasoningEffortOff},
-		"the opt-out reaches claude":  {provider: "anthropic", effort: ptr(llm.ReasoningEffortOff), want: llm.ReasoningEffortOff},
+		"openai gets an explicit set": {provider: "openai", effort: new(llm.ReasoningEffortLow), want: llm.ReasoningEffortLow},
+		"the opt-out reaches openai":  {provider: "openai", effort: new(llm.ReasoningEffortOff), want: llm.ReasoningEffortOff},
+		"the opt-out reaches gemini":  {provider: "gemini", effort: new(llm.ReasoningEffortOff), want: llm.ReasoningEffortOff},
+		"the opt-out reaches claude":  {provider: "anthropic", effort: new(llm.ReasoningEffortOff), want: llm.ReasoningEffortOff},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -53,5 +53,3 @@ func TestNewProviderClientCarriesReasoningEffort(t *testing.T) {
 		})
 	}
 }
-
-func ptr[T any](v T) *T { return &v }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -520,12 +520,10 @@ func redactProviderError(providerName string, err error) error {
 	if err == nil {
 		return nil
 	}
-	var anth *anthropicsdk.Error
-	if errors.As(err, &anth) {
+	if anth, ok := errors.AsType[*anthropicsdk.Error](err); ok {
 		return providerAPIError(providerName, anth.StatusCode, string(anth.Type()), errorEnvelopeMessage(anth.RawJSON()), anth.RequestID)
 	}
-	var oai *openaisdk.Error
-	if errors.As(err, &oai) {
+	if oai, ok := errors.AsType[*openaisdk.Error](err); ok {
 		return providerAPIError(providerName, oai.StatusCode, oai.Type, oai.Message, "")
 	}
 	return err
@@ -623,19 +621,16 @@ func providerAuthStatus(err error) (int, bool) {
 	// Redacted first: an already-redacted error still carries the
 	// status, so this answers the same whichever side of
 	// redactProviderError the caller sits on.
-	var pe *providerError
-	if errors.As(err, &pe) {
+	if pe, ok := errors.AsType[*providerError](err); ok {
 		return pe.Status, pe.Status == http.StatusUnauthorized || pe.Status == http.StatusForbidden
 	}
-	var anth *anthropicsdk.Error
-	if errors.As(err, &anth) {
+	if anth, ok := errors.AsType[*anthropicsdk.Error](err); ok {
 		if anth.StatusCode == http.StatusUnauthorized || anth.StatusCode == http.StatusForbidden {
 			return anth.StatusCode, true
 		}
 		return anth.StatusCode, false
 	}
-	var oai *openaisdk.Error
-	if errors.As(err, &oai) {
+	if oai, ok := errors.AsType[*openaisdk.Error](err); ok {
 		if oai.StatusCode == http.StatusUnauthorized || oai.StatusCode == http.StatusForbidden {
 			return oai.StatusCode, true
 		}


### PR DESCRIPTION
## Why

Go 1.27 landed in #117, and its `go fix` carries modernizers for constructs the recent standard library made obsolete. Running it keeps the code in the shape the current toolchain expects, and lets four pointer helpers go away now that `new(expr)` covers them.

## What

`go fix ./...` applied three fixers:

- **newexpr** — go1.26's `new(expr)` takes the address of any expression, so `ptr`, `intPtr`, `int64Ptr` and `stringPtr` are gone. `int64Ptr(DefaultLogMaxSize)` becomes `new(int64(DefaultLogMaxSize))`, since the constant is untyped and would otherwise yield `*int`.
- **errorsastype** — `errors.AsType[T](err)` replaces the two-step `var x *T; errors.As(err, &x)` in the provider error paths (`redactProviderError`, `providerAuthStatus`, `classifyProfileLoadError`).
- **minmax** — the clamp-to-zero in `readTail` becomes `max(size-n, 0)`.

go fix stopped halfway. It left the helper definitions in place with `//go:fix inline` markers while some call sites stayed, which tripped both the `unused` linter and vet's inline check:

```
internal/config/config.go:378:19: inline: Call of config.int64Ptr should be inlined (govet)
internal/runner/reasoning_test.go:28:66: inline: cannot inline: type parameter inference is not yet supported (govet)
internal/config/config.go:363:6: func ptr is unused (unused)
```

The remaining call sites were converted by hand and the helpers deleted, so no `//go:fix inline` marker survives.

`mise run lint` reports 0 issues, `mise run test` passes, and `mise run schema` regenerates both files with no diff.
